### PR TITLE
s3: move identifiers out of status

### DIFF
--- a/apis/storage/v1alpha3/bucket_types.go
+++ b/apis/storage/v1alpha3/bucket_types.go
@@ -17,9 +17,7 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,12 +29,6 @@ import (
 
 // S3BucketParameters define the desired state of an AWS S3 Bucket.
 type S3BucketParameters struct {
-	// NameFormat specifies the name of the external S3Bucket instance. The
-	// first instance of the string '%s' will be replaced with the Kubernetes
-	// UID of this S3Bucket. Omit this field to use the UID alone as the name.
-	// +optional
-	NameFormat string `json:"nameFormat,omitempty"`
-
 	// Region of the bucket.
 	Region string `json:"region"`
 
@@ -139,30 +131,6 @@ type S3BucketClassList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []S3BucketClass `json:"items"`
-}
-
-// GetBucketName based on the NameFormat spec value,
-// If name format is not provided, bucket name defaults to UID
-// If name format provided with '%s' value, bucket name will result in formatted string + UID,
-//   NOTE: only single %s substitution is supported
-// If name format does not contain '%s' substitution, i.e. a constant string, the
-// constant string value is returned back
-//
-// Examples:
-//   For all examples assume "UID" = "test-uid"
-//   1. NameFormat = "", BucketName = "test-uid"
-//   2. NameFormat = "%s", BucketName = "test-uid"
-//   3. NameFormat = "foo", BucketName = "foo"
-//   4. NameFormat = "foo-%s", BucketName = "foo-test-uid"
-//   5. NameFormat = "foo-%s-bar-%s", BucketName = "foo-test-uid-bar-%!s(MISSING)"
-func (b *S3Bucket) GetBucketName() string {
-	if b.Spec.NameFormat == "" {
-		return string(b.GetUID())
-	}
-	if strings.Contains(b.Spec.NameFormat, "%s") {
-		return fmt.Sprintf(b.Spec.NameFormat, string(b.GetUID()))
-	}
-	return b.Spec.NameFormat
 }
 
 // SetUserPolicyVersion specifies this bucket's policy version.

--- a/apis/storage/v1alpha3/bucket_types.go
+++ b/apis/storage/v1alpha3/bucket_types.go
@@ -50,6 +50,10 @@ type S3BucketParameters struct {
 	// +optional
 	Versioning bool `json:"versioning,omitempty"`
 
+	// IAMUsername is the name of an IAM user that is automatically created and
+	// granted access to this bucket by Crossplane at bucket creation time.
+	IAMUsername string `json:"iamUsername,omitempty"`
+
 	// LocalPermission is the permissions granted on the bucket for the provider
 	// specific bucket service account that is available in a secret after
 	// provisioning.
@@ -69,10 +73,6 @@ type S3BucketStatus struct {
 
 	// ProviderID is the AWS identifier for this bucket.
 	ProviderID string `json:"providerID,omitempty"`
-
-	// IAMUsername is the name of an IAM user that is automatically created and
-	// granted access to this bucket by Crossplane at bucket creation time.
-	IAMUsername string `json:"iamUsername,omitempty"`
 
 	// LastUserPolicyVersion is the most recent version of the policy associated
 	// with this bucket's IAMUser.

--- a/config/crd/storage.aws.crossplane.io_s3bucketclasses.yaml
+++ b/config/crd/storage.aws.crossplane.io_s3bucketclasses.yaml
@@ -58,6 +58,11 @@ spec:
               - log-delivery-write
               - aws-exec-read
               type: string
+            iamUsername:
+              description: IAMUsername is the name of an IAM user that is automatically
+                created and granted access to this bucket by Crossplane at bucket
+                creation time.
+              type: string
             localPermission:
               description: LocalPermission is the permissions granted on the bucket
                 for the provider specific bucket service account that is available

--- a/config/crd/storage.aws.crossplane.io_s3bucketclasses.yaml
+++ b/config/crd/storage.aws.crossplane.io_s3bucketclasses.yaml
@@ -72,12 +72,6 @@ spec:
               - Write
               - ReadWrite
               type: string
-            nameFormat:
-              description: NameFormat specifies the name of the external S3Bucket
-                instance. The first instance of the string '%s' will be replaced with
-                the Kubernetes UID of this S3Bucket. Omit this field to use the UID
-                alone as the name.
-              type: string
             providerRef:
               description: ProviderReference specifies the provider that will be used
                 to create, observe, update, and delete managed resources that are

--- a/config/crd/storage.aws.crossplane.io_s3buckets.yaml
+++ b/config/crd/storage.aws.crossplane.io_s3buckets.yaml
@@ -150,12 +150,6 @@ spec:
               - Write
               - ReadWrite
               type: string
-            nameFormat:
-              description: NameFormat specifies the name of the external S3Bucket
-                instance. The first instance of the string '%s' will be replaced with
-                the Kubernetes UID of this S3Bucket. Omit this field to use the UID
-                alone as the name.
-              type: string
             providerRef:
               description: ProviderReference specifies the provider that will be used
                 to create, observe, update, and delete this managed resource.

--- a/config/crd/storage.aws.crossplane.io_s3buckets.yaml
+++ b/config/crd/storage.aws.crossplane.io_s3buckets.yaml
@@ -136,6 +136,11 @@ spec:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
               type: object
+            iamUsername:
+              description: IAMUsername is the name of an IAM user that is automatically
+                created and granted access to this bucket by Crossplane at bucket
+                creation time.
+              type: string
             localPermission:
               description: LocalPermission is the permissions granted on the bucket
                 for the provider specific bucket service account that is available
@@ -280,11 +285,6 @@ spec:
                 - type
                 type: object
               type: array
-            iamUsername:
-              description: IAMUsername is the name of an IAM user that is automatically
-                created and granted access to this bucket by Crossplane at bucket
-                creation time.
-              type: string
             lastLocalPermission:
               description: LastLocalPermission is the most recent local permission
                 that was set for this bucket.

--- a/pkg/clients/iam/iam.go
+++ b/pkg/clients/iam/iam.go
@@ -9,6 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/awserr"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/iamiface"
+
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
 )
 
 const (
@@ -123,12 +125,12 @@ func (c *iamClient) DeletePolicyAndDetach(username string, policyName string) er
 	}
 
 	_, err = c.iam.DetachUserPolicyRequest(&iam.DetachUserPolicyInput{PolicyArn: aws.String(policyARN), UserName: aws.String(username)}).Send(context.TODO())
-	if err != nil && !IsErrorNotFound(err) {
+	if resource.Ignore(IsErrorNotFound, err) != nil {
 		return err
 	}
 
 	_, err = c.iam.DeletePolicyRequest(&iam.DeletePolicyInput{PolicyArn: aws.String(policyARN)}).Send(context.TODO())
-	if err != nil && !IsErrorNotFound(err) {
+	if resource.Ignore(IsErrorNotFound, err) != nil {
 		return err
 	}
 	return nil
@@ -149,10 +151,9 @@ func (c *iamClient) DeleteUser(username string) error {
 	}
 
 	_, err = c.iam.DeleteUserRequest(&iam.DeleteUserInput{UserName: aws.String(username)}).Send(context.TODO())
-	if err != nil && !IsErrorNotFound(err) {
+	if resource.Ignore(IsErrorNotFound, err) != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/pkg/clients/s3/s3.go
+++ b/pkg/clients/s3/s3.go
@@ -174,13 +174,13 @@ func (c *Client) DeleteBucket(bucket *v1alpha3.S3Bucket) error {
 		return err
 	}
 
-	if bucket.Status.IAMUsername != "" {
-		err := c.iamClient.DeletePolicyAndDetach(bucket.Status.IAMUsername, bucket.Status.IAMUsername)
+	if bucket.Spec.IAMUsername != "" {
+		err := c.iamClient.DeletePolicyAndDetach(bucket.Spec.IAMUsername, bucket.Spec.IAMUsername)
 		if err != nil {
 			return err
 		}
 
-		return c.iamClient.DeleteUser(bucket.Status.IAMUsername)
+		return c.iamClient.DeleteUser(bucket.Spec.IAMUsername)
 	}
 
 	return nil

--- a/pkg/clients/s3/s3_test.go
+++ b/pkg/clients/s3/s3_test.go
@@ -395,7 +395,7 @@ func TestClient_DeleteBucket(t *testing.T) {
 		ret             []types.GomegaMatcher
 	}{
 		"HappyPath": {
-			bucket:          &awsstorage.S3Bucket{Status: awsstorage.S3BucketStatus{IAMUsername: user}},
+			bucket:          &awsstorage.S3Bucket{Spec: awsstorage.S3BucketSpec{S3BucketParameters: awsstorage.S3BucketParameters{IAMUsername: user}}},
 			deleteBucketRet: []interface{}{nil, nil},
 			deletePolicyRet: []interface{}{nil},
 			deleteUserRet:   []interface{}{nil},
@@ -409,14 +409,14 @@ func TestClient_DeleteBucket(t *testing.T) {
 			ret:             []types.GomegaMatcher{gomega.BeNil()},
 		},
 		"SendError": {
-			bucket:          &awsstorage.S3Bucket{Status: awsstorage.S3BucketStatus{IAMUsername: user}},
+			bucket:          &awsstorage.S3Bucket{Spec: awsstorage.S3BucketSpec{S3BucketParameters: awsstorage.S3BucketParameters{IAMUsername: user}}},
 			deleteBucketRet: []interface{}{nil, boom},
 			deletePolicyRet: []interface{}{nil},
 			deleteUserRet:   []interface{}{nil},
 			ret:             []types.GomegaMatcher{gomega.Equal(boom)},
 		},
 		"DeletePolicyError": {
-			bucket:          &awsstorage.S3Bucket{Status: awsstorage.S3BucketStatus{IAMUsername: user}},
+			bucket:          &awsstorage.S3Bucket{Spec: awsstorage.S3BucketSpec{S3BucketParameters: awsstorage.S3BucketParameters{IAMUsername: user}}},
 			deleteBucketRet: []interface{}{nil, nil},
 			deletePolicyRet: []interface{}{boom},
 			deleteUserRet:   []interface{}{nil},

--- a/pkg/controller/s3/claim.go
+++ b/pkg/controller/s3/claim.go
@@ -144,10 +144,6 @@ func ConfigureS3Bucket(_ context.Context, cm resource.Claim, cs resource.Class, 
 		S3BucketParameters: rs.SpecTemplate.S3BucketParameters,
 	}
 
-	if b.Spec.Name != "" {
-		spec.NameFormat = b.Spec.Name
-	}
-
 	if b.Spec.PredefinedACL != nil {
 		spec.CannedACL = translateACL(b.Spec.PredefinedACL)
 	}

--- a/pkg/controller/s3/claim_test.go
+++ b/pkg/controller/s3/claim_test.go
@@ -96,7 +96,6 @@ func TestConfigureBucket(t *testing.T) {
 							ProviderReference: &corev1.ObjectReference{Name: providerName},
 						},
 						S3BucketParameters: v1alpha3.S3BucketParameters{
-							NameFormat:      bucketName,
 							CannedACL:       &s3BucketPrivate,
 							LocalPermission: &ro,
 						},

--- a/pkg/controller/s3/s3bucket.go
+++ b/pkg/controller/s3/s3bucket.go
@@ -129,12 +129,12 @@ func (r *Reconciler) _create(bucket *bucketv1alpha3.S3Bucket, client s3.Service)
 	}
 
 	// Set username for iam user
-	if bucket.Status.IAMUsername == "" {
-		bucket.Status.IAMUsername = s3.GenerateBucketUsername(bucket)
+	if bucket.Spec.IAMUsername == "" {
+		bucket.Spec.IAMUsername = s3.GenerateBucketUsername(bucket)
 	}
 
 	// Get access keys for iam user
-	accessKeys, currentVersion, err := client.CreateUser(bucket.Status.IAMUsername, bucket)
+	accessKeys, currentVersion, err := client.CreateUser(bucket.Spec.IAMUsername, bucket)
 	if err != nil {
 		return r.fail(bucket, err)
 	}
@@ -160,10 +160,10 @@ func (r *Reconciler) _create(bucket *bucketv1alpha3.S3Bucket, client s3.Service)
 }
 
 func (r *Reconciler) _sync(bucket *bucketv1alpha3.S3Bucket, client s3.Service) (reconcile.Result, error) {
-	if bucket.Status.IAMUsername == "" {
+	if bucket.Spec.IAMUsername == "" {
 		return r.fail(bucket, errors.New("username not set, .Status.IAMUsername"))
 	}
-	bucketInfo, err := client.GetBucketInfo(bucket.Status.IAMUsername, bucket)
+	bucketInfo, err := client.GetBucketInfo(bucket.Spec.IAMUsername, bucket)
 	if err != nil {
 		return r.fail(bucket, err)
 	}
@@ -187,7 +187,7 @@ func (r *Reconciler) _sync(bucket *bucketv1alpha3.S3Bucket, client s3.Service) (
 		return r.fail(bucket, err)
 	}
 	if changed {
-		currentVersion, err := client.UpdatePolicyDocument(bucket.Status.IAMUsername, bucket)
+		currentVersion, err := client.UpdatePolicyDocument(bucket.Spec.IAMUsername, bucket)
 		if err != nil {
 			return r.fail(bucket, err)
 		}
@@ -257,7 +257,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	// Create s3 bucket
-	if bucket.Status.IAMUsername == "" {
+	if bucket.Spec.IAMUsername == "" {
 		return r.create(bucket, s3Client)
 	}
 

--- a/pkg/controller/s3/s3bucket_test.go
+++ b/pkg/controller/s3/s3bucket_test.go
@@ -75,10 +75,7 @@ func testResource() *S3Bucket {
 		},
 		Spec: S3BucketSpec{
 			ResourceSpec:       runtimev1alpha1.ResourceSpec{ProviderReference: &corev1.ObjectReference{}},
-			S3BucketParameters: v1alpha3.S3BucketParameters{LocalPermission: &perm},
-		},
-		Status: S3BucketStatus{
-			IAMUsername: testIAMUsername,
+			S3BucketParameters: v1alpha3.S3BucketParameters{LocalPermission: &perm, IAMUsername: testIAMUsername},
 		},
 	}
 }
@@ -116,7 +113,7 @@ func TestSyncBucketError(t *testing.T) {
 	expectedStatus := runtimev1alpha1.ConditionedStatus{}
 	expectedStatus.SetConditions(runtimev1alpha1.ReconcileError(testError))
 	noUserResource := testResource()
-	noUserResource.Status.IAMUsername = ""
+	noUserResource.Spec.IAMUsername = ""
 	assert(noUserResource, cl, resultRequeue, expectedStatus)
 
 	// error get bucket info
@@ -391,7 +388,7 @@ func TestReconcile(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	tr := testResource()
-	tr.Status.IAMUsername = ""
+	tr.Spec.IAMUsername = ""
 
 	r := &Reconciler{
 		Client:            NewFakeClient(tr),
@@ -445,7 +442,7 @@ func TestReconcile(t *testing.T) {
 
 	// test sync
 	r.connect = func(instance *S3Bucket) (client client.Service, e error) {
-		instance.Status.IAMUsername = "foo-user"
+		instance.Spec.IAMUsername = "foo-user"
 		return nil, nil
 	}
 	called = false

--- a/pkg/controller/s3/s3bucket_test.go
+++ b/pkg/controller/s3/s3bucket_test.go
@@ -389,11 +389,12 @@ func TestReconcile(t *testing.T) {
 
 	tr := testResource()
 	tr.Spec.IAMUsername = ""
-
+	kube := NewFakeClient(tr)
 	r := &Reconciler{
-		Client:            NewFakeClient(tr),
-		ReferenceResolver: managed.NewAPIReferenceResolver(NewFakeClient()),
+		Client:            kube,
+		ReferenceResolver: managed.NewAPIReferenceResolver(kube),
 		log:               logging.NewNopLogger(),
+		initializer:       managed.NewNameAsExternalName(kube),
 	}
 
 	// test connect error


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Removing operational identifiers from status as part of https://github.com/crossplane/provider-aws/issues/181

* IAMUsername is stored in `spec` now.
* External name annotation is used as bucket name.

Manually tested.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-aws/blob/master/config/stack/manifests/app.yaml
