### PR TITLE
Support backup and restore of AWS network resources

### DIFF
--- a/apis/network/v1alpha3/internetgateway_referencers.go
+++ b/apis/network/v1alpha3/internetgateway_referencers.go
@@ -19,15 +19,14 @@ package v1alpha3
 import (
 	"context"
 
-	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
-
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
 )
 
 // InternetGatewayIDReferencer is used to get a InternetGatewayID from a InternetGateway
@@ -56,11 +55,11 @@ func (v *InternetGatewayIDReferencer) GetStatus(ctx context.Context, _ resource.
 
 // Build retrieves and builds the InternetGatewayID
 func (v *InternetGatewayIDReferencer) Build(ctx context.Context, _ resource.CanReference, reader client.Reader) (string, error) {
-	ig := InternetGateway{}
+	ig := &InternetGateway{}
 	nn := types.NamespacedName{Name: v.Name}
-	if err := reader.Get(ctx, nn, &ig); err != nil {
+	if err := reader.Get(ctx, nn, ig); err != nil {
 		return "", err
 	}
 
-	return ig.Status.InternetGatewayID, nil
+	return meta.GetExternalName(ig), nil
 }

--- a/apis/network/v1alpha3/internetgateway_referencers_test.go
+++ b/apis/network/v1alpha3/internetgateway_referencers_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
@@ -36,16 +37,6 @@ import (
 func TestInternetGatewayIDReferencerGetStatus(t *testing.T) {
 	errBoom = errors.New("boom")
 	errResourceNotFound := &kerrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
-
-	readyResource := InternetGateway{
-		Status: InternetGatewayStatus{
-			InternetGatewayExternalStatus: InternetGatewayExternalStatus{
-				InternetGatewayID: "mockInternetGatewayID",
-			},
-		},
-	}
-
-	readyResource.Status.SetConditions(runtimev1alpha1.Available())
 
 	type input struct {
 		readerFn func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error
@@ -91,8 +82,7 @@ func TestInternetGatewayIDReferencerGetStatus(t *testing.T) {
 		"ReferenceReady_ReturnsExpected": {
 			input: input{
 				readerFn: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
-					p := obj.(*InternetGateway)
-					p.Status = readyResource.Status
+					obj.(*InternetGateway).SetConditions(runtimev1alpha1.Available())
 					return nil
 				},
 			},
@@ -150,8 +140,7 @@ func TestInternetGatewayIDReferencerBuild(t *testing.T) {
 		"ReferenceRetrieved_ReturnsExpected": {
 			input: input{
 				readerFn: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
-					p := obj.(*InternetGateway)
-					p.Status.InternetGatewayID = "mockInternetGatewayID"
+					meta.SetExternalName(obj.(metav1.Object), "mockInternetGatewayID")
 					return nil
 				},
 			},

--- a/apis/network/v1alpha3/internetgateway_types.go
+++ b/apis/network/v1alpha3/internetgateway_types.go
@@ -81,9 +81,6 @@ type InternetGatewayExternalStatus struct {
 	// Any VPCs attached to the internet gateway.
 	Attachments []InternetGatewayAttachment `json:"attachments,omitempty"`
 
-	// The ID of the internet gateway.
-	InternetGatewayID string `json:"internetGatewayId"`
-
 	// Tags represents to current ec2 tags.
 	Tags []Tag `json:"tags,omitempty"`
 }
@@ -133,7 +130,6 @@ func (i *InternetGateway) UpdateExternalStatus(observation ec2.InternetGateway) 
 	}
 
 	i.Status.InternetGatewayExternalStatus = InternetGatewayExternalStatus{
-		InternetGatewayID: aws.StringValue(observation.InternetGatewayId),
-		Attachments:       attachments,
+		Attachments: attachments,
 	}
 }

--- a/apis/network/v1alpha3/routetable_types.go
+++ b/apis/network/v1alpha3/routetable_types.go
@@ -163,10 +163,6 @@ type RouteTableSpec struct {
 
 // RouteTableExternalStatus keeps the state for the external resource
 type RouteTableExternalStatus struct {
-
-	// RouteTableID is the ID of the RouteTable.
-	RouteTableID string `json:"routeTableId"`
-
 	// The actual routes created for the route table.
 	Routes []RouteState `json:"routes,omitempty"`
 
@@ -209,7 +205,6 @@ type RouteTableList struct {
 // UpdateExternalStatus updates the external status object, given the observation
 func (t *RouteTable) UpdateExternalStatus(observation ec2.RouteTable) {
 	st := RouteTableExternalStatus{
-		RouteTableID: aws.StringValue(observation.RouteTableId),
 		Routes:       []RouteState{},
 		Associations: []AssociationState{},
 	}

--- a/apis/network/v1alpha3/securitygroup_referencers_test.go
+++ b/apis/network/v1alpha3/securitygroup_referencers_test.go
@@ -38,16 +38,6 @@ func TestSecurityGroupIDReferencerGetStatus(t *testing.T) {
 	errBoom = errors.New("boom")
 	errResourceNotFound := &kerrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
 
-	readyResource := SecurityGroup{
-		Status: SecurityGroupStatus{
-			SecurityGroupExternalStatus: SecurityGroupExternalStatus{
-				SecurityGroupID: "mockSecurityGroupID",
-			},
-		},
-	}
-
-	readyResource.Status.SetConditions(runtimev1alpha1.Available())
-
 	type input struct {
 		readerFn func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error
 	}
@@ -92,8 +82,7 @@ func TestSecurityGroupIDReferencerGetStatus(t *testing.T) {
 		"ReferenceReady_ReturnsExpected": {
 			input: input{
 				readerFn: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
-					p := obj.(*SecurityGroup)
-					p.Status = readyResource.Status
+					obj.(*SecurityGroup).SetConditions(runtimev1alpha1.Available())
 					return nil
 				},
 			},

--- a/apis/network/v1alpha3/securitygroup_types.go
+++ b/apis/network/v1alpha3/securitygroup_types.go
@@ -226,9 +226,6 @@ type SecurityGroupSpec struct {
 
 // SecurityGroupExternalStatus keeps the state for the external resource
 type SecurityGroupExternalStatus struct {
-	// SecurityGroupID is the ID of the SecurityGroup.
-	SecurityGroupID string `json:"securityGroupID"`
-
 	// Tags represents to current ec2 tags.
 	Tags []Tag `json:"tags,omitempty"`
 }
@@ -271,7 +268,6 @@ type SecurityGroupList struct {
 // UpdateExternalStatus updates the external status object, given the observation
 func (s *SecurityGroup) UpdateExternalStatus(observation ec2.SecurityGroup) {
 	s.Status.SecurityGroupExternalStatus = SecurityGroupExternalStatus{
-		SecurityGroupID: aws.StringValue(observation.GroupId),
-		Tags:            BuildFromEC2Tags(observation.Tags),
+		Tags: BuildFromEC2Tags(observation.Tags),
 	}
 }

--- a/apis/network/v1alpha3/subnet_referencers.go
+++ b/apis/network/v1alpha3/subnet_referencers.go
@@ -19,6 +19,7 @@ package v1alpha3
 import (
 	"context"
 
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,11 +57,11 @@ func (v *SubnetIDReferencer) GetStatus(ctx context.Context, _ resource.CanRefere
 
 // Build retrieves and builds the SubnetID
 func (v *SubnetIDReferencer) Build(ctx context.Context, _ resource.CanReference, reader client.Reader) (string, error) {
-	subnet := Subnet{}
+	subnet := &Subnet{}
 	nn := types.NamespacedName{Name: v.Name}
-	if err := reader.Get(ctx, nn, &subnet); err != nil {
+	if err := reader.Get(ctx, nn, subnet); err != nil {
 		return "", err
 	}
 
-	return subnet.Status.SubnetID, nil
+	return meta.GetExternalName(subnet), nil
 }

--- a/apis/network/v1alpha3/subnet_referencers_test.go
+++ b/apis/network/v1alpha3/subnet_referencers_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
@@ -36,16 +37,6 @@ import (
 func TestSubnetIDReferencerGetStatus(t *testing.T) {
 	errBoom = errors.New("boom")
 	errResourceNotFound := &kerrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
-
-	readyResource := Subnet{
-		Status: SubnetStatus{
-			SubnetExternalStatus: SubnetExternalStatus{
-				SubnetID: "mockSubnetID",
-			},
-		},
-	}
-
-	readyResource.Status.SetConditions(runtimev1alpha1.Available())
 
 	type input struct {
 		readerFn func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error
@@ -91,8 +82,7 @@ func TestSubnetIDReferencerGetStatus(t *testing.T) {
 		"ReferenceReady_ReturnsExpected": {
 			input: input{
 				readerFn: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
-					p := obj.(*Subnet)
-					p.Status = readyResource.Status
+					obj.(*Subnet).SetConditions(runtimev1alpha1.Available())
 					return nil
 				},
 			},
@@ -150,8 +140,7 @@ func TestSubnetIDReferencerBuild(t *testing.T) {
 		"ReferenceRetrieved_ReturnsExpected": {
 			input: input{
 				readerFn: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
-					p := obj.(*Subnet)
-					p.Status.SubnetID = "mockSubnetID"
+					meta.SetExternalName(obj.(*Subnet), "mockSubnetID")
 					return nil
 				},
 			},

--- a/apis/network/v1alpha3/subnet_types.go
+++ b/apis/network/v1alpha3/subnet_types.go
@@ -19,7 +19,6 @@ package v1alpha3
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/pkg/errors"
 
@@ -79,9 +78,6 @@ type SubnetExternalStatus struct {
 
 	// Tags represents to current ec2 tags.
 	Tags []Tag `json:"tags,omitempty"`
-
-	// SubnetID is the ID of the Subnet.
-	SubnetID string `json:"subnetId,omitempty"`
 }
 
 // A SubnetStatus represents the observed state of a Subnet.
@@ -123,7 +119,6 @@ type SubnetList struct {
 // UpdateExternalStatus updates the external status object,  given the observation
 func (s *Subnet) UpdateExternalStatus(observation ec2.Subnet) {
 	s.Status.SubnetExternalStatus = SubnetExternalStatus{
-		SubnetID:    aws.StringValue(observation.SubnetId),
 		Tags:        BuildFromEC2Tags(observation.Tags),
 		SubnetState: string(observation.State),
 	}

--- a/apis/network/v1alpha3/vpc_referencers.go
+++ b/apis/network/v1alpha3/vpc_referencers.go
@@ -19,6 +19,7 @@ package v1alpha3
 import (
 	"context"
 
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,11 +57,11 @@ func (v *VPCIDReferencer) GetStatus(ctx context.Context, _ resource.CanReference
 
 // Build retrieves and builds the vpcId
 func (v *VPCIDReferencer) Build(ctx context.Context, _ resource.CanReference, reader client.Reader) (string, error) {
-	vpc := VPC{}
+	vpc := &VPC{}
 	nn := types.NamespacedName{Name: v.Name}
-	if err := reader.Get(ctx, nn, &vpc); err != nil {
+	if err := reader.Get(ctx, nn, vpc); err != nil {
 		return "", err
 	}
 
-	return vpc.Status.VPCID, nil
+	return meta.GetExternalName(vpc), nil
 }

--- a/apis/network/v1alpha3/vpc_referencers_test.go
+++ b/apis/network/v1alpha3/vpc_referencers_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
@@ -52,18 +53,7 @@ func (m *mockReader) Get(ctx context.Context, key client.ObjectKey, obj runtime.
 }
 
 func TestVPCIDReferencerGetStatus(t *testing.T) {
-
 	errResourceNotFound := &kerrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
-
-	readyResource := VPC{
-		Status: VPCStatus{
-			VPCExternalStatus: VPCExternalStatus{
-				VPCID: mockVPCID,
-			},
-		},
-	}
-
-	readyResource.Status.SetConditions(runtimev1alpha1.Available())
 
 	type input struct {
 		readerFn func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error
@@ -109,8 +99,7 @@ func TestVPCIDReferencerGetStatus(t *testing.T) {
 		"ReferenceReady_ReturnsExpected": {
 			input: input{
 				readerFn: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
-					p := obj.(*VPC)
-					p.Status = readyResource.Status
+					obj.(*VPC).SetConditions(runtimev1alpha1.Available())
 					return nil
 				},
 			},
@@ -166,8 +155,7 @@ func TestVPCIDReferencerBuild(t *testing.T) {
 		"ReferenceRetrieved_ReturnsExpected": {
 			input: input{
 				readerFn: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
-					p := obj.(*VPC)
-					p.Status.VPCID = mockVPCID
+					meta.SetExternalName(obj.(*VPC), mockVPCID)
 					return nil
 				},
 			},

--- a/apis/network/v1alpha3/vpc_types.go
+++ b/apis/network/v1alpha3/vpc_types.go
@@ -19,7 +19,6 @@ package v1alpha3
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 )
@@ -55,9 +54,6 @@ type VPCExternalStatus struct {
 
 	// Tags represents to current ec2 tags.
 	Tags []Tag `json:"tags,omitempty"`
-
-	// VPCID is the ID of the VPC.
-	VPCID string `json:"vpcId,omitempty"`
 }
 
 // A VPCStatus represents the observed state of a VPC.
@@ -97,7 +93,6 @@ type VPCList struct {
 // UpdateExternalStatus updates the external status object,  given the observation
 func (v *VPC) UpdateExternalStatus(observation ec2.Vpc) {
 	v.Status.VPCExternalStatus = VPCExternalStatus{
-		VPCID:    aws.StringValue(observation.VpcId),
 		Tags:     BuildFromEC2Tags(observation.Tags),
 		VPCState: string(observation.State),
 	}

--- a/config/crd/network.aws.crossplane.io_internetgateways.yaml
+++ b/config/crd/network.aws.crossplane.io_internetgateways.yaml
@@ -287,9 +287,6 @@ spec:
                 - type
                 type: object
               type: array
-            internetGatewayId:
-              description: The ID of the internet gateway.
-              type: string
             tags:
               description: Tags represents to current ec2 tags.
               items:
@@ -306,8 +303,6 @@ spec:
                 - value
                 type: object
               type: array
-          required:
-          - internetGatewayId
           type: object
       required:
       - spec

--- a/config/crd/network.aws.crossplane.io_routetables.yaml
+++ b/config/crd/network.aws.crossplane.io_routetables.yaml
@@ -334,9 +334,6 @@ spec:
                 - type
                 type: object
               type: array
-            routeTableId:
-              description: RouteTableID is the ID of the RouteTable.
-              type: string
             routes:
               description: The actual routes created for the route table.
               items:
@@ -368,8 +365,6 @@ spec:
                 - destinationCidrBlock
                 type: object
               type: array
-          required:
-          - routeTableId
           type: object
       required:
       - spec

--- a/config/crd/network.aws.crossplane.io_securitygroups.yaml
+++ b/config/crd/network.aws.crossplane.io_securitygroups.yaml
@@ -548,9 +548,6 @@ spec:
                 - type
                 type: object
               type: array
-            securityGroupID:
-              description: SecurityGroupID is the ID of the SecurityGroup.
-              type: string
             tags:
               description: Tags represents to current ec2 tags.
               items:
@@ -567,8 +564,6 @@ spec:
                 - value
                 type: object
               type: array
-          required:
-          - securityGroupID
           type: object
       required:
       - spec

--- a/config/crd/network.aws.crossplane.io_subnets.yaml
+++ b/config/crd/network.aws.crossplane.io_subnets.yaml
@@ -280,9 +280,6 @@ spec:
                 - type
                 type: object
               type: array
-            subnetId:
-              description: SubnetID is the ID of the Subnet.
-              type: string
             subnetState:
               description: SubnetState is the current state of the Subnet.
               enum:

--- a/config/crd/network.aws.crossplane.io_vpcs.yaml
+++ b/config/crd/network.aws.crossplane.io_vpcs.yaml
@@ -296,9 +296,6 @@ spec:
                 - value
                 type: object
               type: array
-            vpcId:
-              description: VPCID is the ID of the VPC.
-              type: string
             vpcState:
               description: VPCState is the current state of the VPC.
               enum:

--- a/examples/compute/kubernetescluster/iam.yaml
+++ b/examples/compute/kubernetescluster/iam.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: identity.aws.crossplane.io/v1beta1
+kind: IAMRole
+metadata:
+  name: eks-example
+spec:
+  forProvider:
+    description: Example EKS IAM role
+    assumeRolePolicyDocument: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "eks.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+          }
+        ]
+      }
+  reclaimPolicy: Delete
+  providerRef:
+    name: example
+---
+apiVersion: identity.aws.crossplane.io/v1beta1
+kind: IAMRolePolicyAttachment
+metadata:
+  name: eks-example-servicepolicy
+spec:
+  forProvider:
+    roleNameRef:
+      name: eks-example
+    # A well known policy ARN
+    policyArn: arn:aws:iam::aws:policy/AmazonEKSServicePolicy
+  reclaimPolicy: Delete
+  providerRef:
+    name: example
+---
+apiVersion: identity.aws.crossplane.io/v1beta1
+kind: IAMRolePolicyAttachment
+metadata:
+  name: eks-example-clusterpolicy
+spec:
+  forProvider:
+    roleNameRef:
+      name: eks-example
+    # A well known policy ARN
+    policyArn: arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+  reclaimPolicy: Delete
+  providerRef:
+    name: example

--- a/examples/compute/kubernetescluster/network.yaml
+++ b/examples/compute/kubernetescluster/network.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: VPC
+metadata:
+  name: eks-example
+spec:
+  cidrBlock: 192.168.0.0/16
+  enableDnsSupport: true
+  enableDnsHostNames: true
+  reclaimPolicy: Delete
+  providerRef:
+    name: example
+---
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: Subnet
+metadata:
+  name: eks-example-1
+spec:
+  cidrBlock: 192.168.64.0/18
+  vpcIdRef:
+    name: eks-example
+  availabilityZone: us-east-1a
+  reclaimPolicy: Delete
+  providerRef:
+    name: example
+---
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: Subnet
+metadata:
+  name: eks-example-2
+spec:
+  cidrBlock: 192.168.128.0/18
+  vpcIdRef:
+    name: eks-example
+  availabilityZone: us-east-1b
+  reclaimPolicy: Delete
+  providerRef:
+    name: example
+---
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: Subnet
+metadata:
+  name: eks-example-3
+spec:
+  cidrBlock: 192.168.192.0/18
+  vpcIdRef:
+    name: eks-example
+  availabilityZone: us-east-1c
+  reclaimPolicy: Delete
+  providerRef:
+    name: example
+---
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: InternetGateway
+metadata:
+  name: eks-example
+spec:
+  vpcIdRef:
+    name: eks-example
+  reclaimPolicy: Delete
+  providerRef:
+    name: example
+---
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: RouteTable
+metadata:
+  name: eks-example
+spec:
+  vpcIdRef:
+    name: eks-example
+  routes:
+    - destinationCidrBlock: 0.0.0.0/0
+      gatewayIdRef:
+        name: eks-example
+  associations:
+    - subnetIdRef:
+        name: eks-example-1
+    - subnetIdRef:
+        name: eks-example-2
+    - subnetIdRef:
+        name: eks-example-3
+  reclaimPolicy: Delete
+  providerRef:
+    name: example
+---
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: SecurityGroup
+metadata:
+  name: eks-example
+spec:
+  vpcIdRef:
+    name: eks-example
+  groupName: my-cool-ekscluster-sg
+  description: Cluster communication with worker nodes
+  reclaimPolicy: Delete
+  providerRef:
+    name: example

--- a/examples/compute/kubernetescluster/resource-class.yaml
+++ b/examples/compute/kubernetescluster/resource-class.yaml
@@ -2,25 +2,29 @@
 apiVersion: compute.aws.crossplane.io/v1alpha3
 kind: EKSClusterClass
 metadata:
-  name: ekscluster-standard
+  name: standard-cluster
   labels:
     example: "true"
 specTemplate:
   writeConnectionSecretsToNamespace: crossplane-system
   region: us-east-1
-  roleARN: # arn:aws:iam::<account-id>:role/<role-name>
-  vpcId: #vpc-01
-  subnetIds:
-   - #subnet-01
-   - #subnet-02
-   - #subnet-03
-  securityGroupIds:
-   - #sg-01
+  roleARNRef:
+    name: eks-example
+  vpcIdRef:
+    name: eks-example
+  subnetIdRefs:
+    - name: eks-example-1
+    - name: eks-example-2
+    - name: eks-example-3
+  securityGroupIdRefs:
+    - name: eks-example
   workerNodes:
-    keyName: #named ec2 keypair
     nodeInstanceType: m3.medium
+    nodeAutoScalingGroupMinSize: 1
+    nodeAutoScalingGroupMaxSize: 1
     nodeGroupName: demo-nodes
-    clusterControlPlaneSecurityGroup: #sg-01
+    clusterControlPlaneSecurityGroupRef:
+      name: eks-example
   providerRef:
     name: example
   reclaimPolicy: Delete

--- a/pkg/controller/network/internetgateway/controller.go
+++ b/pkg/controller/network/internetgateway/controller.go
@@ -29,6 +29,7 @@ import (
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -38,14 +39,14 @@ import (
 )
 
 const (
-	errUnexpectedObject = "The managed resource is not an InternetGateway resource"
-	errClient           = "cannot create a new InternetGatewayClient"
-	errDescribe         = "failed to describe InternetGateway with id: %v"
-	errMultipleItems    = "retrieved multiple InternetGateways for the given internetGatewaysId: %v"
-	errCreate           = "failed to create the InternetGateway resource"
-	errDeleteNotPresent = "cannot delete the InternetGateway, since the internetGatewayID is not present"
-	errDetach           = "failed to detach the InternetGateway %v from VPC %v"
-	errDelete           = "failed to delete the InternetGateway resource"
+	errUnexpectedObject    = "The managed resource is not an InternetGateway resource"
+	errClient              = "cannot create a new InternetGatewayClient"
+	errDescribe            = "failed to describe InternetGateway"
+	errMultipleItems       = "retrieved multiple InternetGateways for the given internetGatewaysId"
+	errCreate              = "failed to create the InternetGateway resource"
+	errPersistExternalName = "failed to persist InternetGateway ID"
+	errDetach              = "failed to detach the InternetGateway from VPC"
+	errDelete              = "failed to delete the InternetGateway resource"
 )
 
 // SetupInternetGateway adds a controller that reconciles InternetGateways.
@@ -58,6 +59,7 @@ func SetupInternetGateway(mgr ctrl.Manager, l logging.Logger) error {
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha3.InternetGatewayGroupVersionKind),
 			managed.WithExternalConnecter(&connector{client: mgr.GetClient(), newClientFn: ec2.NewInternetGatewayClient, awsConfigFn: utils.RetrieveAwsConfigFromProvider}),
+			managed.WithInitializers(),
 			managed.WithConnectionPublishers(),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
@@ -85,10 +87,11 @@ func (conn *connector) Connect(ctx context.Context, mgd resource.Managed) (manag
 		return nil, errors.Wrap(err, errClient)
 	}
 
-	return &external{c}, nil
+	return &external{kube: conn.client, client: c}, nil
 }
 
 type external struct {
+	kube   client.Client
 	client ec2.InternetGatewayClient
 }
 
@@ -98,34 +101,28 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 		return managed.ExternalObservation{}, errors.New(errUnexpectedObject)
 	}
 
-	// To find out whether an InternetGateway exist:
-	// - the object's ExternalState should have internetGatewayID populated
-	// - an InternetGateway with the given internetGatewayID should exist
-	if cr.Status.InternetGatewayID == "" {
-		return managed.ExternalObservation{
-			ResourceExists: false,
-		}, nil
+	// AWS network resources are uniquely identified by an ID that is returned
+	// on create time; we can't tell whether they exist unless we have recorded
+	// their ID.
+	if meta.GetExternalName(cr) == "" {
+		return managed.ExternalObservation{ResourceExists: false}, nil
 	}
 
 	req := e.client.DescribeInternetGatewaysRequest(&awsec2.DescribeInternetGatewaysInput{
-		InternetGatewayIds: []string{cr.Status.InternetGatewayID},
+		InternetGatewayIds: []string{meta.GetExternalName(cr)},
 	})
 
 	response, err := req.Send(ctx)
-
 	if ec2.IsInternetGatewayNotFoundErr(err) {
-		return managed.ExternalObservation{
-			ResourceExists: false,
-		}, nil
+		return managed.ExternalObservation{ResourceExists: false}, nil
 	}
-
 	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrapf(err, errDescribe, cr.Status.InternetGatewayID)
+		return managed.ExternalObservation{}, errors.Wrap(err, errDescribe)
 	}
 
 	// in a successful response, there should be one and only one object
 	if len(response.InternetGateways) != 1 {
-		return managed.ExternalObservation{}, errors.Errorf(errMultipleItems, cr.Status.InternetGatewayID)
+		return managed.ExternalObservation{}, errors.New(errMultipleItems)
 	}
 
 	observed := response.InternetGateways[0]
@@ -157,25 +154,28 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		return managed.ExternalCreation{}, errors.New(errUnexpectedObject)
 	}
 
-	cr.Status.SetConditions(runtimev1alpha1.Creating())
-
 	req := e.client.CreateInternetGatewayRequest(&awsec2.CreateInternetGatewayInput{})
 
-	ig, err := req.Send(ctx)
+	rsp, err := req.Send(ctx)
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 	}
 
-	cr.UpdateExternalStatus(*ig.InternetGateway)
+	meta.SetExternalName(cr, aws.StringValue(rsp.InternetGateway.InternetGatewayId))
+	if err := e.kube.Update(ctx, cr); err != nil {
+		return managed.ExternalCreation{}, errors.Wrap(err, errPersistExternalName)
+	}
+
+	cr.SetConditions(runtimev1alpha1.Creating())
+	cr.UpdateExternalStatus(*rsp.InternetGateway)
 
 	// after creating the IG, attach the VPC
 	aReq := e.client.AttachInternetGatewayRequest(&awsec2.AttachInternetGatewayInput{
-		InternetGatewayId: ig.InternetGateway.InternetGatewayId,
+		InternetGatewayId: rsp.InternetGateway.InternetGatewayId,
 		VpcId:             aws.String(cr.Spec.VPCID),
 	})
 
 	_, err = aReq.Send(ctx)
-
 	return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 }
 
@@ -192,17 +192,13 @@ func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
 		return errors.New(errUnexpectedObject)
 	}
 
-	if cr.Status.InternetGatewayID == "" {
-		return errors.New(errDeleteNotPresent)
-	}
-
 	cr.Status.SetConditions(runtimev1alpha1.Deleting())
 
 	// first detach all vpc attachments
 	for _, a := range cr.Status.Attachments {
 		// after creating the IG, attach the VPC
 		dReq := e.client.DetachInternetGatewayRequest(&awsec2.DetachInternetGatewayInput{
-			InternetGatewayId: aws.String(cr.Status.InternetGatewayID),
+			InternetGatewayId: aws.String(meta.GetExternalName(cr)),
 			VpcId:             aws.String(a.VPCID),
 		})
 
@@ -210,18 +206,15 @@ func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
 			if ec2.IsInternetGatewayNotFoundErr(err) {
 				continue
 			}
-			return errors.Wrapf(err, errDetach, cr.Status.InternetGatewayID, a.VPCID)
+			return errors.Wrap(err, errDetach)
 		}
 	}
 
 	// now delete the IG
 	req := e.client.DeleteInternetGatewayRequest(&awsec2.DeleteInternetGatewayInput{
-		InternetGatewayId: aws.String(cr.Status.InternetGatewayID),
+		InternetGatewayId: aws.String(meta.GetExternalName(cr)),
 	})
 
 	_, err := req.Send(ctx)
-	if ec2.IsInternetGatewayNotFoundErr(err) {
-		return nil
-	}
-	return errors.Wrap(err, errDelete)
+	return errors.Wrap(resource.Ignore(ec2.IsInternetGatewayNotFoundErr, err), errDelete)
 }

--- a/pkg/controller/network/vpc/controller.go
+++ b/pkg/controller/network/vpc/controller.go
@@ -29,6 +29,7 @@ import (
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -41,12 +42,12 @@ const (
 	errUnexpectedObject    = "The managed resource is not an VPC resource"
 	errKubeUpdateFailed    = "cannot update VPC custom resource"
 	errClient              = "cannot create a new VPCClient"
-	errDescribe            = "failed to describe VPC with id: %v"
-	errMultipleItems       = "retrieved multiple VPCs for the given vpcId: %v"
+	errDescribe            = "failed to describe VPC"
+	errMultipleItems       = "retrieved multiple VPCs for the given vpcId"
 	errCreate              = "failed to create the VPC resource"
+	errPersistExternalName = "failed to persist InternetGateway ID"
 	errModifyVPCAttributes = "failed to modify the VPC resource attributes"
 	errCreateTags          = "failed to create tags for the VPC resource"
-	errDeleteNotPresent    = "cannot delete the VPC, since the VPCID is not present"
 	errDelete              = "failed to delete the VPC resource"
 )
 
@@ -60,7 +61,7 @@ func SetupVPC(mgr ctrl.Manager, l logging.Logger) error {
 			resource.ManagedKind(v1alpha3.VPCGroupVersionKind),
 			managed.WithExternalConnecter(&connector{client: mgr.GetClient(), newClientFn: ec2.NewVPCClient, awsConfigFn: utils.RetrieveAwsConfigFromProvider}),
 			managed.WithConnectionPublishers(),
-			managed.WithInitializers(managed.NewNameAsExternalName(mgr.GetClient()), &tagger{kube: mgr.GetClient()}),
+			managed.WithInitializers(&tagger{kube: mgr.GetClient()}),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }
@@ -86,10 +87,11 @@ func (conn *connector) Connect(ctx context.Context, mgd resource.Managed) (manag
 	if err != nil {
 		return nil, errors.Wrap(err, errClient)
 	}
-	return &external{c}, nil
+	return &external{kube: conn.client, client: c}, nil
 }
 
 type external struct {
+	kube   client.Client
 	client ec2.VPCClient
 }
 
@@ -99,37 +101,30 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 		return managed.ExternalObservation{}, errors.New(errUnexpectedObject)
 	}
 
-	// To find out whether a VPC exist:
-	// - the object's ExternalState should have vpcId populated
-	// - a VPC with the given vpcId should exist
-	if cr.Status.VPCID == "" {
-		return managed.ExternalObservation{
-			ResourceExists: false,
-		}, nil
+	// AWS network resources are uniquely identified by an ID that is returned
+	// on create time; we can't tell whether they exist unless we have recorded
+	// their ID.
+	if meta.GetExternalName(cr) == "" {
+		return managed.ExternalObservation{ResourceExists: false}, nil
 	}
 
 	req := e.client.DescribeVpcsRequest(&awsec2.DescribeVpcsInput{
-		VpcIds: []string{cr.Status.VPCID},
+		VpcIds: []string{meta.GetExternalName(cr)},
 	})
-
-	response, err := req.Send(ctx)
-
+	rsp, err := req.Send(ctx)
 	if ec2.IsVPCNotFoundErr(err) {
-		return managed.ExternalObservation{
-			ResourceExists: false,
-		}, nil
+		return managed.ExternalObservation{ResourceExists: false}, nil
 	}
-
 	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrapf(err, errDescribe, cr.Status.VPCID)
+		return managed.ExternalObservation{}, errors.Wrap(err, errDescribe)
 	}
 
 	// in a successful response, there should be one and only one object
-	if len(response.Vpcs) != 1 {
-		return managed.ExternalObservation{}, errors.Errorf(errMultipleItems, cr.Status.VPCID)
+	if len(rsp.Vpcs) != 1 {
+		return managed.ExternalObservation{}, errors.New(errMultipleItems)
 	}
 
-	observed := response.Vpcs[0]
+	observed := rsp.Vpcs[0]
 
 	if observed.State == awsec2.VpcStateAvailable {
 		cr.SetConditions(runtimev1alpha1.Available())
@@ -150,32 +145,36 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		return managed.ExternalCreation{}, errors.New(errUnexpectedObject)
 	}
 
-	cr.Status.SetConditions(runtimev1alpha1.Creating())
-
 	// if VPCID already exists, skip creating the vpc
 	// this happens when an error has occurred when modifying vpc attributes
-	if cr.Status.VPCID == "" {
+	if meta.GetExternalName(cr) == "" {
 
 		req := e.client.CreateVpcRequest(&awsec2.CreateVpcInput{
 			CidrBlock: aws.String(cr.Spec.CIDRBlock),
 		})
 
-		result, err := req.Send(ctx)
+		rsp, err := req.Send(ctx)
 		if err != nil {
 			return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 		}
 
-		cr.UpdateExternalStatus(*result.Vpc)
+		meta.SetExternalName(cr, aws.StringValue(rsp.Vpc.VpcId))
+		if err := e.kube.Update(ctx, cr); err != nil {
+			return managed.ExternalCreation{}, errors.Wrap(err, errPersistExternalName)
+		}
+
+		cr.SetConditions(runtimev1alpha1.Creating())
+		cr.UpdateExternalStatus(*rsp.Vpc)
 	}
 
 	// modify vpc attributes
 	for _, input := range []*awsec2.ModifyVpcAttributeInput{
 		{
-			VpcId:            aws.String(cr.Status.VPCID),
+			VpcId:            aws.String(meta.GetExternalName(cr)),
 			EnableDnsSupport: &awsec2.AttributeBooleanValue{Value: aws.Bool(cr.Spec.EnableDNSSupport)},
 		},
 		{
-			VpcId:              aws.String(cr.Status.VPCID),
+			VpcId:              aws.String(meta.GetExternalName(cr)),
 			EnableDnsHostnames: &awsec2.AttributeBooleanValue{Value: aws.Bool(cr.Spec.EnableDNSHostNames)},
 		},
 	} {
@@ -201,7 +200,7 @@ func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.Ex
 	// NOTE(muvaf): VPCs can only be tagged after the creation and this request
 	// is idempotent.
 	if _, err := e.client.CreateTagsRequest(&awsec2.CreateTagsInput{
-		Resources: []string{cr.Status.VPCID},
+		Resources: []string{meta.GetExternalName(cr)},
 		Tags:      v1alpha3.GenerateEC2Tags(cr.Spec.Tags),
 	}).Send(ctx); err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, errCreateTags)
@@ -215,23 +214,14 @@ func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
 		return errors.New(errUnexpectedObject)
 	}
 
-	if cr.Status.VPCID == "" {
-		return errors.New(errDeleteNotPresent)
-	}
-
 	cr.Status.SetConditions(runtimev1alpha1.Deleting())
 
 	req := e.client.DeleteVpcRequest(&awsec2.DeleteVpcInput{
-		VpcId: aws.String(cr.Status.VPCID),
+		VpcId: aws.String(meta.GetExternalName(cr)),
 	})
 
 	_, err := req.Send(ctx)
-
-	if ec2.IsVPCNotFoundErr(err) {
-		return nil
-	}
-
-	return errors.Wrap(err, errDelete)
+	return errors.Wrap(resource.Ignore(ec2.IsVPCNotFoundErr, err), errDelete)
 }
 
 type tagger struct {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Adds the `crossplane.io/external-name` annotation to all AWS network resources. Network resources are uniquely identified by strings that are generated by AWS when they are created, so unlike most controllers these ones must update the `external-name` annotation to match the identifier generated by AWS. This replaces the previous pattern of saving this identifier under status, which we must assume could be lost during the lifetime of a resource.

Tested by creating an EKS cluster using all of the network resources, backing all resources up with Velero, and then restoring it.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-aws/blob/master/config/stack/manifests/app.yaml
