### PR TITLE
Queue API exceptions

### DIFF
--- a/pkg/clients/sqs/queue_test.go
+++ b/pkg/clients/sqs/queue_test.go
@@ -201,6 +201,10 @@ func TestGenerateQueueAttributes(t *testing.T) {
 				v1beta1.AttributeKmsMasterKeyID: kmsMasterKeyID,
 			},
 		},
+		"EmptyInput": {
+			in:  v1beta1.QueueParameters{},
+			out: nil,
+		},
 	}
 
 	for name, tc := range cases {
@@ -208,6 +212,41 @@ func TestGenerateQueueAttributes(t *testing.T) {
 			r := GenerateQueueAttributes(&tc.in)
 			if diff := cmp.Diff(r, tc.out); diff != "" {
 				t.Errorf("GenerateQueueAttributes(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGenerateCreateAttributes(t *testing.T) {
+	cases := map[string]struct {
+		in  v1beta1.QueueParameters
+		out map[string]string
+	}{
+		"EmptyInput": {
+			in:  v1beta1.QueueParameters{},
+			out: nil,
+		},
+		"FifoQueueFalseShouldNotBeSent": {
+			in: v1beta1.QueueParameters{
+				FIFOQueue: aws.Bool(false),
+			},
+			out: nil,
+		},
+		"FifoQueueTrue": {
+			in: v1beta1.QueueParameters{
+				FIFOQueue: aws.Bool(true),
+			},
+			out: map[string]string{
+				v1beta1.AttributeFifoQueue: "true",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := GenerateCreateAttributes(&tc.in)
+			if diff := cmp.Diff(r, tc.out); diff != "" {
+				t.Errorf("GenerateCreateAttributes(...): -want, +got:\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

AWS does not expect FifoQueue attribute if it is false and a `nil` map should be sent if no attribute is defined.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane/provider-aws/issues/457

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested with the following YAMLs:
```yaml
apiVersion: sqs.aws.crossplane.io/v1beta1
kind: Queue
metadata:
  name: test-fifo.fifo
spec:
  forProvider:
    region: us-east-1
    fifoQueue: true
  providerConfigRef:
    name: default
---
apiVersion: sqs.aws.crossplane.io/v1beta1
kind: Queue
metadata:
  name: test-fifo.fifo
spec:
  forProvider:
    region: us-east-1
    fifoQueue: false
  providerConfigRef:
    name: default
---
apiVersion: sqs.aws.crossplane.io/v1beta1
kind: Queue
metadata:
  name: test-fifo.fifo
spec:
  forProvider:
    region: us-east-1
  providerConfigRef:
    name: default
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
