### PR TITLE
AWS Go SDK v1 connection method for ACK-generated resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/crossplane/provider-aws
 go 1.13
 
 require (
+	github.com/aws/aws-sdk-go v1.34.32
 	github.com/aws/aws-sdk-go-v2 v0.23.0
 	github.com/crossplane/crossplane-runtime v0.11.0
 	github.com/crossplane/crossplane-tools v0.0.0-20201007233256-88b291e145bb
@@ -12,7 +13,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/google/go-cmp v0.5.0
 	github.com/gopherjs/gopherjs v0.0.0-20180825215210-0210a2f0f73c // indirect
-	github.com/jmespath/go-jmespath v0.3.0 // indirect
 	github.com/jtolds/gls v4.2.1+incompatible // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mitchellh/copystructure v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.15.78 h1:LaXy6lWR0YK7LKyuU0QWy2ws/LWTPfYV/UgfiBu4tvY=
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
+github.com/aws/aws-sdk-go v1.34.32 h1:EHjowHEGXyLHWhcO7M7AVA+oA2c8aLE9WfRvqHwxd3A=
+github.com/aws/aws-sdk-go v1.34.32/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/aws/aws-sdk-go-v2 v0.23.0 h1:+E1q1LLSfHSDn/DzOtdJOX+pLZE2HiNV2yO5AjZINwM=
 github.com/aws/aws-sdk-go-v2 v0.23.0/go.mod h1:2LhT7UgHOXK3UXONKI5OMgIyoQL6zTAw/jwIeX6yqzw=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -268,8 +270,10 @@ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJS
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
-github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
-github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/pkg/clients/aws.go
+++ b/pkg/clients/aws.go
@@ -27,12 +27,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/crossplane/provider-aws/apis/v1beta1"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/external"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	awsv1 "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/go-ini/ini"
 	"github.com/pkg/errors"
@@ -44,6 +44,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplane/provider-aws/apis/v1alpha3"
+	"github.com/crossplane/provider-aws/apis/v1beta1"
 )
 
 // DefaultSection for INI files.
@@ -233,6 +234,71 @@ func UsePodServiceAccount(ctx context.Context, _ []byte, _, region string) (*aws
 	}
 	config, err := external.LoadDefaultAWSConfig(shared)
 	return &config, err
+}
+
+// NOTE(muvaf): ACK-generated controllers use aws/aws-sdk-go instead of
+// aws/aws-sdk-go-v2. These functions are implemented to be used by those controllers.
+
+// GetConfigV1 constructs an *awsv1.Config that can be used to authenticate to AWS
+// API by the AWSv1 clients.
+func GetConfigV1(ctx context.Context, c client.Client, mg resource.Managed, region string) (*awsv1.Config, error) {
+	pc := &v1beta1.ProviderConfig{}
+	if err := c.Get(ctx, types.NamespacedName{Name: mg.GetProviderConfigReference().Name}, pc); err != nil {
+		return nil, errors.Wrap(err, "cannot get referenced Provider")
+	}
+
+	t := resource.NewProviderConfigUsageTracker(c, &v1beta1.ProviderConfigUsage{})
+	if err := t.Track(ctx, mg); err != nil {
+		return nil, errors.Wrap(err, "cannot track ProviderConfig usage")
+	}
+
+	// TODO(muvaf): Support IRSA.
+	switch s := pc.Spec.Credentials.Source; s { //nolint:exhaustive
+	case runtimev1alpha1.CredentialsSourceSecret:
+		csr := pc.Spec.Credentials.SecretRef
+		if csr == nil {
+			return nil, errors.New("no credentials secret referenced")
+		}
+		s := &corev1.Secret{}
+		if err := c.Get(ctx, types.NamespacedName{Namespace: csr.Namespace, Name: csr.Name}, s); err != nil {
+			return nil, errors.Wrap(err, "cannot get credentials secret")
+		}
+		return UseProviderSecretV1(s.Data[csr.Key], DefaultSection, region)
+	default:
+		return nil, errors.Errorf("credentials source %s is not currently supported", s)
+	}
+}
+
+// UseProviderSecretV1 retrieves AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY from
+// the data which contains aws credentials under given profile and produces a *awsv1.Config
+// Example:
+// [default]
+// aws_access_key_id = <YOUR_ACCESS_KEY_ID>
+// aws_secret_access_key = <YOUR_SECRET_ACCESS_KEY>
+func UseProviderSecretV1(data []byte, profile, region string) (*awsv1.Config, error) {
+	config, err := ini.InsensitiveLoad(data)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot parse credentials secret")
+	}
+
+	iniProfile, err := config.GetSection(profile)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("cannot get %s profile in credentials secret", profile))
+	}
+
+	accessKeyID := iniProfile.Key("aws_access_key_id")
+	secretAccessKey := iniProfile.Key("aws_secret_access_key")
+	sessionToken := iniProfile.Key("aws_session_token")
+
+	// NOTE(muvaf): Key function implementation never returns nil but still its
+	// type is pointer so we check to make sure its next versions doesn't break
+	// that implicit contract.
+	if accessKeyID == nil || secretAccessKey == nil || sessionToken == nil {
+		return nil, errors.New("returned key can be empty but cannot be nil")
+	}
+
+	creds := credentials.NewStaticCredentials(accessKeyID.Value(), secretAccessKey.Value(), sessionToken.Value())
+	return awsv1.NewConfig().WithCredentials(creds).WithRegion(region), nil
 }
 
 // TODO(muvaf): All the types that use CreateJSONPatch are known during


### PR DESCRIPTION
### Description of your changes

We will be using ACK code generation pipeline to add new [resources](https://github.com/aws/aws-controllers-k8s/pull/444) to `provider-aws` but ACK and generated code works with AWS Go SDK v1 whereas we use v2. One place they differ is how they authorize. This PR adds a function specific to v1.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Not tested yet with an actual controller.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
