### PR TITLE
Do not panic on missing date in bucket lifecycleConfig

### DIFF
--- a/pkg/controller/s3/bucket/lifecycleConfig.go
+++ b/pkg/controller/s3/bucket/lifecycleConfig.go
@@ -137,9 +137,11 @@ func GenerateLifecycleRules(in []v1beta1.LifecycleRule) []awss3.LifecycleRule { 
 			rule.Transitions = make([]awss3.Transition, len(local.Transitions))
 			for tIndex, transition := range local.Transitions {
 				rule.Transitions[tIndex] = awss3.Transition{
-					Date:         &transition.Date.Time,
 					Days:         transition.Days,
 					StorageClass: awss3.TransitionStorageClass(transition.StorageClass),
+				}
+				if transition.Date != nil {
+					rule.Transitions[tIndex].Date = &transition.Date.Time
 				}
 			}
 		}


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This updates the GenerateLifecycleConfig method to not assume that a
non-nil Date is provided for every transition. This was causing a panic
if Days and/or StorageClass was provided but no Date was provided.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Unit tests.

[contribution process]: https://git.io/fj2m9
