### PR TITLE
Remove missing docs links and minimize release branch prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ control plane and adds the following new functionality:
   [EKS clusters](https://aws.amazon.com/eks/), etc.)
 * Controllers to provision these resources in AWS based on the users desired
   state captured in CRDs they create
-* Implementations of Crossplane's [portable resource
-  abstractions](https://crossplane.io/docs/master/concepts.html), enabling AWS
+* Implementations of Crossplane's portable resource abstractions, enabling AWS
   resources to fulfill a user's general need for cloud services
 
 ## Getting Started and Documentation

--- a/config/stack/manifests/app.yaml
+++ b/config/stack/manifests/app.yaml
@@ -12,7 +12,7 @@ readme: |
 
  * Custom Resource Definitions (CRDs) that model AWS infrastructure and services (e.g. [Amazon Relational Database Service (RDS)](https://aws.amazon.com/rds/), [EKS clusters](https://aws.amazon.com/eks/), etc.)
  * Controllers to provision these resources in AWS based on the users desired state captured in CRDs they create
- * Implementations of Crossplane's [portable resource abstractions](https://crossplane.io/docs/master/concepts.html), enabling AWS resources to fulfill a user's general need for cloud services
+ * Implementations of Crossplane's portable resource abstractions, enabling AWS resources to fulfill a user's general need for cloud services
 
 # Maintainer names and emails.
 maintainers:

--- a/config/stack/manifests/resources/eksclusterclass.resource.yaml
+++ b/config/stack/manifests/resources/eksclusterclass.resource.yaml
@@ -8,4 +8,4 @@ overview: |
 readme: |
  Cloud-specific resource classes are used to define a reusable configuration for a specific managed service. This class provides a managed Kubernetes cluster, which is satisfied by [Amazon Elastic Kubernetes Service (EKS)](https://aws.amazon.com/eks).
 
- Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplane/provider-aws/compute-aws-crossplane-io-v1alpha3.html#EKSClusterClass).
+ Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-aws/compute.aws.crossplane.io_eksclusterclasses.yaml).

--- a/config/stack/manifests/resources/provider.resource.yaml
+++ b/config/stack/manifests/resources/provider.resource.yaml
@@ -10,4 +10,4 @@ readme: |
 
  The Crossplane AWS Provider Resource configures an AWS 'provider', i.e. a connection to a particular AWS account using a particular AWS IAM Role.
 
- Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplane/provider-aws/aws-crossplane-io-v1alpha3.html#Provider).
+ Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-aws/aws.crossplane.io_providers.yaml).

--- a/config/stack/manifests/resources/rdsinstanceclass.resource.yaml
+++ b/config/stack/manifests/resources/rdsinstanceclass.resource.yaml
@@ -8,4 +8,4 @@ overview: |
 readme: |
  Cloud-specific resource classes are used to define a reusable configuration for a specific managed service. This class provides a relational database, which is satisfied by [Amazon Relational Database Service (RDS)](https://aws.amazon.com/rds/).
 
- Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplane/provider-aws/database-aws-crossplane-io-v1beta1.html#RDSInstanceClass).
+ Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-aws/database.aws.crossplane.io_rdsinstanceclasses.yaml).

--- a/config/stack/manifests/resources/replicationgroupclass.resource.yaml
+++ b/config/stack/manifests/resources/replicationgroupclass.resource.yaml
@@ -8,4 +8,4 @@ overview: |
 readme: |
  Cloud-specific resource classes are used to define a reusable configuration for a specific managed service. This class provides a Redis Replication Group, which is satisfied by [Amazon ElastiCache for Redis](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Replication.CreatingRepGroup.html).
 
- Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplane/provider-aws/cache-aws-crossplane-io-v1beta1.html#ReplicationGroupClass).
+ Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-aws/cache.aws.crossplane.io_replicationgroupclasses.yaml).

--- a/config/stack/manifests/resources/s3bucketclass.resource.yaml
+++ b/config/stack/manifests/resources/s3bucketclass.resource.yaml
@@ -8,4 +8,4 @@ overview: |
 readme: |
  Cloud-specific resource classes are used to define a reusable configuration for a specific managed service. This class provides a object storage bucks, which is satisfied by [AWS S3](https://aws.amazon.com/s3/).
 
- Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplane/provider-aws/storage-aws-crossplane-io-v1alpha3.html#S3BucketClass).
+ Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-aws/storage.aws.crossplane.io_s3bucketclasses.yaml).


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
The `portable resource abstractions` link no longer exists (this change was already made in release). The docs api references no longer exist on `master` and the `v0.7` release was the last one in which they did. These changes also remove almost all updates required in our branch prep PRs.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-aws/blob/master/config/stack/manifests/app.yaml
