### PR TITLE
Pass fsGroup in install.yaml

### DIFF
--- a/config/package/manifests/install.yaml
+++ b/config/package/manifests/install.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         core.crossplane.io/name: "provider-aws"
     spec:
+      securityContext:
+        fsGroup: 65534
       containers:
       - name: "provider-aws-controller"
         env:

--- a/config/package/manifests/install.yaml
+++ b/config/package/manifests/install.yaml
@@ -16,6 +16,10 @@ spec:
         core.crossplane.io/name: "provider-aws"
     spec:
       securityContext:
+        # TODO(hasheddan): this can be removed when there is no desire
+        # to support pre-v1.19 Kubernetes clusters
+        # https://github.com/kubernetes/enhancements/pull/1598
+        # https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8
         fsGroup: 65534
       containers:
       - name: "provider-aws-controller"


### PR DESCRIPTION


Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

This re-enables support for IAM Roles for Service Accounts by passing an fsGroup,
meaning that the projected service account token volume will be owned by the GID and the GID will be added as a supplemental group to the container process.

Fixes #211 
Depends on https://github.com/crossplane/crossplane/pull/1577

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-aws/blob/master/config/package/manifests/app.yaml
