### PR TITLE
Optional ACL, Endpoint secret

### DIFF
--- a/apis/s3/v1beta1/bucket_types.go
+++ b/apis/s3/v1beta1/bucket_types.go
@@ -23,7 +23,9 @@ import (
 
 // BucketParameters are parameters for configuring the calls made to AWS Bucket API.
 type BucketParameters struct {
-	// The canned ACL to apply to the bucket.
+	// The canned ACL to apply to the bucket. Note that either canned ACL or specific access
+	// permissions are required. If neither (or both) are provided, the creation of the bucket
+	// will fail.
 	// +kubebuilder:validation:Enum=private;public-read;public-read-write;authenticated-read
 	// +optional
 	ACL *string `json:"acl,omitempty"`

--- a/examples/s3/bucket.yaml
+++ b/examples/s3/bucket.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   forProvider:
     acl: private
+    locationConstraint: us-west-1
     accelerateConfiguration:
       status: Enabled
     versioningConfiguration:
@@ -17,7 +18,6 @@ spec:
           value: val2
         - key: key3
           value: val3
-    locationConstraint: us-west-1
     objectLockEnabledForBucket: false
     serverSideEncryptionConfiguration:
       rules:

--- a/package/crds/s3.aws.crossplane.io_buckets.yaml
+++ b/package/crds/s3.aws.crossplane.io_buckets.yaml
@@ -66,7 +66,7 @@ spec:
                     - status
                     type: object
                   acl:
-                    description: The canned ACL to apply to the bucket.
+                    description: The canned ACL to apply to the bucket. Note that either canned ACL or specific access permissions are required. If neither (or both) are provided, the creation of the bucket will fail.
                     enum:
                     - private
                     - public-read

--- a/pkg/controller/s3/bucket_test.go
+++ b/pkg/controller/s3/bucket_test.go
@@ -117,6 +117,10 @@ func TestObserve(t *testing.T) {
 				result: managed.ExternalObservation{
 					ResourceExists:   true,
 					ResourceUpToDate: true,
+					ConnectionDetails: map[string][]byte{
+						corev1alpha1.ResourceCredentialsSecretEndpointKey: []byte(s3Testing.BucketName),
+						ResourceCredentialsSecretRegionKey:                []byte(s3Testing.Region),
+					},
 				},
 			},
 		},
@@ -163,6 +167,10 @@ func TestObserve(t *testing.T) {
 				result: managed.ExternalObservation{
 					ResourceExists:   true,
 					ResourceUpToDate: true,
+					ConnectionDetails: map[string][]byte{
+						corev1alpha1.ResourceCredentialsSecretEndpointKey: []byte(s3Testing.BucketName),
+						ResourceCredentialsSecretRegionKey:                []byte(s3Testing.Region),
+					},
 				},
 			},
 		},

--- a/pkg/controller/s3/testing/testHelper.go
+++ b/pkg/controller/s3/testing/testHelper.go
@@ -28,8 +28,9 @@ import (
 
 var (
 	// an arbitrary managed resource
-	acl              = "private"
-	region           = "us-east-1"
+	acl = "private"
+	// Region is the test region of the bucket
+	Region           = "us-east-1"
 	grantFullControl = "fullGrant"
 	grantRead        = "readGrant"
 	grantReadACP     = "readACPGrant"
@@ -116,7 +117,7 @@ func Bucket(m ...BucketModifier) *v1beta1.Bucket {
 		Spec: v1beta1.BucketSpec{
 			ForProvider: v1beta1.BucketParameters{
 				ACL:                        &acl,
-				LocationConstraint:         region,
+				LocationConstraint:         Region,
 				GrantFullControl:           &grantFullControl,
 				GrantRead:                  &grantRead,
 				GrantReadACP:               &grantReadACP,


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue outlined on the Crossplane slack channel regarding the ACL field in the bucket resource. Additionally, one piece of functionality that we lost when bringing the s3 bucket to v1beta1 was the connection secret containing the endpoint of the bucket. This is something that I am adding back in this PR.

Slack Conversation: https://crossplane.slack.com/archives/CEG3T90A1/p1607034420017100?thread_ts=1607033622.011100&cid=CEG3T90A1

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Updated unit tests, manual testing via the examples manifest.

[contribution process]: https://git.io/fj2m9
