### PR TITLE
aws_session_token key should be used when credentials are parsed

### DIFF
--- a/pkg/clients/aws_test.go
+++ b/pkg/clients/aws_test.go
@@ -31,22 +31,31 @@ const (
 func TestCredentialsIdSecret(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	testProfile := "default"
-	testID := "testID"
-	testSecret := "testSecret"
-	credentials := []byte(fmt.Sprintf(awsCredentialsFileFormat, testProfile, testID, testSecret))
+	profile := "default"
+	id := "testID"
+	secret := "testSecret"
+	token := "testtoken"
+	credentials := []byte(fmt.Sprintf(awsCredentialsFileFormat, profile, id, secret))
 
 	// valid profile
-	id, secret, err := CredentialsIDSecret(credentials, testProfile)
+	creds, err := CredentialsIDSecret(credentials, profile)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(id).To(Equal(testID))
-	g.Expect(secret).To(Equal(testSecret))
+	g.Expect(creds.AccessKeyID).To(Equal(id))
+	g.Expect(creds.SecretAccessKey).To(Equal(secret))
+
+	// valid profile with session token
+	credentialsWithToken := []byte(fmt.Sprintf(awsCredentialsFileFormat+"\naws_session_token = %s", profile, id, secret, token))
+	creds, err = CredentialsIDSecret(credentialsWithToken, profile)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(creds.AccessKeyID).To(Equal(id))
+	g.Expect(creds.SecretAccessKey).To(Equal(secret))
+	g.Expect(creds.SessionToken).To(Equal(token))
 
 	// invalid profile - foo does not exist
-	id, secret, err = CredentialsIDSecret(credentials, "foo")
+	creds, err = CredentialsIDSecret(credentials, "foo")
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(id).To(Equal(""))
-	g.Expect(secret).To(Equal(""))
+	g.Expect(creds.AccessKeyID).To(Equal(""))
+	g.Expect(creds.SecretAccessKey).To(Equal(""))
 }
 
 func TestUseProviderSecret(t *testing.T) {


### PR DESCRIPTION
# Description of your changes

Adds support for additional `aws_session_token` key.

Fixes #278 

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-aws/blob/master/config/package/manifests/app.yaml
