### PR TITLE
Remove unused dbClusterParamterGroup field from RDS

### DIFF
--- a/apis/database/v1beta1/rdsinstance_types.go
+++ b/apis/database/v1beta1/rdsinstance_types.go
@@ -207,11 +207,6 @@ type RDSInstanceParameters struct {
 	// +optional
 	DBClusterIdentifier *string `json:"dbClusterIdentifier,omitempty"`
 
-	// DBClusterParameterGroupName is the name of the DB cluster parameter group to use for the DB cluster.
-	// +immutable
-	// +optional
-	DBClusterParameterGroupName *string `json:"dbClusterParameterGroupName,omitempty"`
-
 	// DBInstanceClass is the compute and memory capacity of the DB instance, for example, db.m4.large.
 	// Not all DB instance classes are available in all AWS Regions, or for all
 	// database engines. For the full list of DB instance classes, and availability

--- a/apis/database/v1beta1/zz_generated.deepcopy.go
+++ b/apis/database/v1beta1/zz_generated.deepcopy.go
@@ -627,11 +627,6 @@ func (in *RDSInstanceParameters) DeepCopyInto(out *RDSInstanceParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.DBClusterParameterGroupName != nil {
-		in, out := &in.DBClusterParameterGroupName, &out.DBClusterParameterGroupName
-		*out = new(string)
-		**out = **in
-	}
 	if in.DBName != nil {
 		in, out := &in.DBName, &out.DBName
 		*out = new(string)

--- a/config/crd/database.aws.crossplane.io_rdsinstanceclasses.yaml
+++ b/config/crd/database.aws.crossplane.io_rdsinstanceclasses.yaml
@@ -175,10 +175,6 @@ spec:
                     that the instance will belong to. For information on creating
                     a DB cluster, see CreateDBCluster. Type: String'
                   type: string
-                dbClusterParameterGroupName:
-                  description: DBClusterParameterGroupName is the name of the DB cluster
-                    parameter group to use for the DB cluster.
-                  type: string
                 dbInstanceClass:
                   description: DBInstanceClass is the compute and memory capacity
                     of the DB instance, for example, db.m4.large. Not all DB instance

--- a/config/crd/database.aws.crossplane.io_rdsinstances.yaml
+++ b/config/crd/database.aws.crossplane.io_rdsinstances.yaml
@@ -261,10 +261,6 @@ spec:
                     that the instance will belong to. For information on creating
                     a DB cluster, see CreateDBCluster. Type: String'
                   type: string
-                dbClusterParameterGroupName:
-                  description: DBClusterParameterGroupName is the name of the DB cluster
-                    parameter group to use for the DB cluster.
-                  type: string
                 dbInstanceClass:
                   description: DBInstanceClass is the compute and memory capacity
                     of the DB instance, for example, db.m4.large. Not all DB instance

--- a/pkg/clients/rds/rds.go
+++ b/pkg/clients/rds/rds.go
@@ -77,7 +77,7 @@ func GenerateCreateDBInstanceInput(name, password string, p *v1beta1.RDSInstance
 		AllocatedStorage:                   awsclients.Int64Address(p.AllocatedStorage),
 		AutoMinorVersionUpgrade:            p.AutoMinorVersionUpgrade,
 		AvailabilityZone:                   p.AvailabilityZone,
-		BackupRetentionPeriod:              aws.Int64(0),
+		BackupRetentionPeriod:              awsclients.Int64Address(p.BackupRetentionPeriod),
 		CharacterSetName:                   p.CharacterSetName,
 		CopyTagsToSnapshot:                 p.CopyTagsToSnapshot,
 		DBClusterIdentifier:                p.DBClusterIdentifier,


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Removes `dbClusterParamterGroup` as it seems it's not used in any API call and backup retention call was given as `0` for all cases for some reason, that's also fixed.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-aws/blob/master/config/package/manifests/app.yaml
