### PR TITLE
eks: move identification data out of status

### DIFF
--- a/apis/compute/v1alpha3/types.go
+++ b/apis/compute/v1alpha3/types.go
@@ -181,6 +181,9 @@ type EKSClusterParameters struct {
 	// +optional
 	ClusterVersion string `json:"clusterVersion,omitempty"`
 
+	// CloudFormationStackID of the Stack used to create node groups.
+	CloudFormationStackID string `json:"cloudformationStackId,omitempty"`
+
 	// WorkerNodes configuration for cloudformation
 	WorkerNodes WorkerNodesSpec `json:"workerNodes"`
 
@@ -288,9 +291,6 @@ type EKSClusterStatus struct {
 
 	// Endpoint for connecting to the cluster.
 	Endpoint string `json:"endpoint,omitempty"`
-
-	// CloudFormationStackID of the Stack used to create node groups.
-	CloudFormationStackID string `json:"cloudformationStackId,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/compute/v1alpha3/types.go
+++ b/apis/compute/v1alpha3/types.go
@@ -283,9 +283,6 @@ type EKSClusterStatus struct {
 	// State of the cluster.
 	State string `json:"state,omitempty"`
 
-	// ClusterName of the cluster.
-	ClusterName string `json:"resourceName,omitempty"`
-
 	// ClusterVersion of the cluster.
 	ClusterVersion string `json:"resourceVersion,omitempty"`
 

--- a/config/crd/compute.aws.crossplane.io_eksclusterclasses.yaml
+++ b/config/crd/compute.aws.crossplane.io_eksclusterclasses.yaml
@@ -47,6 +47,10 @@ spec:
           description: SpecTemplate is a template for the spec of a dynamically provisioned
             EKSCluster.
           properties:
+            cloudformationStackId:
+              description: CloudFormationStackID of the Stack used to create node
+                groups.
+              type: string
             clusterVersion:
               description: 'ClusterVersion: The desired Kubernetes version of this
                 EKS Cluster. If you do not specify a value here, the latest version

--- a/config/crd/compute.aws.crossplane.io_eksclusters.yaml
+++ b/config/crd/compute.aws.crossplane.io_eksclusters.yaml
@@ -517,9 +517,6 @@ spec:
             endpoint:
               description: Endpoint for connecting to the cluster.
               type: string
-            resourceName:
-              description: ClusterName of the cluster.
-              type: string
             resourceVersion:
               description: ClusterVersion of the cluster.
               type: string

--- a/config/crd/compute.aws.crossplane.io_eksclusters.yaml
+++ b/config/crd/compute.aws.crossplane.io_eksclusters.yaml
@@ -138,6 +138,10 @@ spec:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
               type: object
+            cloudformationStackId:
+              description: CloudFormationStackID of the Stack used to create node
+                groups.
+              type: string
             clusterVersion:
               description: 'ClusterVersion: The desired Kubernetes version of this
                 EKS Cluster. If you do not specify a value here, the latest version
@@ -476,10 +480,6 @@ spec:
               - Unbound
               - Bound
               - Released
-              type: string
-            cloudformationStackId:
-              description: CloudFormationStackID of the Stack used to create node
-                groups.
               type: string
             conditions:
               description: Conditions of the resource.

--- a/pkg/clients/eks/eks.go
+++ b/pkg/clients/eks/eks.go
@@ -353,18 +353,18 @@ func GenerateClientConfig(cluster *Cluster, token string) (clientcmdapi.Config, 
 
 // IsErrorAlreadyExists helper function
 func IsErrorAlreadyExists(err error) bool {
-	return strings.Contains(err.Error(), eks.ErrCodeResourceInUseException)
+	return err != nil && strings.Contains(err.Error(), eks.ErrCodeResourceInUseException)
 }
 
 // IsErrorBadRequest helper function
 func IsErrorBadRequest(err error) bool {
-	return strings.Contains(err.Error(), eks.ErrCodeInvalidParameterException) ||
-		strings.Contains(err.Error(), eks.ErrCodeUnsupportedAvailabilityZoneException)
+	return err != nil && (strings.Contains(err.Error(), eks.ErrCodeInvalidParameterException) ||
+		strings.Contains(err.Error(), eks.ErrCodeUnsupportedAvailabilityZoneException))
 }
 
 // IsErrorNotFound helper function
 func IsErrorNotFound(err error) bool {
-	return strings.Contains(err.Error(), eks.ErrCodeResourceNotFoundException)
+	return err != nil && strings.Contains(err.Error(), eks.ErrCodeResourceNotFoundException)
 }
 
 const (


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

For backup support, `status` should be purely observational and its loss should not recur any cost, if possible. This is necessary for [backup and restore](https://github.com/crossplane/provider-aws/issues/181) workflows.

This PR makes EKS controller:
* use external name annotation for cluster name,
* save cloud formation stack id in spec,
* use version retrieved from the server instead of the one saved in status,
* save the version into status continuously instead of one time.

Fix error checking bug for case where the err is nil.

I think we can use external name for both cloud formation stack identification and also cluster name but I didn't want to touch that part; it's working and all will change in v1beta1 anyway.

Manually tested.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-aws/blob/master/config/stack/manifests/app.yaml
