### PR TITLE
security group: remove the default egress and fix comparison issue

### DIFF
--- a/pkg/clients/ec2/fake/securitygroup.go
+++ b/pkg/clients/ec2/fake/securitygroup.go
@@ -32,6 +32,7 @@ type MockSecurityGroupClient struct {
 	MockDescribe        func(*ec2.DescribeSecurityGroupsInput) ec2.DescribeSecurityGroupsRequest
 	MockAuthorizeIgress func(*ec2.AuthorizeSecurityGroupIngressInput) ec2.AuthorizeSecurityGroupIngressRequest
 	MockAuthorizeEgress func(*ec2.AuthorizeSecurityGroupEgressInput) ec2.AuthorizeSecurityGroupEgressRequest
+	MockRevokeEgress    func(*ec2.RevokeSecurityGroupEgressInput) ec2.RevokeSecurityGroupEgressRequest
 	MockCreateTags      func(*ec2.CreateTagsInput) ec2.CreateTagsRequest
 }
 
@@ -58,6 +59,11 @@ func (m *MockSecurityGroupClient) AuthorizeSecurityGroupIngressRequest(input *ec
 // AuthorizeSecurityGroupEgressRequest mocks AuthorizeSecurityGroupEgressRequest method
 func (m *MockSecurityGroupClient) AuthorizeSecurityGroupEgressRequest(input *ec2.AuthorizeSecurityGroupEgressInput) ec2.AuthorizeSecurityGroupEgressRequest {
 	return m.MockAuthorizeEgress(input)
+}
+
+// RevokeSecurityGroupEgressRequest mocks RevokeSecurityGroupEgressRequest method
+func (m *MockSecurityGroupClient) RevokeSecurityGroupEgressRequest(input *ec2.RevokeSecurityGroupEgressInput) ec2.RevokeSecurityGroupEgressRequest {
+	return m.MockRevokeEgress(input)
 }
 
 // CreateTagsRequest mocks CreateTagsInput method


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

`SecurityGroup` creates an inital egress rule and if user's egress rule corresponds to this existing one, no change is propagated such as description so it always returned that the resource is not up-to-date. Additionally, `-1` value for `fromPort` and `toPort` is special for AWS and they return `nil` for values of those fields if you had submitted `-1` and that'd cause not up-to-date error since spec has `-1` but observed value seems to be `nil`.

Manually tested.

Fixes #296 
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-aws/blob/master/config/package/manifests/app.yaml
