### PR TITLE
Build provider package with static content

### DIFF
--- a/cluster/images/provider-aws/Dockerfile
+++ b/cluster/images/provider-aws/Dockerfile
@@ -1,3 +1,3 @@
 FROM BASEIMAGE
 
-COPY package .
+COPY package.yaml .

--- a/cluster/images/provider-aws/Makefile
+++ b/cluster/images/provider-aws/Makefile
@@ -7,7 +7,7 @@ include ../../../build/makelib/common.mk
 # ====================================================================================
 #  Options
 IMAGE = $(BUILD_REGISTRY)/provider-aws-$(ARCH)
-OSBASEIMAGE = crossplane/pkg-unpack:master
+OSBASEIMAGE = scratch
 include ../../../build/makelib/image.mk
 
 # ====================================================================================
@@ -19,6 +19,7 @@ img.build:
 	@cp -R ../../../package $(IMAGE_TEMP_DIR) || $(FAIL)
 	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|BASEIMAGE|$(OSBASEIMAGE)|g' Dockerfile || $(FAIL)
 	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|VERSION|$(VERSION)|g' package/crossplane.yaml || $(FAIL)
+	@cd $(IMAGE_TEMP_DIR) && find package -type f -name '*.yaml' -exec cat {} >> 'package.yaml' \; -exec printf '\n---\n' \; || $(FAIL)
 	@docker build $(BUILD_ARGS) \
 		--build-arg ARCH=$(ARCH) \
 		--build-arg TINI_VERSION=$(TINI_VERSION) \


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


Updates the provider package image to only include a single static
package.yaml file that can be parsed by the package manager.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Draft until https://github.com/crossplane/crossplane/pull/1795 is merged, which is required for integration tests to pass. Integration tests will also have to be updated to support loading the package image into the cache dir due to the fact that the package manager will no longer be able to pull from local docker (for the package image, loading into kind will still work for provider controller). This process

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Integration tests demonstrate the functionality we are testing here, see https://github.com/crossplane/crossplane/pull/1807 for more info.

[contribution process]: https://git.io/fj2m9
