### PR TITLE
s3: subresources that cannot be deleted should not have deletion implemented

### DIFF
--- a/examples/s3/bucket.yaml
+++ b/examples/s3/bucket.yaml
@@ -6,5 +6,13 @@ spec:
   forProvider:
     locationConstraint: us-west-2
     acl: private
+    accelerateConfiguration:
+      status: Enabled
+    versioningConfiguration:
+      status: Enabled
+    tagging:
+      tagSet:
+        - key: key1
+          value: val1
   providerConfigRef:
     name: example

--- a/pkg/controller/s3/bucket.go
+++ b/pkg/controller/s3/bucket.go
@@ -101,7 +101,6 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	cr.Status.AtProvider = s3.GenerateBucketObservation(meta.GetExternalName(cr))
 
 	current := cr.Spec.ForProvider.DeepCopy()
-
 	for _, awsClient := range e.subresourceClients {
 		err := awsClient.LateInitialize(ctx, cr)
 		if err != nil {

--- a/pkg/controller/s3/bucket/CORSConfig.go
+++ b/pkg/controller/s3/bucket/CORSConfig.go
@@ -40,11 +40,9 @@ type CORSConfigurationClient struct {
 	client s3.BucketClient
 }
 
-// LateInitialize is responsible for initializing the resource based on the external value
-func (in *CORSConfigurationClient) LateInitialize(ctx context.Context, bucket *v1beta1.Bucket) error {
-	// GetBucketCorsRequest throws an error if nothing exists externally
-	// Future work can be done to support brownfield initialization for the CORSConfig
-	// TODO
+// LateInitialize does nothing because CORSConfiguration might have been be
+// deleted by the user.
+func (*CORSConfigurationClient) LateInitialize(_ context.Context, _ *v1beta1.Bucket) error {
 	return nil
 }
 

--- a/pkg/controller/s3/bucket/CORSConfig.go
+++ b/pkg/controller/s3/bucket/CORSConfig.go
@@ -40,8 +40,8 @@ type CORSConfigurationClient struct {
 	client s3.BucketClient
 }
 
-// LateInitialize does nothing because CORSConfiguration might have been be
-// deleted by the user.
+// LateInitialize does nothing because CORSConfiguration might have been deleted
+// by the user.
 func (*CORSConfigurationClient) LateInitialize(_ context.Context, _ *v1beta1.Bucket) error {
 	return nil
 }

--- a/pkg/controller/s3/bucket/accelerateConfig.go
+++ b/pkg/controller/s3/bucket/accelerateConfig.go
@@ -97,6 +97,6 @@ func (in *AccelerateConfigurationClient) CreateOrUpdate(ctx context.Context, buc
 }
 
 // Delete does not do anything since AccelerateConfiguration doesn't have Delete call.
-func (in *AccelerateConfigurationClient) Delete(_ context.Context, _ *v1beta1.Bucket) error {
+func (*AccelerateConfigurationClient) Delete(_ context.Context, _ *v1beta1.Bucket) error {
 	return nil
 }

--- a/pkg/controller/s3/bucket/lifecycleConfig.go
+++ b/pkg/controller/s3/bucket/lifecycleConfig.go
@@ -41,11 +41,9 @@ type LifecycleConfigurationClient struct {
 	client s3.BucketClient
 }
 
-// LateInitialize is responsible for initializing the resource based on the external value
-func (in *LifecycleConfigurationClient) LateInitialize(ctx context.Context, bucket *v1beta1.Bucket) error {
-	// GetBucketLifecycleConfigurationRequest throws an error if nothing exists externally
-	// Future work can be done to support brownfield initialization for the LifecycleConfiguration
-	// TODO
+// LateInitialize does nothing because LifecycleConfiguration might have been be
+// deleted by the user.
+func (*LifecycleConfigurationClient) LateInitialize(_ context.Context, _ *v1beta1.Bucket) error {
 	return nil
 }
 

--- a/pkg/controller/s3/bucket/loggingConfig.go
+++ b/pkg/controller/s3/bucket/loggingConfig.go
@@ -164,6 +164,6 @@ func (in *LoggingConfigurationClient) CreateOrUpdate(ctx context.Context, bucket
 }
 
 // Delete does nothing because there is no deletion call for logging config.
-func (in *LoggingConfigurationClient) Delete(_ context.Context, _ *v1beta1.Bucket) error {
+func (*LoggingConfigurationClient) Delete(_ context.Context, _ *v1beta1.Bucket) error {
 	return nil
 }

--- a/pkg/controller/s3/bucket/loggingConfig.go
+++ b/pkg/controller/s3/bucket/loggingConfig.go
@@ -19,6 +19,9 @@ package bucket
 import (
 	"context"
 
+	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/google/go-cmp/cmp"
@@ -30,9 +33,8 @@ import (
 )
 
 const (
-	loggingGetFailed    = "cannot get Bucket logging configuration"
-	loggingPutFailed    = "cannot put Bucket logging configuration"
-	loggingDeleteFailed = "cannot delete Bucket logging configuration"
+	loggingGetFailed = "cannot get Bucket logging configuration"
+	loggingPutFailed = "cannot put Bucket logging configuration"
 )
 
 // LoggingConfigurationClient is the client for API methods and reconciling the LoggingConfiguration
@@ -86,6 +88,9 @@ func NewLoggingConfigurationClient(client s3.BucketClient) *LoggingConfiguration
 
 // GenerateAWSLogging creates an S3 logging enabled struct from the local logging configuration
 func GenerateAWSLogging(local *v1beta1.LoggingConfiguration) *awss3.LoggingEnabled {
+	if local == nil {
+		return nil
+	}
 	output := awss3.LoggingEnabled{
 		TargetBucket: local.TargetBucket,
 		TargetPrefix: local.TargetPrefix,
@@ -116,18 +121,11 @@ func (in *LoggingConfigurationClient) Observe(ctx context.Context, bucket *v1bet
 	if err != nil {
 		return NeedsUpdate, errors.Wrap(err, loggingGetFailed)
 	}
-	config := bucket.Spec.ForProvider.LoggingConfiguration
-
-	switch {
-	case external.LoggingEnabled == nil && config == nil:
-		return Updated, nil
-	case external.LoggingEnabled != nil && config == nil:
-		return NeedsDeletion, nil
-	case cmp.Equal(GenerateAWSLogging(config), external.LoggingEnabled):
-		return Updated, nil
-	default:
+	if !cmp.Equal(GenerateAWSLogging(bucket.Spec.ForProvider.LoggingConfiguration), external.LoggingEnabled,
+		cmpopts.IgnoreTypes(&v1alpha1.Reference{}, &v1alpha1.Selector{})) {
 		return NeedsUpdate, nil
 	}
+	return Updated, nil
 }
 
 // GeneratePutBucketLoggingInput creates the input for the PutBucketLogging request for the S3 Client
@@ -165,12 +163,7 @@ func (in *LoggingConfigurationClient) CreateOrUpdate(ctx context.Context, bucket
 	return errors.Wrap(err, loggingPutFailed)
 }
 
-// Delete creates the request to delete the resource on AWS or set it to the default value.
-func (in *LoggingConfigurationClient) Delete(ctx context.Context, bucket *v1beta1.Bucket) error {
-	input := &awss3.PutBucketLoggingInput{
-		Bucket:              aws.String(meta.GetExternalName(bucket)),
-		BucketLoggingStatus: &awss3.BucketLoggingStatus{}, //  Empty BucketLoggingStatus disables logging
-	}
-	_, err := in.client.PutBucketLoggingRequest(input).Send(ctx)
-	return errors.Wrap(err, loggingDeleteFailed)
+// Delete does nothing because there is no deletion call for logging config.
+func (in *LoggingConfigurationClient) Delete(_ context.Context, _ *v1beta1.Bucket) error {
+	return nil
 }

--- a/pkg/controller/s3/bucket/notificationConfig.go
+++ b/pkg/controller/s3/bucket/notificationConfig.go
@@ -30,9 +30,8 @@ import (
 )
 
 const (
-	notificationGetFailed    = "cannot get Bucket notification"
-	notificationPutFailed    = "cannot put Bucket notification"
-	notificationDeleteFailed = "cannot delete Bucket notification"
+	notificationGetFailed = "cannot get Bucket notification"
+	notificationPutFailed = "cannot put Bucket notification"
 )
 
 // NotificationConfigurationClient is the client for API methods and reconciling the LifecycleConfiguration
@@ -344,6 +343,6 @@ func (in *NotificationConfigurationClient) CreateOrUpdate(ctx context.Context, b
 }
 
 // Delete does nothing because there is no corresponding deletion call in AWS.
-func (in *NotificationConfigurationClient) Delete(_ context.Context, _ *v1beta1.Bucket) error {
+func (*NotificationConfigurationClient) Delete(_ context.Context, _ *v1beta1.Bucket) error {
 	return nil
 }

--- a/pkg/controller/s3/bucket/notificationConfig.go
+++ b/pkg/controller/s3/bucket/notificationConfig.go
@@ -343,12 +343,7 @@ func (in *NotificationConfigurationClient) CreateOrUpdate(ctx context.Context, b
 	return errors.Wrap(err, notificationPutFailed)
 }
 
-// Delete creates the request to delete the resource on AWS or set it to the default value.
-func (in *NotificationConfigurationClient) Delete(ctx context.Context, bucket *v1beta1.Bucket) error {
-	input := &awss3.PutBucketNotificationConfigurationInput{
-		Bucket:                    aws.String(meta.GetExternalName(bucket)),
-		NotificationConfiguration: &awss3.NotificationConfiguration{},
-	}
-	_, err := in.client.PutBucketNotificationConfigurationRequest(input).Send(ctx)
-	return errors.Wrap(err, notificationDeleteFailed)
+// Delete does nothing because there is no corresponding deletion call in AWS.
+func (in *NotificationConfigurationClient) Delete(_ context.Context, _ *v1beta1.Bucket) error {
+	return nil
 }

--- a/pkg/controller/s3/bucket/replicationConfig.go
+++ b/pkg/controller/s3/bucket/replicationConfig.go
@@ -40,11 +40,9 @@ type ReplicationConfigurationClient struct {
 	client s3.BucketClient
 }
 
-// LateInitialize is responsible for initializing the resource based on the external value
-func (in *ReplicationConfigurationClient) LateInitialize(ctx context.Context, bucket *v1beta1.Bucket) error {
-	// GetBucketReplicationRequest throws an error if nothing exists externally
-	// Future work can be done to support brownfield initialization for the ReplicationConfiguration
-	// TODO
+// LateInitialize does nothing because the resource might have been deleted by
+// the user.
+func (*ReplicationConfigurationClient) LateInitialize(_ context.Context, _ *v1beta1.Bucket) error {
 	return nil
 }
 

--- a/pkg/controller/s3/bucket/requestPaymentConfig.go
+++ b/pkg/controller/s3/bucket/requestPaymentConfig.go
@@ -101,9 +101,7 @@ func (in *RequestPaymentConfigurationClient) CreateOrUpdate(ctx context.Context,
 	return errors.Wrap(err, paymentPutFailed)
 }
 
-// Delete creates the request to delete the resource on AWS or set it to the default value.
-func (in *RequestPaymentConfigurationClient) Delete(ctx context.Context, bucket *v1beta1.Bucket) error {
-	// There is no delete operation for the S3Bucket Payer
-	// The value must be BucketOwner or Requester
+// Delete does nothing since there is no corresponding deletion call in AWS.
+func (*RequestPaymentConfigurationClient) Delete(_ context.Context, _ *v1beta1.Bucket) error {
 	return nil
 }

--- a/pkg/controller/s3/bucket/sseConfig.go
+++ b/pkg/controller/s3/bucket/sseConfig.go
@@ -39,11 +39,9 @@ type SSEConfigurationClient struct {
 	client s3.BucketClient
 }
 
-// LateInitialize is responsible for initializing the resource based on the external value
-func (in *SSEConfigurationClient) LateInitialize(ctx context.Context, bucket *v1beta1.Bucket) error {
-	// GetBucketEncryptionRequest throws an error if nothing exists externally
-	// Future work can be done to support brownfield initialization for the SSEConfiguration
-	// TODO
+// LateInitialize does nothing because the resource might have been deleted by
+// the user.
+func (*SSEConfigurationClient) LateInitialize(_ context.Context, _ *v1beta1.Bucket) error {
 	return nil
 }
 

--- a/pkg/controller/s3/bucket/taggingConfig.go
+++ b/pkg/controller/s3/bucket/taggingConfig.go
@@ -24,6 +24,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
 	aws "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/s3"
@@ -59,7 +61,7 @@ func (in *TaggingConfigurationClient) Observe(ctx context.Context, bucket *v1bet
 		if s3.TaggingNotFound(err) && config == nil {
 			return Updated, nil
 		}
-		return NeedsUpdate, errors.Wrap(err, taggingGetFailed)
+		return NeedsUpdate, errors.Wrap(resource.Ignore(s3.TaggingNotFound, err), taggingGetFailed)
 	}
 
 	switch {

--- a/pkg/controller/s3/bucket/taggingConfig.go
+++ b/pkg/controller/s3/bucket/taggingConfig.go
@@ -40,11 +40,9 @@ type TaggingConfigurationClient struct {
 	client s3.BucketClient
 }
 
-// LateInitialize is responsible for initializing the resource based on the external value
-func (in *TaggingConfigurationClient) LateInitialize(ctx context.Context, bucket *v1beta1.Bucket) error {
-	// GetBucketTaggingRequest throws an error if nothing exists externally
-	// Future work can be done to support brownfield initialization for the TaggingConfiguration
-	// TODO
+// LateInitialize does nothing because the resource might have been deleted by
+// the user.
+func (*TaggingConfigurationClient) LateInitialize(_ context.Context, _ *v1beta1.Bucket) error {
 	return nil
 }
 

--- a/pkg/controller/s3/bucket/versioningConfig.go
+++ b/pkg/controller/s3/bucket/versioningConfig.go
@@ -53,12 +53,8 @@ func (in *VersioningConfigurationClient) LateInitialize(ctx context.Context, buc
 		bucket.Spec.ForProvider.VersioningConfiguration = &v1beta1.VersioningConfiguration{}
 		config = bucket.Spec.ForProvider.VersioningConfiguration
 	}
-	if len(external.Status) != 0 { // By default Status is the string ""
-		config.Status = aws.String(string(external.Status))
-	}
-	if len(external.MFADelete) != 0 { // By default MFADelete is the string ""
-		config.MFADelete = aws.String(string(external.MFADelete))
-	}
+	config.Status = aws.LateInitializeStringPtr(config.Status, aws.String(string(external.Status)))
+	config.MFADelete = aws.LateInitializeStringPtr(config.MFADelete, aws.String(string(external.MFADelete)))
 	return nil
 }
 

--- a/pkg/controller/s3/bucket/versioningConfig.go
+++ b/pkg/controller/s3/bucket/versioningConfig.go
@@ -29,9 +29,8 @@ import (
 )
 
 const (
-	versioningGetFailed    = "cannot get Bucket versioning configuration"
-	versioningPutFailed    = "cannot put Bucket versioning configuration"
-	versioningDeleteFailed = "cannot delete Bucket versioning configuration"
+	versioningGetFailed = "cannot get Bucket versioning configuration"
+	versioningPutFailed = "cannot put Bucket versioning configuration"
 )
 
 // VersioningConfigurationClient is the client for API methods and reconciling the VersioningConfiguration
@@ -74,17 +73,14 @@ func (in *VersioningConfigurationClient) Observe(ctx context.Context, bucket *v1
 	if err != nil {
 		return NeedsUpdate, errors.Wrap(err, versioningGetFailed)
 	}
-	config := bucket.Spec.ForProvider.VersioningConfiguration
-	switch {
-	case len(external.Status) == 0 && len(external.MFADelete) == 0 && config == nil:
+	if bucket.Spec.ForProvider.VersioningConfiguration == nil {
 		return Updated, nil
-	case (len(external.Status) != 0 || len(external.MFADelete) != 0) && config == nil:
-		return NeedsDeletion, nil
-	case aws.StringValue(config.Status) == string(external.Status) && aws.StringValue(config.MFADelete) == string(external.MFADelete):
-		return Updated, nil
-	default:
+	}
+	if string(external.Status) != aws.StringValue(bucket.Spec.ForProvider.VersioningConfiguration.Status) ||
+		string(external.MFADelete) != aws.StringValue(bucket.Spec.ForProvider.VersioningConfiguration.MFADelete) {
 		return NeedsUpdate, nil
 	}
+	return Updated, nil
 }
 
 // GeneratePutBucketVersioningInput creates the input for the PutBucketVersioning request for the S3 Client
@@ -108,15 +104,7 @@ func (in *VersioningConfigurationClient) CreateOrUpdate(ctx context.Context, buc
 	return errors.Wrap(err, versioningPutFailed)
 }
 
-// Delete creates the request to delete the resource on AWS or set it to the default value.
-func (in *VersioningConfigurationClient) Delete(ctx context.Context, bucket *v1beta1.Bucket) error {
-	input := &awss3.PutBucketVersioningInput{
-		Bucket: aws.String(meta.GetExternalName(bucket)),
-		VersioningConfiguration: &awss3.VersioningConfiguration{
-			Status:    awss3.BucketVersioningStatusSuspended,
-			MFADelete: awss3.MFADeleteDisabled,
-		},
-	}
-	_, err := in.client.PutBucketVersioningRequest(input).Send(ctx)
-	return errors.Wrap(err, versioningDeleteFailed)
+// Delete does nothing because there is no corresponding deletion call in AWS.
+func (*VersioningConfigurationClient) Delete(_ context.Context, _ *v1beta1.Bucket) error {
+	return nil
 }

--- a/pkg/controller/s3/bucket/websiteConfig.go
+++ b/pkg/controller/s3/bucket/websiteConfig.go
@@ -40,11 +40,9 @@ type WebsiteConfigurationClient struct {
 	client s3.BucketClient
 }
 
-// LateInitialize is responsible for initializing the resource based on the external value
-func (in *WebsiteConfigurationClient) LateInitialize(ctx context.Context, bucket *v1beta1.Bucket) error {
-	// GetBucketWebsiteRequest throws an error if nothing exists externally
-	// Future work can be done to support brownfield initialization for the WebsiteConfiguration
-	// TODO
+// LateInitialize does nothing because the resource might have been deleted by
+// the user.
+func (*WebsiteConfigurationClient) LateInitialize(_ context.Context, _ *v1beta1.Bucket) error {
 	return nil
 }
 


### PR DESCRIPTION
### Description of your changes

Removes the `Delete` implementations of S3 subresources that do not have corresponding deletion call and fixes some bugs related to versioning and tagging.

Fixes https://github.com/crossplane/provider-aws/issues/368
Fixes https://github.com/crossplane/provider-aws/issues/379

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually with `examples/s3/bucket.yaml`

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
