### PR TITLE
Adopt AWS SDK behavior for resource record array

### DIFF
--- a/pkg/clients/resourcerecordset/resourcerecordset.go
+++ b/pkg/clients/resourcerecordset/resourcerecordset.go
@@ -104,11 +104,10 @@ func GenerateChangeResourceRecordSetsInput(name string, p v1alpha1.ResourceRecor
 		Region:                  route53.ResourceRecordSetRegion(p.Region),
 		TrafficPolicyInstanceId: p.TrafficPolicyInstanceID,
 	}
-	r.ResourceRecords = make([]route53.ResourceRecord, len(p.ResourceRecords))
-	for i, v := range p.ResourceRecords {
-		r.ResourceRecords[i] = route53.ResourceRecord{
+	for _, v := range p.ResourceRecords {
+		r.ResourceRecords = append(r.ResourceRecords, route53.ResourceRecord{
 			Value: aws.String(v.Value),
-		}
+		})
 	}
 	if p.AliasTarget != nil {
 		r.AliasTarget = &route53.AliasTarget{


### PR DESCRIPTION
## Description of your changes

@skmcgrail [informed](https://github.com/aws/aws-sdk-go-v2/issues/803#issuecomment-706436385) that the array here is expected to be `nil` if it's empty. The issue doesn't exist in the newer versions of AWS SDK but until we update to the new versions, this fix is necessary.

Fixes https://github.com/crossplane/provider-aws/issues/372
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually tested with an alias target.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
