### PR TITLE
Separate add and remove tag operations for v1beta1 EKS cluster

### DIFF
--- a/pkg/clients/aws.go
+++ b/pkg/clients/aws.go
@@ -296,3 +296,24 @@ func CompactAndEscapeJSON(s string) (string, error) {
 	}
 	return url.QueryEscape(buffer.String()), nil
 }
+
+// DiffTags returns tags that should be added or removed.
+func DiffTags(local, remote map[string]string) (add map[string]string, remove []string) {
+	add = make(map[string]string, len(local))
+	remove = []string{}
+	for k, v := range local {
+		add[k] = v
+	}
+	for k, v := range remote {
+		switch val, ok := local[k]; {
+		case ok && val != v:
+			remove = append(remove, k)
+		case !ok:
+			remove = append(remove, k)
+			delete(add, k)
+		default:
+			delete(add, k)
+		}
+	}
+	return
+}

--- a/pkg/clients/eks/fake/fake.go
+++ b/pkg/clients/eks/fake/fake.go
@@ -32,6 +32,7 @@ type MockClient struct {
 	MockUpdateClusterConfigRequest  func(*eks.UpdateClusterConfigInput) eks.UpdateClusterConfigRequest
 	MockDeleteClusterRequest        func(*eks.DeleteClusterInput) eks.DeleteClusterRequest
 	MockTagResourceRequest          func(*eks.TagResourceInput) eks.TagResourceRequest
+	MockUntagResourceRequest        func(*eks.UntagResourceInput) eks.UntagResourceRequest
 	MockUpdateClusterVersionRequest func(*eks.UpdateClusterVersionInput) eks.UpdateClusterVersionRequest
 }
 
@@ -60,6 +61,11 @@ func (c *MockClient) DeleteClusterRequest(i *eks.DeleteClusterInput) eks.DeleteC
 // TagResourceRequest calls the underlying MockTagResourceRequest method.
 func (c *MockClient) TagResourceRequest(i *eks.TagResourceInput) eks.TagResourceRequest {
 	return c.MockTagResourceRequest(i)
+}
+
+// UntagResourceRequest calls the underlying MockUntagResourceRequest method.
+func (c *MockClient) UntagResourceRequest(i *eks.UntagResourceInput) eks.UntagResourceRequest {
+	return c.MockUntagResourceRequest(i)
 }
 
 // UpdateClusterVersionRequest calls the underlying

--- a/pkg/controller/eks/cluster.go
+++ b/pkg/controller/eks/cluster.go
@@ -204,9 +204,8 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, errors.Wrap(err, errPatchCreationFailed)
 	}
 	if patch.Version != nil {
-		if _, err := e.client.UpdateClusterVersionRequest(&awseks.UpdateClusterVersionInput{Name: awsclients.String(meta.GetExternalName(cr)), Version: patch.Version}).Send(ctx); err != nil {
-			return managed.ExternalUpdate{}, errors.Wrap(resource.Ignore(eks.IsErrorInUse, err), errUpdateVersionFailed)
-		}
+		_, err := e.client.UpdateClusterVersionRequest(&awseks.UpdateClusterVersionInput{Name: awsclients.String(meta.GetExternalName(cr)), Version: patch.Version}).Send(ctx)
+		return managed.ExternalUpdate{}, errors.Wrap(resource.Ignore(eks.IsErrorInUse, err), errUpdateVersionFailed)
 	}
 	_, err = e.client.UpdateClusterConfigRequest(eks.GenerateUpdateClusterConfigInput(meta.GetExternalName(cr), patch)).Send(ctx)
 	return managed.ExternalUpdate{}, errors.Wrap(resource.Ignore(eks.IsErrorInUse, err), errUpdateConfigFailed)

--- a/pkg/controller/eks/cluster_test.go
+++ b/pkg/controller/eks/cluster_test.go
@@ -641,11 +641,6 @@ func TestUpdate(t *testing.T) {
 							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.UpdateClusterVersionOutput{}},
 						}
 					},
