### PR TITLE
Use the new ExternalCreation.ExternalNameAssigned ExternalObservation.ResourceLateInitialized fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/aws/aws-sdk-go v1.34.32
 	github.com/aws/aws-sdk-go-v2 v0.23.0
-	github.com/crossplane/crossplane-runtime v0.11.0
+	github.com/crossplane/crossplane-runtime v0.11.1-0.20201116232334-1b691efff491
 	github.com/crossplane/crossplane-tools v0.0.0-20201007233256-88b291e145bb
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/go-ini/ini v1.46.0

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane-runtime v0.11.0 h1:hLDWsGYhU/CUVQ1sU7NHF5bnP6WT6wA6Nu2SaBSSe6w=
-github.com/crossplane/crossplane-runtime v0.11.0/go.mod h1:cJl5ZZONisre4v6wTmbrC8Jh3AI+erq/lNaxZzv9tnU=
+github.com/crossplane/crossplane-runtime v0.11.1-0.20201116232334-1b691efff491 h1:Xj33mVx0Ij6pYyjZ6Oi411C/08QGH1+tb3/WtMO/afs=
+github.com/crossplane/crossplane-runtime v0.11.1-0.20201116232334-1b691efff491/go.mod h1:cJl5ZZONisre4v6wTmbrC8Jh3AI+erq/lNaxZzv9tnU=
 github.com/crossplane/crossplane-tools v0.0.0-20201007233256-88b291e145bb h1:j09j/Gk1qH64HUtf/fcTjMAxLxUdOuQXySWu46WTVTU=
 github.com/crossplane/crossplane-tools v0.0.0-20201007233256-88b291e145bb/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
 github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=

--- a/pkg/controller/acm/controller.go
+++ b/pkg/controller/acm/controller.go
@@ -46,8 +46,7 @@ const (
 	errUpdate           = "failed to update the Certificate resource"
 	errSDK              = "empty Certificate received from ACM API"
 
-	errKubeUpdateFailed    = "cannot late initialize Certificate"
-	errPersistExternalName = "failed to persist Certificate ARN"
+	errKubeUpdateFailed = "cannot late initialize Certificate"
 
 	errAddTagsFailed        = "cannot add tags to Certificate"
 	errListTagsFailed       = "failed to list tags for Certificate"
@@ -152,16 +151,12 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		return managed.ExternalCreation{}, errors.New(errUnexpectedObject)
 	}
 
-	cr.Status.SetConditions(runtimev1alpha1.Creating())
-
 	response, err := e.client.RequestCertificateRequest(acm.GenerateCreateCertificateInput(meta.GetExternalName(cr), &cr.Spec.ForProvider)).Send(ctx)
-
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 	}
-
 	meta.SetExternalName(cr, aws.StringValue(response.RequestCertificateOutput.CertificateArn))
-	return managed.ExternalCreation{}, errors.Wrap(e.kube.Update(ctx, cr), errPersistExternalName)
+	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
 
 }
 

