### PR TITLE
fixes #332 subnet reconciliatiion

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,7 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/crossplane/crossplane v0.11.0 h1:uye4oDt8Pz7JoGBI0qtPuUHENDxLu0LIxhX+gyTUySM=
 github.com/crossplane/crossplane v0.11.0/go.mod h1:+AH83k737iABb8jUKyo8zML73JZZioeybuShGyAtbkg=
 github.com/crossplane/crossplane-runtime v0.7.1-0.20200421211018-be37c50cc2ab/go.mod h1:e12p4X6dbtqd9GOnph78Epd6aezyvmcMM1+6aQy3VzY=
+github.com/crossplane/crossplane-runtime v0.9.0 h1:K6/tLhXKzhsEUUddTvEWWnQLLrawWyw1ptNK7NBDpDU=
 github.com/crossplane/crossplane-runtime v0.9.0/go.mod h1:gNY/21MLBaz5KNP7hmfXbBXp8reYRbwY5B/97Kp4tgM=
 github.com/crossplane/crossplane-runtime v0.9.1-0.20200827134951-29150890d4c1 h1:WLHvlKo69ii3ezcCEXK0XVHZRoBMQex2ylQEcCUmxO4=
 github.com/crossplane/crossplane-runtime v0.9.1-0.20200827134951-29150890d4c1/go.mod h1:gNY/21MLBaz5KNP7hmfXbBXp8reYRbwY5B/97Kp4tgM=

--- a/pkg/controller/ec2/subnet/controller.go
+++ b/pkg/controller/ec2/subnet/controller.go
@@ -107,9 +107,9 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 		// either of AvailabilityZone or AvailabilityZoneID needs to be set
 		if cr.Spec.ForProvider.AvailabilityZone != nil && cr.Spec.ForProvider.AvailabilityZoneID != nil {
 			cr.Spec.ForProvider.AvailabilityZoneID = nil
-		}
-		if err := e.kube.Update(ctx, cr); err != nil {
-			return managed.ExternalObservation{}, errors.Wrap(err, errKubeUpdateFailed)
+			if err := e.kube.Update(ctx, cr); err != nil {
+				return managed.ExternalObservation{}, errors.Wrap(err, errKubeUpdateFailed)
+			}
 		}
 		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(ec2.IsSubnetNotFoundErr, err), errDescribe)
 	}


### PR DESCRIPTION
Signed-off-by: Noel Georgi <git@frezbo.com>


### Description of your changes

When the subnet resource has been externally deleted, the current CR fields has `availabilityZone` and `availabilityZoneID` set. To work around the issue of not passing in both fields `availabilityZoneID` is updated to `nil`

Fixes #332 
-->

### Checklist
I have:
- [ x ] Run `make reviewable` to ensure this PR is ready for review.
- [ x ] Ensured this PR contains a neat, self documenting set of commits.
- [ x ] Updated any relevant [documentation], [examples], or [release notes].
- [ x ] Updated the dependencies in [`app.yaml`] to include any new role permissions.