### PR TITLE
S3 Acceleration Parameter Optional

### DIFF
--- a/pkg/clients/s3/bucket.go
+++ b/pkg/clients/s3/bucket.go
@@ -43,6 +43,10 @@ var (
 	TaggingErrCode = "NoSuchTagSet"
 	// WebsiteErrCode is the error code sent by AWS when the website config does not exist
 	WebsiteErrCode = "NoSuchWebsiteConfiguration"
+	// MethodNotAllowed is the error code sent by AWS when the request method for an object is not allowed
+	MethodNotAllowed = "MethodNotAllowed"
+	// UnsupportedArgument is the error code sent by AWS when the request fields contain an argument that is not supported
+	UnsupportedArgument = "UnsupportedArgument"
 )
 
 // BucketClient is the interface for Client for making S3 Bucket requests.
@@ -192,6 +196,22 @@ func TaggingNotFound(err error) bool {
 // WebsiteConfigurationNotFound is parses the aws Error and validates if the website configuration does not exist
 func WebsiteConfigurationNotFound(err error) bool {
 	if s3Err, ok := err.(awserr.Error); ok && s3Err.Code() == WebsiteErrCode {
+		return true
+	}
+	return false
+}
+
+// MethodNotSupported is parses the aws Error and validates if the method is allowed for a request
+func MethodNotSupported(err error) bool {
+	if s3Err, ok := err.(awserr.Error); ok && s3Err.Code() == MethodNotAllowed {
+		return true
+	}
+	return false
+}
+
+// ArgumentNotSupported is parses the aws Error and validates if parameters are now allowed for a request
+func ArgumentNotSupported(err error) bool {
+	if s3Err, ok := err.(awserr.Error); ok && s3Err.Code() == UnsupportedArgument {
 		return true
 	}
 	return false


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Rig the `AccelerateConfigurationClient` such that it will not panic if the method or parameter is not allows for Acceleration Configuration similar to the Terraform Provider. This is necessary for some regions which does not have S3 acceleration support.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #388

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually tested with bucket creation in region `us-gov-west-1`.
s3.yaml
```
apiVersion: s3.aws.crossplane.io/v1beta1
kind: Bucket
metadata:
  name: crossplane-bucket
spec:
  forProvider:
    locationConstraint: us-gov-west-1
    acl: private
    versioningConfiguration:
      status: Enabled
  providerConfigRef:
    name: default
```
Output:
```
  Normal   CreatedExternalResource  5s                 managed/bucket.s3.aws.crossplane.io  Successfully requested creation of external resource
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
