### PR TITLE
fix: add missing region field for providerconfig v1beta1

### DIFF
--- a/apis/v1beta1/providerconfig_types.go
+++ b/apis/v1beta1/providerconfig_types.go
@@ -26,6 +26,9 @@ import (
 type ProviderConfigSpec struct {
 	runtimev1alpha1.ProviderConfigSpec `json:",inline"`
 
+	// Region for managed resources created using this AWS provider.
+	Region string `json:"region"`
+
 	// UseServiceAccount indicates to use an IAM Role associated Kubernetes
 	// ServiceAccount for authentication instead of a credentials Secret.
 	// https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html

--- a/config/crd/aws.crossplane.io_providerconfigs.yaml
+++ b/config/crd/aws.crossplane.io_providerconfigs.yaml
@@ -66,12 +66,17 @@ spec:
               - name
               - namespace
               type: object
+            region:
+              description: Region for managed resources created using this AWS provider.
+              type: string
             useServiceAccount:
               description: "UseServiceAccount indicates to use an IAM Role associated
                 Kubernetes ServiceAccount for authentication instead of a credentials
                 Secret. https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
                 \n If set to true, credentialsSecretRef will be ignored."
               type: boolean
+          required:
+          - region
           type: object
       required:
       - spec

--- a/examples/aws-setup-provider/provider.yaml
+++ b/examples/aws-setup-provider/provider.yaml
@@ -13,6 +13,7 @@ kind: ProviderConfig
 metadata:
   name: example
 spec:
+  region: ((AWS_REGION))
   credentialsSecretRef:
     namespace: crossplane-system
     name: aws-account-creds

--- a/pkg/clients/aws.go
+++ b/pkg/clients/aws.go
@@ -70,6 +70,9 @@ func GetConfig(ctx context.Context, kube client.Client, cr resource.Managed, reg
 		if err := kube.Get(ctx, nn, pc); resource.IgnoreNotFound(err) != nil {
 			return nil, errors.Wrap(err, "cannot get referenced ProviderConfig")
 		}
+		if region == "" {
+			region = pc.Spec.Region
+		}
 	case cr.GetProviderReference() != nil && cr.GetProviderReference().Name != "":
 		nn := types.NamespacedName{Name: cr.GetProviderReference().Name}
 		p := &v1alpha3.Provider{}


### PR DESCRIPTION
Signed-off-by: Noel Georgi <git@frezbo.com>

### Description of your changes
add missing region field for providerconfig v1beta1

FIxes:

```bash
2020-09-10T16:02:42.981+0530	DEBUG	provider-aws	Cannot create external resource	{"controller": "managed/vpc.ec2.aws.crossplane.io", "request": "/frezbo-vpc", "uid": "1c03a87b-de4c-40d6-a9aa-8e0ddab5b29b", "version": "1363", "external-name": "", "error": "failed to create the VPC resource: unknown endpoint, could not resolve endpoint, partition: \"aws\", service: \"ec2\", region: \"\", known: [ap-northeast-2 ap-southeast-1 fips-us-west-1 us-east-1 ap-northeast-1 ap-southeast-2 ca-central-1 eu-south-1 eu-west-2 eu-west-3 fips-us-west-2 af-south-1 ap-south-1 eu-central-1 eu-north-1 fips-us-east-2 ap-east-1 eu-west-1 fips-ca-central-1 fips-us-east-1 me-south-1 sa-east-1 us-east-2 us-west-1 us-west-2]", "errorVerbose": "unknown endpoint, could not resolve endpoint, partition: \"aws\", service: \"ec2\", region: \"\", known: [ap-northeast-2 ap-southeast-1 fips-us-west-1 us-east-1 ap-northeast-1 ap-southeast-2 ca-central-1 eu-south-1 eu-west-2 eu-west-3 fips-us-west-2 af-south-1 ap-south-1 eu-central-1 eu-north-1 fips-us-east-2 ap-east-1 eu-west-1 fips-ca-central-1 fips-us-east-1 me-south-1 sa-east-1 us-east-2 us-west-1 us-west-2]\nfailed to create the VPC resource\ngithub.com/crossplane/provider-aws/pkg/controller/ec2/vpc.(*external).Create\n\t/Users/ngeorgi/work/golang/src/github.com/crossplane/provider-aws/pkg/controller/ec2/vpc/controller.go:181\ngithub.com/crossplane/crossplane-runtime/pkg/reconciler/managed.(*Reconciler).Reconcile\n\t/Users/ngeorgi/work/golang/src/github.com/crossplane/provider-aws/.work/pkg/pkg/mod/github.com/crossplane/crossplane-runtime@v0.9.1-0.20200827134951-29150890d4c1/pkg/reconciler/managed/reconciler.go:620\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/Users/ngeorgi/work/golang/src/github.com/crossplane/provider-aws/.work/pkg/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:256\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/Users/ngeorgi/work/golang/src/github.com/crossplane/provider-aws/.work/pkg/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/Users/ngeorgi/work/golang/src/github.com/crossplane/provider-aws/.work/pkg/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/Users/ngeorgi/work/golang/src/github.com/crossplane/provider-aws/.work/pkg/pkg/mod/k8s.io/apimachinery@v0.18.2/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/Users/ngeorgi/work/golang/src/github.com/crossplane/provider-aws/.work/pkg/pkg/mod/k8s.io/apimachinery@v0.18.2/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/Users/ngeorgi/work/golang/src/github.com/crossplane/provider-aws/.work/pkg/pkg/mod/k8s.io/apimachinery@v0.18.2/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/Users/ngeorgi/work/golang/src/github.com/crossplane/provider-aws/.work/pkg/pkg/mod/k8s.io/apimachinery@v0.18.2/pkg/util/wait/wait.go:90\nruntime.goexit\n\t/usr/local/Cellar/go/1.15.1/libexec/src/runtime/asm_amd64.s:1374", "requeue-after": "2020-09-10T16:03:12.981+0530"}
2020-09-10T16:02:42.982+0530	DEBUG	controller-runtime.manager.events	Warning	{"object": {"kind":"VPC","name":"frezbo-vpc","uid":"1c03a87b-de4c-40d6-a9aa-8e0ddab5b29b","apiVersion":"ec2.aws.crossplane.io/v1beta1","resourceVersion":"1385"}, "reason": "CannotCreateExternalResource", "message": "failed to create the VPC resource: unknown endpoint, could not resolve endpoint, partition: \"aws\", service: \"ec2\", region: \"\", known: [ap-northeast-2 ap-southeast-1 fips-us-west-1 us-east-1 ap-northeast-1 ap-southeast-2 ca-central-1 eu-south-1 eu-west-2 eu-west-3 fips-us-west-2 af-south-1 ap-south-1 eu-central-1 eu-north-1 fips-us-east-2 ap-east-1 eu-west-1 fips-ca-central-1 fips-us-east-1 me-south-1 sa-east-1 us-east-2 us-west-1 us-west-2]"}
2020-09-10T16:02:42.991+0530	DEBUG	provider-aws	Reconciling	{"controller": "managed/vpc.ec2.aws.crossplane.io", "request": "/frezbo-vpc"}
```

I have:
- [ x ] Run `make reviewable` to ensure this PR is ready for review.
- [ x ] Ensured this PR contains a neat, self documenting set of commits.
- [ x ] Updated any relevant [documentation], [examples], or [release notes].
- [ x ] Updated the dependencies in [`app.yaml`] to include any new role permissions.
