### PR TITLE
rds: fix unnecessary update requests

### DIFF
--- a/pkg/clients/rds/rds_test.go
+++ b/pkg/clients/rds/rds_test.go
@@ -504,7 +504,7 @@ func TestLateInitialize(t *testing.T) {
 				MultiAZ:                            &multiAZ,
 				PerformanceInsightsKMSKeyId:        &kmsID,
 				PerformanceInsightsRetentionPeriod: &retention64,
-				DbInstancePort:                     &port64,
+				Endpoint:                           &rds.Endpoint{Port: &port64},
 				PreferredBackupWindow:              &window,
 				PreferredMaintenanceWindow:         &window,
 				PromotionTier:                      &tier64,

--- a/pkg/controller/database/rdsinstance.go
+++ b/pkg/controller/database/rdsinstance.go
@@ -285,8 +285,9 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) error {
 		return nil
 	}
 	input := awsrds.DeleteDBInstanceInput{
-		DBInstanceIdentifier: aws.String(meta.GetExternalName(cr)),
-		SkipFinalSnapshot:    cr.Spec.ForProvider.SkipFinalSnapshotBeforeDeletion,
+		DBInstanceIdentifier:      aws.String(meta.GetExternalName(cr)),
+		SkipFinalSnapshot:         cr.Spec.ForProvider.SkipFinalSnapshotBeforeDeletion,
+		FinalDBSnapshotIdentifier: cr.Spec.ForProvider.FinalDBSnapshotIdentifier,
 	}
 	_, err = e.client.DeleteDBInstanceRequest(&input).Send(ctx)
 	return errors.Wrap(resource.Ignore(rds.IsErrorNotFound, err), errDeleteFailed)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

I have discovered that our skip list was missing some fields that should be skipped since they don't appear on `ModifyDBInstanceInput`.

Also, AWS seems to have a bug where `DescribeDBInstances` request always returns `0` for `DbInstancePort` which triggers an update if the user entered `3306` or any custom port. I have reproduced the bug via AWS CLI, too: console says 3306 but CLI returns 0. Apparently, this [happens in Java SDK](https://github.com/aws/aws-sdk-java/issues/924#issuecomment-658089792), too. Luckily, there is another field we can retrieve the port and it seems to be working.

Manually tested.

Fixes #285 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-aws/blob/master/config/package/manifests/app.yaml
