### PR TITLE
routetable: do not issue status update before create 

### DIFF
--- a/pkg/controller/ec2/routetable/controller_test.go
+++ b/pkg/controller/ec2/routetable/controller_test.go
@@ -206,8 +206,7 @@ func TestCreate(t *testing.T) {
 			want: want{
 				cr: rt(withSpec(v1alpha4.RouteTableParameters{
 					VPCID: aws.String(vpcID),
-				}), withExternalName(rtID),
-					withConditions(runtimev1alpha1.Creating())),
+				}), withExternalName(rtID)),
 			},
 		},
 		"EmptyResult": {
@@ -230,7 +229,7 @@ func TestCreate(t *testing.T) {
 			want: want{
 				cr: rt(withSpec(v1alpha4.RouteTableParameters{
 					VPCID: aws.String(vpcID),
-				}), withExternalName(rtID), withConditions(runtimev1alpha1.Creating())),
+				}), withExternalName(rtID)),
 				err: errors.New(errCreate),
 			},
 		},
@@ -254,7 +253,7 @@ func TestCreate(t *testing.T) {
 			want: want{
 				cr: rt(withSpec(v1alpha4.RouteTableParameters{
 					VPCID: aws.String(vpcID),
-				}), withConditions(runtimev1alpha1.Creating())),
+				})),
 				err: errors.Wrap(errBoom, errCreate),
 			},
 		},


### PR DESCRIPTION
### Description of your changes

Because the object returned by the api-server may not be latest, hence, causing spec update to fail which in turn creates additional routetable whose track is lost.

Keep in mind that this should not happen as status update already updates the local `cr` variable. However, we see this happening in some environments.

The actual solution to this problem is to have `Create` operations whose result has to be saved to be atomic, i.e. if spec update didn't go through then delete the created external resource.

Fixes #392
Fixes https://github.com/crossplane/provider-aws/issues/210
Fixes https://github.com/upbound/platform-ref-aws/issues/3

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