--- a/pkg/controller/acm/controller_test.go
+++ b/pkg/controller/acm/controller_test.go
@@ -116,7 +116,7 @@ func TestObserve(t *testing.T) {
 		args
 		want
 	}{
-		"VaildInput": {
+		"ValidInput": {
 			args: args{
 				acm: &fake.MockCertificateClient{
 					MockDescribeCertificateRequest: func(input *awsacm.DescribeCertificateInput) awsacm.DescribeCertificateRequest {
@@ -225,7 +225,7 @@ func TestCreate(t *testing.T) {
 		args
 		want
 	}{
-		"VaildInput": {
+		"ValidInput": {
 			args: args{
 				acm: &fake.MockCertificateClient{
 					MockRequestCertificateRequest: func(input *awsacm.RequestCertificateInput) awsacm.RequestCertificateRequest {
@@ -240,8 +240,8 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr: certificate(
-					withDomainName(),
-					withConditions(corev1alpha1.Creating())),
+					withDomainName()),
+				result: managed.ExternalCreation{ExternalNameAssigned: true},
 			},
 		},
 		"InValidInput": {
@@ -265,7 +265,7 @@ func TestCreate(t *testing.T) {
 				cr: certificate(),
 			},
 			want: want{
-				cr:  certificate(withConditions(corev1alpha1.Creating())),
+				cr:  certificate(),
 				err: errors.Wrap(errBoom, errCreate),
 			},
 		},
@@ -306,7 +306,7 @@ func TestUpdate(t *testing.T) {
 		args
 		want
 	}{
-		"VaildInput": {
+		"ValidInput": {
 			args: args{
 				acm: &fake.MockCertificateClient{
 
@@ -450,7 +450,7 @@ func TestDelete(t *testing.T) {
 		args
 		want
 	}{
-		"VaildInput": {
+		"ValidInput": {
 			args: args{
 				acm: &fake.MockCertificateClient{
 					MockDeleteCertificateRequest: func(input *awsacm.DeleteCertificateInput) awsacm.DeleteCertificateRequest {

--- a/pkg/controller/acmpca/certificateauthority/controller_test.go
+++ b/pkg/controller/acmpca/certificateauthority/controller_test.go
@@ -117,7 +117,7 @@ func TestObserve(t *testing.T) {
 		args
 		want
 	}{
-		"VaildInput": {
+		"ValidInput": {
 			args: args{
 				acmpca: &fake.MockCertificateAuthorityClient{
 					MockDescribeCertificateAuthorityRequest: func(*awsacmpca.DescribeCertificateAuthorityInput) awsacmpca.DescribeCertificateAuthorityRequest {
@@ -235,7 +235,7 @@ func TestCreate(t *testing.T) {
 		args
 		want
 	}{
-		"VaildInput": {
+		"ValidInput": {
 			args: args{
 				acmpca: &fake.MockCertificateAuthorityClient{
 					MockCreateCertificateAuthorityRequest: func(input *awsacmpca.CreateCertificateAuthorityInput) awsacmpca.CreateCertificateAuthorityRequest {
@@ -254,7 +254,8 @@ func TestCreate(t *testing.T) {
 				cr: certificateAuthority(withCertificateAuthorityArn()),
 			},
 			want: want{
-				cr: certificateAuthority(withCertificateAuthorityArn(), withConditions(corev1alpha1.Creating())),
+				cr:     certificateAuthority(withCertificateAuthorityArn()),
+				result: managed.ExternalCreation{ExternalNameAssigned: true},
 			},
 		},
 		"InValidInput": {
@@ -283,7 +284,7 @@ func TestCreate(t *testing.T) {
 				cr: certificateAuthority(),
 			},
 			want: want{
-				cr:  certificateAuthority(withConditions(corev1alpha1.Creating())),
+				cr:  certificateAuthority(),
 				err: errors.Wrap(errBoom, errCreate),
 			},
 		},
@@ -324,7 +325,7 @@ func TestUpdate(t *testing.T) {
 		args
 		want
 	}{
-		"VaildInput": {
+		"ValidInput": {
 			args: args{
 				acmpca: &fake.MockCertificateAuthorityClient{
 					MockDeletePermissionRequest: func(*awsacmpca.DeletePermissionInput) awsacmpca.DeletePermissionRequest {
@@ -468,7 +469,7 @@ func TestDelete(t *testing.T) {
 		args
 		want
 	}{
-		"VaildInput": {
+		"ValidInput": {
 			args: args{
 				acmpca: &fake.MockCertificateAuthorityClient{
 					MockDeleteCertificateAuthorityRequest: func(*awsacmpca.DeleteCertificateAuthorityInput) awsacmpca.DeleteCertificateAuthorityRequest {

--- a/pkg/controller/apigatewayv2/apimapping/hooks.go
+++ b/pkg/controller/apigatewayv2/apimapping/hooks.go
@@ -72,12 +72,13 @@ func (*external) preCreate(context.Context, *svcapitypes.APIMapping) error {
 	return nil
 }
 
-func (e *external) postCreate(ctx context.Context, cr *svcapitypes.APIMapping, resp *svcsdk.CreateApiMappingOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
+func (e *external) postCreate(_ context.Context, cr *svcapitypes.APIMapping, resp *svcsdk.CreateApiMappingOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
 	if err != nil {
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.ApiMappingId))
-	return cre, e.kube.Update(ctx, cr)
+	cre.ExternalNameAssigned = true
+	return cre, nil
 }
 
 func (*external) preUpdate(context.Context, *svcapitypes.APIMapping) error {

--- a/pkg/controller/apigatewayv2/deployment/hooks.go
+++ b/pkg/controller/apigatewayv2/deployment/hooks.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
-	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/crossplane/crossplane-runtime/pkg/event"
@@ -68,12 +67,13 @@ func (*external) preCreate(context.Context, *svcapitypes.Deployment) error {
 	return nil
 }
 
-func (e *external) postCreate(ctx context.Context, cr *svcapitypes.Deployment, resp *svcsdk.CreateDeploymentOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
+func (e *external) postCreate(_ context.Context, cr *svcapitypes.Deployment, resp *svcsdk.CreateDeploymentOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
 	if err != nil {
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.DeploymentId))
-	return cre, errors.Wrap(e.kube.Update(ctx, cr), "cannot update Deployment")
+	cre.ExternalNameAssigned = true
+	return cre, nil
 }
 
 func (*external) preUpdate(context.Context, *svcapitypes.Deployment) error {

--- a/pkg/controller/apigatewayv2/integration/hooks.go
+++ b/pkg/controller/apigatewayv2/integration/hooks.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
-	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
@@ -74,12 +73,13 @@ func (*external) preCreate(context.Context, *svcapitypes.Integration) error {
 	return nil
 }
 
-func (e *external) postCreate(ctx context.Context, cr *svcapitypes.Integration, resp *svcsdk.CreateIntegrationOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
+func (e *external) postCreate(_ context.Context, cr *svcapitypes.Integration, resp *svcsdk.CreateIntegrationOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
 	if err != nil {
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.IntegrationId))
-	return cre, errors.Wrap(e.kube.Update(ctx, cr), "cannot update Integration")
+	cre.ExternalNameAssigned = true
+	return cre, nil
 }
 
 func (*external) preUpdate(context.Context, *svcapitypes.Integration) error {

--- a/pkg/controller/apigatewayv2/integrationresponse/hooks.go
+++ b/pkg/controller/apigatewayv2/integrationresponse/hooks.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
-	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
@@ -74,12 +73,13 @@ func (*external) preCreate(context.Context, *svcapitypes.IntegrationResponse) er
 	return nil
 }
 
-func (e *external) postCreate(ctx context.Context, cr *svcapitypes.IntegrationResponse, resp *svcsdk.CreateIntegrationResponseOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
+func (e *external) postCreate(_ context.Context, cr *svcapitypes.IntegrationResponse, resp *svcsdk.CreateIntegrationResponseOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
 	if err != nil {
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.IntegrationResponseId))
-	return cre, errors.Wrap(e.kube.Update(ctx, cr), "cannot update IntegrationResponse")
+	cre.ExternalNameAssigned = true
+	return cre, nil
 }
 
 func (*external) preUpdate(context.Context, *svcapitypes.IntegrationResponse) error {

--- a/pkg/controller/apigatewayv2/route/hooks.go
+++ b/pkg/controller/apigatewayv2/route/hooks.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
-	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
@@ -74,14 +73,15 @@ func (*external) preCreate(context.Context, *svcapitypes.Route) error {
 	return nil
 }
 
-func (e *external) postCreate(ctx context.Context, cr *svcapitypes.Route, res *svcsdk.CreateRouteOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
+func (e *external) postCreate(_ context.Context, cr *svcapitypes.Route, res *svcsdk.CreateRouteOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
 	if err != nil {
 		return managed.ExternalCreation{}, err
 	}
 	// NOTE(muvaf): Route ID is chosen as external name since it's the only unique
 	// identifier.
 	meta.SetExternalName(cr, aws.StringValue(res.RouteId))
-	return cre, errors.Wrap(e.kube.Update(ctx, cr), "cannot update Route")
+	cre.ExternalNameAssigned = true
+	return cre, nil
 }
 
 func (*external) preUpdate(context.Context, *svcapitypes.Route) error {

--- a/pkg/controller/apigatewayv2/routeresponse/hooks.go
+++ b/pkg/controller/apigatewayv2/routeresponse/hooks.go
@@ -73,12 +73,13 @@ func (*external) preCreate(context.Context, *svcapitypes.RouteResponse) error {
 	return nil
 }
 
-func (e *external) postCreate(ctx context.Context, cr *svcapitypes.RouteResponse, resp *svcsdk.CreateRouteResponseOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
+func (e *external) postCreate(_ context.Context, cr *svcapitypes.RouteResponse, resp *svcsdk.CreateRouteResponseOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
 	if err != nil {
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.RouteResponseId))
-	return cre, e.kube.Update(ctx, cr)
+	cre.ExternalNameAssigned = true
+	return cre, nil
 }
 
 func (*external) preUpdate(context.Context, *svcapitypes.RouteResponse) error {

--- a/pkg/controller/ec2/elasticip/controller_test.go
+++ b/pkg/controller/ec2/elasticip/controller_test.go
@@ -237,6 +237,7 @@ func TestCreate(t *testing.T) {
 			want: want{
 				cr: elasticIP(withExternalName(allocationID),
 					withConditions(runtimev1alpha1.Creating())),
+				result: managed.ExternalCreation{ExternalNameAssigned: true},
 			},
 		},
 		"SuccessfulStandard": {
@@ -264,6 +265,7 @@ func TestCreate(t *testing.T) {
 					withSpec(v1alpha1.ElasticIPParameters{
 						Domain: &domainStandard,
 					})),
+				result: managed.ExternalCreation{ExternalNameAssigned: true},
 			},
 		},
 		"CreateFail": {

--- a/pkg/controller/ec2/internetgateway/controller_test.go
+++ b/pkg/controller/ec2/internetgateway/controller_test.go
@@ -261,6 +261,7 @@ func TestCreate(t *testing.T) {
 				}),
 					withExternalName(igID),
 					withConditions(runtimev1alpha1.Creating())),
+				result: managed.ExternalCreation{ExternalNameAssigned: true},
 			},
 		},
 		"FailedRequest": {

--- a/pkg/controller/ec2/natgateway/controller.go
+++ b/pkg/controller/ec2/natgateway/controller.go
@@ -26,7 +26,6 @@ const (
 	errUnexpectedObject = "The managed resource is not an NATGateway resource"
 	errDescribe         = "failed to describe NATGateway"
 	errNotSingleItem    = "either no or multiple NATGateways retrieved for the given natGatewayId"
-	errSpecUpdate       = "cannot update spec of the NATGateway resource"
 	errCreate           = "failed to create the NATGateway resource"
 	errDelete           = "failed to delete the NATGateway resource"
 	errUpdateTags       = "failed to update tags for the NATGateway resource"
@@ -140,10 +139,8 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 	}
-
 	meta.SetExternalName(cr, aws.StringValue(nat.NatGateway.NatGatewayId))
-
-	return managed.ExternalCreation{}, errors.Wrap(e.kube.Update(ctx, cr), errSpecUpdate)
+	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/ec2/natgateway/controller_test.go
+++ b/pkg/controller/ec2/natgateway/controller_test.go
@@ -470,7 +470,7 @@ func TestCreate(t *testing.T) {
 				cr: nat(withExternalName(natGatewayID),
 					withSpec(specNatSpec()),
 				),
-				result: managed.ExternalCreation{},
+				result: managed.ExternalCreation{ExternalNameAssigned: true},
 			},
 		},
 		"FailedRequest": {

--- a/pkg/controller/ec2/routetable/controller_test.go
+++ b/pkg/controller/ec2/routetable/controller_test.go
@@ -207,30 +207,7 @@ func TestCreate(t *testing.T) {
 				cr: rt(withSpec(v1alpha4.RouteTableParameters{
 					VPCID: aws.String(vpcID),
 				}), withExternalName(rtID)),
-			},
-		},
-		"EmptyResult": {
-			args: args{
-				kube: &test.MockClient{
-					MockUpdate:       test.NewMockClient().MockUpdate,
-					MockStatusUpdate: test.NewMockClient().MockStatusUpdate,
-				},
-				rt: &fake.MockRouteTableClient{
-					MockCreate: func(input *awsec2.CreateRouteTableInput) awsec2.CreateRouteTableRequest {
-						return awsec2.CreateRouteTableRequest{
-							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &awsec2.CreateRouteTableOutput{}},
-						}
-					},
-				},
-				cr: rt(withSpec(v1alpha4.RouteTableParameters{
-					VPCID: aws.String(vpcID),
-				}), withExternalName(rtID)),
-			},
-			want: want{
-				cr: rt(withSpec(v1alpha4.RouteTableParameters{
-					VPCID: aws.String(vpcID),
-				}), withExternalName(rtID)),
-				err: errors.New(errCreate),
+				result: managed.ExternalCreation{ExternalNameAssigned: true},
 			},
 		},
 		"CreateFailed": {

--- a/pkg/controller/ec2/securitygroup/controller_test.go
+++ b/pkg/controller/ec2/securitygroup/controller_test.go
@@ -224,6 +224,7 @@ func TestCreate(t *testing.T) {
 		"Successful": {
 			args: args{
 				kube: &test.MockClient{
+					MockGet:          test.NewMockGetFn(nil),
 					MockUpdate:       test.NewMockUpdateFn(nil),
 					MockStatusUpdate: test.NewMockStatusUpdateFn(nil),
 				},
@@ -271,6 +272,7 @@ func TestCreate(t *testing.T) {
 		"RevokeFail": {
 			args: args{
 				kube: &test.MockClient{
+					MockGet:          test.NewMockGetFn(nil),
 					MockUpdate:       test.NewMockUpdateFn(nil),
 					MockStatusUpdate: test.NewMockStatusUpdateFn(nil),
 				},

--- a/pkg/controller/ec2/subnet/controller_test.go
+++ b/pkg/controller/ec2/subnet/controller_test.go
@@ -218,10 +218,6 @@ func TestCreate(t *testing.T) {
 	}{
 		"Successful": {
 			args: args{
-				kube: &test.MockClient{
-					MockUpdate:       test.NewMockClient().Update,
-					MockStatusUpdate: test.NewMockClient().MockStatusUpdate,
-				},
 				subnet: &fake.MockSubnetClient{
 					MockCreate: func(input *awsec2.CreateSubnetInput) awsec2.CreateSubnetRequest {
 						return awsec2.CreateSubnetRequest{
@@ -236,8 +232,8 @@ func TestCreate(t *testing.T) {
 				cr: subnet(),
 			},
 			want: want{
-				cr: subnet(withExternalName(subnetID),
-					withConditions(runtimev1alpha1.Creating())),
+				cr:     subnet(withExternalName(subnetID)),
+				result: managed.ExternalCreation{ExternalNameAssigned: true},
 			},
 		},
 		"CreateFailed": {
@@ -256,7 +252,7 @@ func TestCreate(t *testing.T) {
 				cr: subnet(),
 			},
 			want: want{
-				cr:  subnet(withConditions(runtimev1alpha1.Creating())),
+				cr:  subnet(),
 				err: errors.Wrap(errBoom, errCreate),
 			},
 		},

--- a/pkg/controller/ec2/vpc/controller_test.go
+++ b/pkg/controller/ec2/vpc/controller_test.go
@@ -233,10 +233,6 @@ func TestCreate(t *testing.T) {
 	}{
 		"Successful": {
 			args: args{
-				kube: &test.MockClient{
-					MockUpdate:       test.NewMockClient().Update,
-					MockStatusUpdate: test.NewMockClient().MockStatusUpdate,
-				},
 				vpc: &fake.MockVPCClient{
 					MockCreate: func(input *awsec2.CreateVpcInput) awsec2.CreateVpcRequest {
 						return awsec2.CreateVpcRequest{
@@ -257,16 +253,12 @@ func TestCreate(t *testing.T) {
 				cr: vpc(),
 			},
 			want: want{
-				cr: vpc(withExternalName(vpcID),
-					withConditions(runtimev1alpha1.Creating())),
+				cr:     vpc(withExternalName(vpcID)),
+				result: managed.ExternalCreation{ExternalNameAssigned: true},
 			},
 		},
 		"CreateFail": {
 			args: args{
-				kube: &test.MockClient{
-					MockUpdate:       test.NewMockClient().Update,
-					MockStatusUpdate: test.NewMockClient().MockStatusUpdate,
-				},
 				vpc: &fake.MockVPCClient{
 					MockCreate: func(input *awsec2.CreateVpcInput) awsec2.CreateVpcRequest {
 						return awsec2.CreateVpcRequest{
@@ -277,7 +269,7 @@ func TestCreate(t *testing.T) {
 				cr: vpc(),
 			},
 			want: want{
-				cr:  vpc(withConditions(runtimev1alpha1.Creating())),
+				cr:  vpc(),
 				err: errors.Wrap(errBoom, errCreate),
 			},
 		},

--- a/pkg/controller/identity/iampolicy/controller.go
+++ b/pkg/controller/identity/iampolicy/controller.go
@@ -143,8 +143,6 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		return managed.ExternalCreation{}, errors.New(errUnexpectedObject)
 	}
 
-	cr.Status.SetConditions(runtimev1alpha1.Creating())
-
 	createResp, err := e.client.CreatePolicyRequest(&awsiam.CreatePolicyInput{
 		Description:    cr.Spec.ForProvider.Description,
 		Path:           cr.Spec.ForProvider.Path,
@@ -158,7 +156,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 
 	meta.SetExternalName(cr, aws.StringValue(createResp.CreatePolicyOutput.Policy.Arn))
 
-	return managed.ExternalCreation{}, errors.Wrap(e.kube.Update(ctx, cr), errCreate)
+	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/identity/iampolicy/controller_test.go
+++ b/pkg/controller/identity/iampolicy/controller_test.go
@@ -251,8 +251,8 @@ func TestCreate(t *testing.T) {
 						Document: document,
 						Name:     name,
 					}),
-					withExterName(arn),
-					withConditions(corev1alpha1.Creating())),
+					withExterName(arn)),
+				result: managed.ExternalCreation{ExternalNameAssigned: true},
 			},
 		},
 		"InValidInput": {
@@ -276,7 +276,7 @@ func TestCreate(t *testing.T) {
 				cr: policy(),
 			},
 			want: want{
-				cr:  policy(withConditions(corev1alpha1.Creating())),
+				cr:  policy(),
 				err: errors.Wrap(errBoom, errCreate),
 			},
 		},

--- a/pkg/controller/redshift/controller.go
+++ b/pkg/controller/redshift/controller.go
@@ -162,7 +162,7 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		runtimev1alpha1.ResourceCredentialsSecretUserKey:     []byte(aws.StringValue(input.MasterUsername)),
 	}
 
-	return managed.ExternalCreation{ConnectionDetails: conn}, errors.Wrap(err, errCreateFailed)
+	return managed.ExternalCreation{ConnectionDetails: conn}, nil
 }
 
 func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/route53/hostedzone/controller_test.go
+++ b/pkg/controller/route53/hostedzone/controller_test.go
@@ -266,8 +266,8 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr: instance(
-					withExternalName(strings.SplitAfter(id, hostedzone.IDPrefix)[1]),
-					withConditions(runtimev1alpha1.Creating())),
+					withExternalName(strings.SplitAfter(id, hostedzone.IDPrefix)[1])),
+				result: managed.ExternalCreation{ExternalNameAssigned: true},
 			},
 		},
 		"InValidInput": {
@@ -291,7 +291,7 @@ func TestCreate(t *testing.T) {
 				cr: instance(),
 			},
 			want: want{
-				cr:  instance(withConditions(runtimev1alpha1.Creating())),
+				cr:  instance(),
 				err: errors.Wrap(errBoom, errCreate),
 			},
 		},


### PR DESCRIPTION
### Description of your changes

Implements functionality in https://github.com/crossplane/crossplane-runtime/pull/228 and https://github.com/crossplane/crossplane-runtime/pull/216 (only the ones we used `ExternalNameAssigned` for now)

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to sdsindicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/upbound/platform-ref-aws/issues/3

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually with VPC example YAML.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
