### PR TITLE
Use crossplane-runtime Reference type for Provider in ACM Cert

### DIFF
--- a/apis/acm/v1alpha1/zz_generated.managed.go
+++ b/apis/acm/v1alpha1/zz_generated.managed.go
@@ -44,7 +44,7 @@ func (mg *Certificate) GetCondition(ct runtimev1alpha1.ConditionType) runtimev1a
 }
 
 // GetProviderReference of this Certificate.
-func (mg *Certificate) GetProviderReference() *corev1.ObjectReference {
+func (mg *Certificate) GetProviderReference() runtimev1alpha1.Reference {
 	return mg.Spec.ProviderReference
 }
 
@@ -79,7 +79,7 @@ func (mg *Certificate) SetConditions(c ...runtimev1alpha1.Condition) {
 }
 
 // SetProviderReference of this Certificate.
-func (mg *Certificate) SetProviderReference(r *corev1.ObjectReference) {
+func (mg *Certificate) SetProviderReference(r runtimev1alpha1.Reference) {
 	mg.Spec.ProviderReference = r
 }
 

--- a/config/crd/acm.aws.crossplane.io_certificates.yaml
+++ b/config/crd/acm.aws.crossplane.io_certificates.yaml
@@ -226,38 +226,11 @@ spec:
               description: ProviderReference specifies the provider that will be used
                 to create, observe, update, and delete this managed resource.
               properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
                 name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  description: Name of the referenced object.
                   type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
+              required:
+              - name
               type: object
             reclaimPolicy:
               description: ReclaimPolicy specifies what will happen to this managed

--- a/pkg/controller/acm/controller.go
+++ b/pkg/controller/acm/controller.go
@@ -24,7 +24,6 @@ import (
 	awsacm "github.com/aws/aws-sdk-go-v2/service/acm"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -82,7 +81,7 @@ func SetupCertificate(mgr ctrl.Manager, l logging.Logger) error {
 type connector struct {
 	client      client.Client
 	newClientFn func(*aws.Config) (acm.Client, error)
-	awsConfigFn func(context.Context, client.Reader, *corev1.ObjectReference) (*aws.Config, error)
+	awsConfigFn func(context.Context, client.Reader, runtimev1alpha1.Reference) (*aws.Config, error)
 }
 
 func (conn *connector) Connect(ctx context.Context, mgd resource.Managed) (managed.ExternalClient, error) {

--- a/pkg/controller/acm/controller_test.go
+++ b/pkg/controller/acm/controller_test.go
@@ -26,7 +26,6 @@ import (
 	awsacm "github.com/aws/aws-sdk-go-v2/service/acm"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
@@ -106,7 +105,7 @@ func certificate(m ...certificateModifier) *v1alpha1.Certificate {
 	cr := &v1alpha1.Certificate{
 		Spec: v1alpha1.CertificateSpec{
 			ResourceSpec: corev1alpha1.ResourceSpec{
-				ProviderReference: &corev1.ObjectReference{Name: providerName},
+				ProviderReference: runtimev1alpha1.Reference{Name: providerName},
 			},
 		},
 	}
@@ -121,7 +120,7 @@ func TestConnect(t *testing.T) {
 
 	type args struct {
 		newClientFn func(*aws.Config) (acm.Client, error)
-		awsConfigFn func(context.Context, client.Reader, *corev1.ObjectReference) (*aws.Config, error)
+		awsConfigFn func(context.Context, client.Reader, runtimev1alpha1.Reference) (*aws.Config, error)
 		cr          resource.Managed
 	}
 	type want struct {
@@ -140,7 +139,7 @@ func TestConnect(t *testing.T) {
 					}
 					return nil, nil
 				},
-				awsConfigFn: func(_ context.Context, _ client.Reader, p *corev1.ObjectReference) (*aws.Config, error) {
+				awsConfigFn: func(_ context.Context, _ client.Reader, p runtimev1alpha1.Reference) (*aws.Config, error) {
 					if diff := cmp.Diff(providerName, p.Name); diff != "" {
 						t.Errorf("r: -want, +got:\n%s", diff)
 					}
@@ -165,7 +164,7 @@ func TestConnect(t *testing.T) {
 					}
 					return nil, errBoom
 				},
-				awsConfigFn: func(_ context.Context, _ client.Reader, p *corev1.ObjectReference) (*aws.Config, error) {
+				awsConfigFn: func(_ context.Context, _ client.Reader, p runtimev1alpha1.Reference) (*aws.Config, error) {
 					if diff := cmp.Diff(providerName, p.Name); diff != "" {
 						t.Errorf("r: -want, +got:\n%s", diff)
 					}


### PR DESCRIPTION
This updates ACM Certificate to use the Reference instead of
ObjectReference for its ProviderRef type. This is currently causing a
build failure because the PR that added it was not rebased on master
after change to crossplane-tools generation.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-aws/blob/master/config/package/manifests/app.yaml
