### PR TITLE
fix examples/acm/certificate.yaml

### DIFF
--- a/examples/acm/certificate.yaml
+++ b/examples/acm/certificate.yaml
@@ -7,7 +7,7 @@ spec:
     region: us-east-1
     certificateAuthorityArn: somearn
     domainName: www.example.com
-    certificateTransparencyLoggingPreference: disabled
+    certificateTransparencyLoggingPreference: DISABLED
     tags:
     - key: Name
       value: example


### PR DESCRIPTION
when trying out the certificate example i got the following Warning: 

```
 Warning  CannotCreateExternalResource  2s (x6013 over 5m2s)  managed/certificate.acm.aws.crossplane.io  
(combined from similar events): failed to create the Certificate resource: ValidationException: 
1 validation error detected: Value 'disabled' at 'options.certificateTransparencyLoggingPreference' failed to satisfy constraint: 
Member must satisfy enum value set: [ENABLED, DISABLED]
```
`Member must satisfy enum value set: [ENABLED, DISABLED]`
after changing the value like this: `certificateTransparencyLoggingPreference: DISABLED` the previous Warning is gone

```
Status:
  At Provider:
  Conditions:
    Last Transition Time:  2020-11-13T21:23:39Z
    Reason:                Creating
    Status:                False
    Type:                  Ready
    Last Transition Time:  2020-11-13T21:23:46Z
    Message:               create failed: failed to create the Certificate resource: AccessDeniedException: User: arn:aws:iam::111111:user/crossplane.playground.caas.xxx.corp.io is not authorized to perform: acm:RequestCertificate
                           status code: 400, request id: fdf5e910-72dd-498f-9e27-24a5f53eacd5
```

