### PR TITLE
Make EKS cluster get ARN from IAM role reference

### DIFF
--- a/apis/eks/v1beta1/referencers.go
+++ b/apis/eks/v1beta1/referencers.go
@@ -37,7 +37,7 @@ func (mg *Cluster) ResolveReferences(ctx context.Context, c client.Reader) error
 		Reference:    mg.Spec.ForProvider.RoleArnRef,
 		Selector:     mg.Spec.ForProvider.RoleArnSelector,
 		To:           reference.To{Managed: &iamv1beta1.IAMRole{}, List: &iamv1beta1.IAMRoleList{}},
-		Extract:      reference.ExternalName(),
+		Extract:      iamv1beta1.IAMRoleARN(),
 	})
 	if err != nil {
 		return err

--- a/apis/eks/v1beta1/types.go
+++ b/apis/eks/v1beta1/types.go
@@ -84,8 +84,7 @@ type ClusterParameters struct {
 	//
 	// RoleArn is a required field
 	// +immutable
-	// +optional
-	RoleArn *string `json:"roleArn"`
+	RoleArn *string `json:"roleArn,omitempty"`
 
 	// RoleArnRef is a reference to an IAMRole used to set
 	// the RoleArn.
@@ -195,12 +194,12 @@ type VpcConfigRequest struct {
 	// SecurityGroupIDRefs are references to SecurityGroups used to set
 	// the SecurityGroupIDs.
 	// +optional
-	SecurityGroupIDRefs []runtimev1alpha1.Reference `json:"securityGroupIDRefs,omitempty"`
+	SecurityGroupIDRefs []runtimev1alpha1.Reference `json:"securityGroupIdRefs,omitempty"`
 
 	// SecurityGroupIDSelector selects references to SecurityGroups used
 	// to set the SecurityGroupIDs.
 	// +optional
-	SecurityGroupIDSelector *runtimev1alpha1.Selector `json:"securityGroupIDSelector,omitempty"`
+	SecurityGroupIDSelector *runtimev1alpha1.Selector `json:"securityGroupIdSelector,omitempty"`
 
 	// Specify subnets for your Amazon EKS worker nodes. Amazon EKS creates cross-account
 	// elastic network interfaces in these subnets to allow communication between
@@ -211,12 +210,12 @@ type VpcConfigRequest struct {
 	// SubnetIDRefs are references to Subnets used to set
 	// the SubnetIDs.
 	// +optional
-	SubnetIDRefs []runtimev1alpha1.Reference `json:"subnetIDRefs,omitempty"`
+	SubnetIDRefs []runtimev1alpha1.Reference `json:"subnetIdRefs,omitempty"`
 
 	// SubnetIDSelector selects references to Subnets used
 	// to set the SubnetIDs.
 	// +optional
-	SubnetIDSelector *runtimev1alpha1.Selector `json:"subnetIDSelector,omitempty"`
+	SubnetIDSelector *runtimev1alpha1.Selector `json:"subnetIdSelector,omitempty"`
 }
 
 // ClusterObservation is the observed state of a cluster.

--- a/config/crd/eks.aws.crossplane.io_clusters.yaml
+++ b/config/crd/eks.aws.crossplane.io_clusters.yaml
@@ -246,7 +246,7 @@ spec:
                       items:
                         type: string
                       type: array
-                    securityGroupIDRefs:
+                    securityGroupIdRefs:
                       description: SecurityGroupIDRefs are references to SecurityGroups
                         used to set the SecurityGroupIDs.
                       items:
@@ -259,7 +259,7 @@ spec:
                         - name
                         type: object
                       type: array
-                    securityGroupIDSelector:
+                    securityGroupIdSelector:
                       description: SecurityGroupIDSelector selects references to SecurityGroups
                         used to set the SecurityGroupIDs.
                       properties:
@@ -283,7 +283,7 @@ spec:
                       items:
                         type: string
                       type: array
-                    subnetIDRefs:
+                    subnetIdRefs:
                       description: SubnetIDRefs are references to Subnets used to
                         set the SubnetIDs.
                       items:
@@ -296,7 +296,7 @@ spec:
                         - name
                         type: object
                       type: array
-                    subnetIDSelector:
+                    subnetIdSelector:
                       description: SubnetIDSelector selects references to Subnets
                         used to set the SubnetIDs.
                       properties:


### PR DESCRIPTION


Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

EKS Cluster was mistakenly resolving IAM role references by getting the
role name rather than its ARN. This updates the the reference resolver
and also make the roleArn omitempty so that updates that have a null ARN
(i.e. all of them before it is successfully resolved) will not fail. A
few instances of ID were also changed to Id.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-aws/blob/master/config/package/manifests/app.yaml
