### PR TITLE
Adds the ARN to the AtProvider for the SNS Topic

### DIFF
--- a/apis/notification/v1alpha1/snstopic_types.go
+++ b/apis/notification/v1alpha1/snstopic_types.go
@@ -22,7 +22,7 @@ import (
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 )
 
-// Tag represetnt a user-provided metadata that can be associated with a
+// Tag represent a user-provided metadata that can be associated with a
 // SNS Topic. For more information about tagging,
 // see Tagging SNS Topics (https://docs.aws.amazon.com/sns/latest/dg/sns-tags.html)
 // in the SNS User Guide.
@@ -108,6 +108,9 @@ type SNSTopicObservation struct {
 	// DeletedSubscriptions - The no of deleted subscriptions
 	// +optional
 	DeletedSubscriptions *int64 `json:"deletedSubscriptions,omitempty"`
+
+	// ARN is the Amazon Resource Name (ARN) specifying the SNS Topic.
+	ARN string `json:"arn"`
 }
 
 // SNSTopicStatus is the status of AWS SNS Topic

--- a/config/crd/notification.aws.crossplane.io_snstopics.yaml
+++ b/config/crd/notification.aws.crossplane.io_snstopics.yaml
@@ -82,7 +82,7 @@ spec:
                 tags:
                   description: Tags represetnt a list of user-provided metadata that can be associated with a SNS Topic. For more information about tagging, see Tagging SNS Topics (https://docs.aws.amazon.com/sns/latest/dg/sns-tags.html) in the SNS User Guide.
                   items:
-                    description: Tag represetnt a user-provided metadata that can be associated with a SNS Topic. For more information about tagging, see Tagging SNS Topics (https://docs.aws.amazon.com/sns/latest/dg/sns-tags.html) in the SNS User Guide.
+                    description: Tag represent a user-provided metadata that can be associated with a SNS Topic. For more information about tagging, see Tagging SNS Topics (https://docs.aws.amazon.com/sns/latest/dg/sns-tags.html) in the SNS User Guide.
                     properties:
                       key:
                         description: The key name that can be used to look up or retrieve the associated value. For example, Department or Cost Center are common choices.
@@ -138,6 +138,9 @@ spec:
             atProvider:
               description: SNSTopicObservation represents the observed state of a AWS SNS Topic
               properties:
+                arn:
+                  description: ARN is the Amazon Resource Name (ARN) specifying the SNS Topic.
+                  type: string
                 confirmedSubscriptions:
                   description: ConfirmedSubscriptions - The no of confirmed subscriptions
                   format: int64
@@ -153,6 +156,8 @@ spec:
                   description: PendingSubscriptions - The no of pending subscriptions
                   format: int64
                   type: integer
+              required:
+              - arn
               type: object
             conditions:
               description: Conditions of the resource.

--- a/pkg/clients/sns/snstopic.go
+++ b/pkg/clients/sns/snstopic.go
@@ -48,6 +48,8 @@ const (
 	TopicSubscriptionsPending TopicAttributes = "SubscriptionsPending"
 	// TopicSubscriptionsDeleted is status of SNS Topic Subscription Confirmation
 	TopicSubscriptionsDeleted TopicAttributes = "SubscriptionsDeleted"
+	// TopicARN is the ARN for the SNS Topic
+	TopicARN TopicAttributes = "TopicARN"
 )
 
 // TopicClient is the external client used for AWS SNSTopic
@@ -127,6 +129,8 @@ func GenerateTopicObservation(attr map[string]string) v1alpha1.SNSTopicObservati
 	if s, err := strconv.ParseInt(attr[string(TopicSubscriptionsDeleted)], 10, 64); err == nil {
 		o.DeletedSubscriptions = aws.Int64(s)
 	}
+
+	o.ARN = attr[string(TopicARN)]
 
 	return o
 }

--- a/pkg/clients/sns/snstopic_test.go
+++ b/pkg/clients/sns/snstopic_test.go
@@ -61,6 +61,12 @@ func withOwner(s *string) topicAttrModifier {
 	}
 }
 
+func withARN(s *string) topicAttrModifier {
+	return func(attr *map[string]string) {
+		(*attr)[string(TopicARN)] = *s
+	}
+}
+
 func withTopicSubs(confirmed, pending, deleted string) topicAttrModifier {
 	return func(attr *map[string]string) {
 		a := *attr
@@ -94,6 +100,13 @@ func withObservationOwner(s *string) topicObservationModifier {
 		o.Owner = s
 	}
 }
+
+func withObservationARN(s string) topicObservationModifier {
+	return func(o *v1alpha1.SNSTopicObservation) {
+		o.ARN = s
+	}
+}
+
 func withObservationSubs(confirmed, pending, deleted string) topicObservationModifier {
 	return func(o *v1alpha1.SNSTopicObservation) {
 		if s, err := strconv.ParseInt(confirmed, 10, 64); err == nil {
@@ -219,24 +232,29 @@ func TestGenerateTopicObservation(t *testing.T) {
 			in: topicAttributes(
 				withOwner(&subOwner),
 				withTopicSubs(confirmedSubs, pendingSubs, deletedSubs),
+				withARN(&topicArn),
 			),
 			out: topicObservation(
 				withObservationOwner(&subOwner),
 				withObservationSubs(confirmedSubs, pendingSubs, deletedSubs),
+				withObservationARN(topicArn),
 			),
 		},
 		"NoSubscriptions": {
 			in: topicAttributes(
 				withOwner(&subOwner),
+				withARN(&topicArn),
 			),
 			out: topicObservation(
 				withObservationOwner(&subOwner),
+				withObservationARN(topicArn),
 			),
 		},
 		"Empty": {
 			in: topicAttributes(),
 			out: topicObservation(
 				withObservationOwner(&empty),
+				withObservationARN(empty),
 			),
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #347 

This PR just adds a field in the SNS Topic to store the ARN. The main reason this is important is so that when other functions require the ARN string, they can simply access the value in the status as opposed to querying the API.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] Ensured this PR contains a neat, self documenting set of commits.
- [X] Updated any relevant [documentation], [examples], or [release notes].
- [X] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplane/crossplane/tree/master/docs
[examples]: https://github.com/crossplane/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplane/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplane/provider-aws/blob/master/config/package/manifests/app.yaml
