### PR TITLE
securitygroup: add reference and selector fields to UserIDGroupPair

### DIFF
--- a/apis/ec2/v1beta1/securitygroup_types.go
+++ b/apis/ec2/v1beta1/securitygroup_types.go
@@ -150,6 +150,15 @@ type UserIDGroupPair struct {
 	// +optional
 	VPCID *string `json:"vpcId,omitempty"`
 
+	// VPCIDRef reference a VPC to retrieve its vpcId
+	// +optional
+	// +immutable
+	VPCIDRef *runtimev1alpha1.Reference `json:"vpcIdRef,omitempty"`
+
+	// VPCIDSelector selects reference to a VPC to retrieve its vpcId
+	// +optional
+	VPCIDSelector *runtimev1alpha1.Selector `json:"vpcIdSelector,omitempty"`
+
 	// The ID of the VPC peering connection, if applicable.
 	// +optional
 	VPCPeeringConnectionID *string `json:"vpcPeeringConnectionId,omitempty"`

--- a/apis/ec2/v1beta1/zz_generated.deepcopy.go
+++ b/apis/ec2/v1beta1/zz_generated.deepcopy.go
@@ -684,6 +684,16 @@ func (in *UserIDGroupPair) DeepCopyInto(out *UserIDGroupPair) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.VPCIDRef != nil {
+		in, out := &in.VPCIDRef, &out.VPCIDRef
+		*out = new(v1alpha1.Reference)
+		**out = **in
+	}
+	if in.VPCIDSelector != nil {
+		in, out := &in.VPCIDSelector, &out.VPCIDSelector
+		*out = new(v1alpha1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.VPCPeeringConnectionID != nil {
 		in, out := &in.VPCPeeringConnectionID, &out.VPCPeeringConnectionID
 		*out = new(string)

--- a/package/crds/ec2.aws.crossplane.io_securitygroups.yaml
+++ b/package/crds/ec2.aws.crossplane.io_securitygroups.yaml
@@ -143,6 +143,27 @@ spec:
                               vpcId:
                                 description: The ID of the VPC for the referenced security group, if applicable.
                                 type: string
+                              vpcIdRef:
+                                description: VPCIDRef reference a VPC to retrieve its vpcId
+                                properties:
+                                  name:
+                                    description: Name of the referenced object.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              vpcIdSelector:
+                                description: VPCIDSelector selects reference to a VPC to retrieve its vpcId
+                                properties:
+                                  matchControllerRef:
+                                    description: MatchControllerRef ensures an object with the same controller reference as the selecting object is selected.
+                                    type: boolean
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: MatchLabels ensures an object with matching labels is selected.
+                                    type: object
+                                type: object
                               vpcPeeringConnectionId:
                                 description: The ID of the VPC peering connection, if applicable.
                                 type: string
@@ -236,6 +257,27 @@ spec:
                               vpcId:
                                 description: The ID of the VPC for the referenced security group, if applicable.
                                 type: string
+                              vpcIdRef:
+                                description: VPCIDRef reference a VPC to retrieve its vpcId
+                                properties:
+                                  name:
+                                    description: Name of the referenced object.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              vpcIdSelector:
+                                description: VPCIDSelector selects reference to a VPC to retrieve its vpcId
+                                properties:
+                                  matchControllerRef:
+                                    description: MatchControllerRef ensures an object with the same controller reference as the selecting object is selected.
+                                    type: boolean
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: MatchLabels ensures an object with matching labels is selected.
+                                    type: object
+                                type: object
                               vpcPeeringConnectionId:
                                 description: The ID of the VPC peering connection, if applicable.
                                 type: string


### PR DESCRIPTION
### Description of your changes

I just realized that we have `VPCID` but no reference or selector fields for it.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Not tested manually yet.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
