### PR TITLE
Add MasterPasswordSecretRef to allow specifying a password for RDS

### DIFF
--- a/apis/database/v1beta1/rdsinstance_types.go
+++ b/apis/database/v1beta1/rdsinstance_types.go
@@ -430,6 +430,13 @@ type RDSInstanceParameters struct {
 	// +optional
 	MasterUsername *string `json:"masterUsername,omitempty"`
 
+	// MasterPasswordSecretRef references the secret that contains the password used
+	// in the creation of this RDS instance. If no reference is given, a password
+	// will be auto-generated.
+	// +optional
+	// +immutable
+	MasterPasswordSecretRef *runtimev1alpha1.SecretKeySelector `json:"masterPasswordSecretRef,omitempty"`
+
 	// MonitoringInterval is the interval, in seconds, between points when Enhanced Monitoring metrics
 	// are collected for the DB instance. To disable collecting Enhanced Monitoring
 	// metrics, specify 0. The default is 0.

--- a/apis/database/v1beta1/zz_generated.deepcopy.go
+++ b/apis/database/v1beta1/zz_generated.deepcopy.go
@@ -697,6 +697,11 @@ func (in *RDSInstanceParameters) DeepCopyInto(out *RDSInstanceParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MasterPasswordSecretRef != nil {
+		in, out := &in.MasterPasswordSecretRef, &out.MasterPasswordSecretRef
+		*out = new(v1alpha1.SecretKeySelector)
+		**out = **in
+	}
 	if in.MonitoringInterval != nil {
 		in, out := &in.MonitoringInterval, &out.MonitoringInterval
 		*out = new(int)

--- a/config/crd/database.aws.crossplane.io_rdsinstanceclasses.yaml
+++ b/config/crd/database.aws.crossplane.io_rdsinstanceclasses.yaml
@@ -389,6 +389,25 @@ spec:
                   description: 'LicenseModel information for this DB instance. Valid
                     values: license-included | bring-your-own-license | general-public-license'
                   type: string
+                masterPasswordSecretRef:
+                  description: MasterPasswordSecretRef references the secret that
+                    contains the password used in the creation of this RDS instance.
+                    If no reference is given, a password will be auto-generated.
+                  properties:
+                    key:
+                      description: The key to select.
+                      type: string
+                    name:
+                      description: Name of the secret.
+                      type: string
+                    namespace:
+                      description: Namespace of the secret.
+                      type: string
+                  required:
+                  - key
+                  - name
+                  - namespace
+                  type: object
                 masterUsername:
                   description: 'MasterUsername is the name for the master user. Amazon
                     Aurora Not applicable. The name for the master user is managed

--- a/config/crd/database.aws.crossplane.io_rdsinstances.yaml
+++ b/config/crd/database.aws.crossplane.io_rdsinstances.yaml
@@ -475,6 +475,25 @@ spec:
                   description: 'LicenseModel information for this DB instance. Valid
                     values: license-included | bring-your-own-license | general-public-license'
                   type: string
+                masterPasswordSecretRef:
+                  description: MasterPasswordSecretRef references the secret that
+                    contains the password used in the creation of this RDS instance.
+                    If no reference is given, a password will be auto-generated.
+                  properties:
+                    key:
+                      description: The key to select.
+                      type: string
+                    name:
+                      description: Name of the secret.
+                      type: string
+                    namespace:
+                      description: Namespace of the secret.
+                      type: string
+                  required:
+                  - key
+                  - name
+                  - namespace
+                  type: object
                 masterUsername:
                   description: 'MasterUsername is the name for the master user. Amazon
                     Aurora Not applicable. The name for the master user is managed

--- a/pkg/clients/rds/rds.go
+++ b/pkg/clients/rds/rds.go
@@ -439,6 +439,9 @@ func IsUpToDate(p v1beta1.RDSInstanceParameters, db rds.DBInstance) (bool, error
 	//  <Modify/Create/Delete>DBInstanceInput objects but not in DBInstance
 	//  object are not late-inited. So, this func always returns true when
 	//  those configurations are changed by the user.
+
+	// TODO(muvaf): If a secret is provided for password, this logic should check
+	// whether it's changed by comparing it to the password in the published secret.
 	patch, err := CreatePatch(&db, &p)
 	if err != nil {
 		return false, err

--- a/pkg/clients/rds/rds.go
+++ b/pkg/clients/rds/rds.go
@@ -97,7 +97,7 @@ func GenerateCreateDBInstanceInput(name, password string, p *v1beta1.RDSInstance
 		Iops:                               awsclients.Int64Address(p.IOPS),
 		KmsKeyId:                           p.KMSKeyID,
 		LicenseModel:                       p.LicenseModel,
-		MasterUserPassword:                 aws.String(password),
+		MasterUserPassword:                 awsclients.String(password),
 		MasterUsername:                     p.MasterUsername,
 		MonitoringInterval:                 awsclients.Int64Address(p.MonitoringInterval),
 		MonitoringRoleArn:                  p.MonitoringRoleARN,


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

We already had plans to use `Secret`s as input for sensitive fields [per managed resource design](https://github.com/crossplane/crossplane/blob/master/design/one-pager-managed-resource-api-design.md#sensitive-input-fields) but I think there hasn't been actual implementation of it yet.

I have implemented it for RDS mainly to address the use case @kelvinwijaya described in https://github.com/crossplane/provider-aws/issues/267 ; it's not possible to create a read replica instance for aurora to join an existing DB cluster since the password is required to be empty.

I have tested creating an Aurora MySQL cluster with no IAM auth and used the following YAML to join that cluster:
```yaml
apiVersion: database.aws.crossplane.io/v1beta1
kind: RDSInstance
metadata:
  name: mvf-test-replica
spec:
  forProvider:
    engine: aurora
    dbClusterIdentifier: mvf-cl-1
    dbInstanceClass: db.t2.small
    availabilityZone: us-east-2a
    masterPasswordSecretRef:
      name: mvf-secret
      namespace: crossplane-system
      key: password
  writeConnectionSecretToRef:
    name: instance-secret
    namespace: crossplane-system
  providerRef:
    name: aws-provider
  reclaimPolicy: Delete
---
apiVersion: v1
kind: Secret
metadata:
  name: mvf-secret
  namespace: crossplane-system
type: Opaque
```

As you can see, in order to send an empty password, we need to reference an empty `Secret`, i.e. existence of a reference means opt-out of password generation. The opt-in for generation could be implemented but that'd be a breaking change for the current users in v1beta1, so, we can consider it in later API versions of this resource.

Fixes https://github.com/crossplane/provider-aws/issues/267

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-aws/blob/master/config/package/manifests/app.yaml