-					MockUpdateClusterConfigRequest: func(input *awseks.UpdateClusterConfigInput) awseks.UpdateClusterConfigRequest {
-						return awseks.UpdateClusterConfigRequest{
-							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.UpdateClusterConfigOutput{}},
-						}
-					},
 					MockDescribeClusterRequest: func(input *awseks.DescribeClusterInput) awseks.DescribeClusterRequest {
 						return awseks.DescribeClusterRequest{
 							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.DescribeClusterOutput{

--- a/pkg/controller/eks/cluster_test.go
+++ b/pkg/controller/eks/cluster_test.go
@@ -93,6 +93,10 @@ func withStatus(s v1beta1.ClusterStatusType) clusterModifier {
 	return func(r *v1beta1.Cluster) { r.Status.AtProvider.Status = s }
 }
 
+func withConfig(c v1beta1.VpcConfigRequest) clusterModifier {
+	return func(r *v1beta1.Cluster) { r.Spec.ForProvider.ResourcesVpcConfig = c }
+}
+
 func cluster(m ...clusterModifier) *v1beta1.Cluster {
 	cr := &v1beta1.Cluster{
 		Spec: v1beta1.ClusterSpec{
@@ -571,24 +575,19 @@ func TestUpdate(t *testing.T) {
 		args
 		want
 	}{
-		"Successful": {
+		"SuccessfulAddTags": {
 			args: args{
 				eks: &fake.MockClient{
-					MockUpdateClusterConfigRequest: func(input *awseks.UpdateClusterConfigInput) awseks.UpdateClusterConfigRequest {
-						return awseks.UpdateClusterConfigRequest{
-							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.UpdateClusterConfigOutput{}},
-						}
-					},
-					MockUpdateClusterVersionRequest: func(input *awseks.UpdateClusterVersionInput) awseks.UpdateClusterVersionRequest {
-						return awseks.UpdateClusterVersionRequest{
-							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.UpdateClusterVersionOutput{}},
-						}
-					},
 					MockDescribeClusterRequest: func(input *awseks.DescribeClusterInput) awseks.DescribeClusterRequest {
 						return awseks.DescribeClusterRequest{
 							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.DescribeClusterOutput{
 								Cluster: &awseks.Cluster{},
 							}},
+						}
+					},
+					MockUpdateClusterConfigRequest: func(input *awseks.UpdateClusterConfigInput) awseks.UpdateClusterConfigRequest {
+						return awseks.UpdateClusterConfigRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.UpdateClusterConfigOutput{}},
 						}
 					},
 					MockTagResourceRequest: func(input *awseks.TagResourceInput) awseks.TagResourceRequest {
@@ -598,13 +597,89 @@ func TestUpdate(t *testing.T) {
 					},
 				},
 				cr: cluster(
-					withVersion(&version),
 					withTags(map[string]string{"foo": "bar"})),
 			},
 			want: want{
 				cr: cluster(
-					withVersion(&version),
 					withTags(map[string]string{"foo": "bar"})),
+			},
+		},
+		"SuccessfulRemoveTags": {
+			args: args{
+				eks: &fake.MockClient{
+					MockDescribeClusterRequest: func(input *awseks.DescribeClusterInput) awseks.DescribeClusterRequest {
+						return awseks.DescribeClusterRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.DescribeClusterOutput{
+								Cluster: &awseks.Cluster{
+									Tags: map[string]string{"foo": "bar"},
+								},
+							}},
+						}
+					},
+					MockUpdateClusterConfigRequest: func(input *awseks.UpdateClusterConfigInput) awseks.UpdateClusterConfigRequest {
+						return awseks.UpdateClusterConfigRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.UpdateClusterConfigOutput{}},
+						}
+					},
+					MockUntagResourceRequest: func(input *awseks.UntagResourceInput) awseks.UntagResourceRequest {
+						return awseks.UntagResourceRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.UntagResourceOutput{}},
+						}
+					},
+				},
+				cr: cluster(),
+			},
+			want: want{
+				cr: cluster(),
+			},
+		},
+		"SuccessfulUpdateVersion": {
+			args: args{
+				eks: &fake.MockClient{
+					MockUpdateClusterVersionRequest: func(input *awseks.UpdateClusterVersionInput) awseks.UpdateClusterVersionRequest {
+						return awseks.UpdateClusterVersionRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.UpdateClusterVersionOutput{}},
+						}
+					},
+					MockUpdateClusterConfigRequest: func(input *awseks.UpdateClusterConfigInput) awseks.UpdateClusterConfigRequest {
+						return awseks.UpdateClusterConfigRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.UpdateClusterConfigOutput{}},
+						}
+					},
+					MockDescribeClusterRequest: func(input *awseks.DescribeClusterInput) awseks.DescribeClusterRequest {
+						return awseks.DescribeClusterRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.DescribeClusterOutput{
+								Cluster: &awseks.Cluster{},
+							}},
+						}
+					},
+				},
+				cr: cluster(withVersion(&version)),
+			},
+			want: want{
+				cr: cluster(withVersion(&version)),
+			},
+		},
+		"SuccessfulUpdateCluster": {
+			args: args{
+				eks: &fake.MockClient{
+					MockUpdateClusterConfigRequest: func(input *awseks.UpdateClusterConfigInput) awseks.UpdateClusterConfigRequest {
+						return awseks.UpdateClusterConfigRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.UpdateClusterConfigOutput{}},
+						}
+					},
+					MockDescribeClusterRequest: func(input *awseks.DescribeClusterInput) awseks.DescribeClusterRequest {
+						return awseks.DescribeClusterRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.DescribeClusterOutput{
+								Cluster: &awseks.Cluster{},
+							}},
+						}
+					},
+				},
+				cr: cluster(withConfig(v1beta1.VpcConfigRequest{SubnetIDs: []string{"subnet"}})),
+			},
+			want: want{
+				cr: cluster(withConfig(v1beta1.VpcConfigRequest{SubnetIDs: []string{"subnet"}})),
 			},
 		},
 		"AlreadyModifying": {
@@ -657,11 +732,6 @@ func TestUpdate(t *testing.T) {
 		"FailedUpdateVersion": {
 			args: args{
 				eks: &fake.MockClient{
-					MockUpdateClusterConfigRequest: func(input *awseks.UpdateClusterConfigInput) awseks.UpdateClusterConfigRequest {
-						return awseks.UpdateClusterConfigRequest{
-							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.UpdateClusterConfigOutput{}},
-						}
-					},
 					MockUpdateClusterVersionRequest: func(input *awseks.UpdateClusterVersionInput) awseks.UpdateClusterVersionRequest {
 						return awseks.UpdateClusterVersionRequest{
 							Request: &aws.Request{HTTPRequest: &http.Request{}, Error: errBoom},
@@ -682,6 +752,31 @@ func TestUpdate(t *testing.T) {
 				err: errors.Wrap(errBoom, errUpdateVersionFailed),
 			},
 		},
+		"FailedRemoveTags": {
+			args: args{
+				eks: &fake.MockClient{
+					MockDescribeClusterRequest: func(input *awseks.DescribeClusterInput) awseks.DescribeClusterRequest {
+						return awseks.DescribeClusterRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.DescribeClusterOutput{
+								Cluster: &awseks.Cluster{
+									Tags: map[string]string{"foo": "bar"},
+								},
+							}},
+						}
+					},
+					MockUntagResourceRequest: func(input *awseks.UntagResourceInput) awseks.UntagResourceRequest {
+						return awseks.UntagResourceRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Error: errBoom},
+						}
+					},
+				},
+				cr: cluster(),
+			},
+			want: want{
+				cr:  cluster(),
+				err: errors.Wrap(errBoom, errAddTagsFailed),
+			},
+		},
 		"FailedAddTags": {
 			args: args{
 				eks: &fake.MockClient{
@@ -690,11 +785,6 @@ func TestUpdate(t *testing.T) {
 							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.DescribeClusterOutput{
 								Cluster: &awseks.Cluster{},
 							}},
-						}
-					},
-					MockUpdateClusterConfigRequest: func(input *awseks.UpdateClusterConfigInput) awseks.UpdateClusterConfigRequest {
-						return awseks.UpdateClusterConfigRequest{
-							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awseks.UpdateClusterConfigOutput{}},
 						}
 					},
 					MockTagResourceRequest: func(input *awseks.TagResourceInput) awseks.TagResourceRequest {


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

The AWS SDK has separate methods for adding and removing tags from an
EKS cluster. This updates the update method of its controller to make
separate calls for adding and removing tags.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #276 #251 

cc @janwillies 

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-aws/blob/master/config/package/manifests/app.yaml
