### PR TITLE
s3 bucket: make the filter an empty dictionary by default

### DIFF
--- a/pkg/controller/s3/bucket/lifecycleConfig.go
+++ b/pkg/controller/s3/bucket/lifecycleConfig.go
@@ -145,10 +145,10 @@ func GenerateLifecycleRules(in []v1beta1.LifecycleRule) []awss3.LifecycleRule { 
 				}
 			}
 		}
+		// This is done because S3 expects an empty filter, and never nil
+		rule.Filter = &awss3.LifecycleRuleFilter{}
 		if local.Filter != nil {
-			rule.Filter = &awss3.LifecycleRuleFilter{
-				Prefix: local.Filter.Prefix,
-			}
+			rule.Filter.Prefix = local.Filter.Prefix
 			if local.Filter.Tag != nil {
 				rule.Filter.Tag = &awss3.Tag{Key: aws.String(local.Filter.Tag.Key), Value: aws.String(local.Filter.Tag.Value)}
 			}

--- a/pkg/controller/s3/bucket/lifecycleConfig_test.go
+++ b/pkg/controller/s3/bucket/lifecycleConfig_test.go
@@ -60,10 +60,10 @@ func generateLifecycleConfig() *v1beta1.BucketLifecycleConfiguration {
 				},
 				Filter: &v1beta1.LifecycleRuleFilter{
 					And: &v1beta1.LifecycleRuleAndOperator{
-						Prefix: &prefix,
+						Prefix: aws.String(prefix),
 						Tags:   tags,
 					},
-					Prefix: &prefix,
+					Prefix: aws.String(prefix),
 					Tag:    &tag,
 				},
 				ID:                          aws.String(id),
@@ -95,10 +95,10 @@ func generateAWSLifecycle(sortTag bool) *s3.BucketLifecycleConfiguration {
 				},
 				Filter: &s3.LifecycleRuleFilter{
 					And: &s3.LifecycleRuleAndOperator{
-						Prefix: &prefix,
+						Prefix: aws.String(prefix),
 						Tags:   awsTags,
 					},
-					Prefix: &prefix,
+					Prefix: aws.String(prefix),
 					Tag:    &awsTag,
 				},
 				ID:                          aws.String(id),


### PR DESCRIPTION
Signed-off-by: Krish Chowdhary <krish@redhat.com>

### Description of your changes

Fixes #430 

This PR makes the filter in the s3 bucket lifecycle empty by default, as opposed to `nil`. This is because S3 expects an empty dictionary as opposed to nil if no filter is provided. 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manual testing with an S3 Bucket, and updated unit-tests
[contribution process]: https://git.io/fj2m9
