### PR TITLE
Attempt to remove requestId from aws errs, align on awsclient name

### DIFF
--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -302,7 +302,7 @@ echo_step "uninstalling ${PROJECT_NAME}"
 echo "${INSTALL_YAML}" | "${KUBECTL}" delete -f -
 
 # check pods deleted
-sleep 30
+sleep 60
 echo_step "check only crossplane pods remain"
 echo "--- pods ---"
 "${KUBECTL}" -n "${CROSSPLANE_NAMESPACE}" get pods

--- a/pkg/clients/acmpca/certificateauthority_test.go
+++ b/pkg/clients/acmpca/certificateauthority_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	customCname                    = "soemcustomname"
+	customCname                    = "somecustomname"
 	revocationConfigurationEnabled = true
 	s3BucketName                   = "somes3bucketname"
 	commonName                     = "someCommonName"

--- a/pkg/clients/aws.go
+++ b/pkg/clients/aws.go
@@ -28,9 +28,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/session"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/awserr"
 	"github.com/aws/aws-sdk-go-v2/aws/endpoints"
 	"github.com/aws/aws-sdk-go-v2/aws/external"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -38,15 +37,15 @@ import (
 	awsv1 "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	endpointsv1 "github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/session"
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/go-ini/ini"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
-	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplane/provider-aws/apis/v1alpha3"
 	"github.com/crossplane/provider-aws/apis/v1beta1"
@@ -631,4 +630,21 @@ func DiffLabels(local, remote map[string]string) (addOrModify map[string]string,
 		}
 	}
 	return
+}
+
+// CleanError Will remove the requestID from a awserr.Error and return a new awserr.
+// If not awserr it will return the original error
+func CleanError(err error) error {
+	if err == nil {
+		return err
+	}
+	if awsErr, ok := err.(awserr.Error); ok {
+		return awserr.New(awsErr.Code(), awsErr.Message(), nil)
+	}
+	return err
+}
+
+// Wrap Attempts to remove requestID from awserr before calling Wrap
+func Wrap(err error, msg string) error {
+	return errors.Wrap(CleanError(err), msg)
 }

--- a/pkg/controller/acm/controller_test.go
+++ b/pkg/controller/acm/controller_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	v1alpha1 "github.com/crossplane/provider-aws/apis/acm/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	acm "github.com/crossplane/provider-aws/pkg/clients/acm"
 	"github.com/crossplane/provider-aws/pkg/clients/acm/fake"
 )
@@ -168,7 +169,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  certificate(withCertificateArn()),
-				err: errors.Wrap(errBoom, errGet),
+				err: awsclient.Wrap(errBoom, errGet),
 			},
 		},
 		"ResourceDoesNotExist": {
@@ -265,7 +266,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  certificate(),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -380,7 +381,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  certificate(withCertificateTransparencyLoggingPreference()),
-				err: errors.Wrap(errBoom, errUpdate),
+				err: awsclient.Wrap(errBoom, errUpdate),
 			},
 		},
 		"ClientUpdateTagsError": {
@@ -415,7 +416,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  certificate(withTags()),
-				err: errors.Wrap(errBoom, errAddTagsFailed),
+				err: awsclient.Wrap(errBoom, errAddTagsFailed),
 			},
 		},
 	}
@@ -487,7 +488,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  certificate(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 		"ResourceDoesNotExist": {

--- a/pkg/controller/acmpca/certificateauthority/controller_test.go
+++ b/pkg/controller/acmpca/certificateauthority/controller_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	v1alpha1 "github.com/crossplane/provider-aws/apis/acmpca/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	acmpca "github.com/crossplane/provider-aws/pkg/clients/acmpca"
 	"github.com/crossplane/provider-aws/pkg/clients/acmpca/fake"
 )
@@ -194,7 +195,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  certificateAuthority(withCertificateAuthorityArn()),
-				err: errors.Wrap(errBoom, errGet),
+				err: awsclient.Wrap(errBoom, errGet),
 			},
 		},
 	}
@@ -285,7 +286,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  certificateAuthority(),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -435,7 +436,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  certificateAuthority(withCertificateAuthorityStatus()),
-				err: errors.Wrap(errBoom, errCertificateAuthority),
+				err: awsclient.Wrap(errBoom, errCertificateAuthority),
 			},
 		},
 	}
@@ -541,7 +542,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  certificateAuthority(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 		"ResourceDoesNotExist": {
@@ -567,7 +568,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  certificateAuthority(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(awserr.New(awsacmpca.ErrCodeResourceNotFoundException, "", nil), errDelete),
+				err: awsclient.Wrap(awserr.New(awsacmpca.ErrCodeResourceNotFoundException, "", nil), errDelete),
 			},
 		},
 	}

--- a/pkg/controller/acmpca/certificateauthoritypermission/controller.go
+++ b/pkg/controller/acmpca/certificateauthoritypermission/controller.go
@@ -32,7 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplane/provider-aws/apis/acmpca/v1alpha1"
-	awscommon "github.com/crossplane/provider-aws/pkg/clients"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/acmpca"
 )
 
@@ -72,7 +72,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if !ok {
 		return nil, errors.New(errUnexpectedObject)
 	}
-	cfg, err := awscommon.GetConfig(ctx, c.client, mg, cr.Spec.ForProvider.Region)
+	cfg, err := awsclient.GetConfig(ctx, c.client, mg, cr.Spec.ForProvider.Region)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 		CertificateAuthorityArn: cr.Spec.ForProvider.CertificateAuthorityARN,
 	}).Send(ctx)
 	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(acmpca.IsErrorNotFound, err), errGet)
+		return managed.ExternalObservation{}, awsclient.Wrap(resource.Ignore(acmpca.IsErrorNotFound, err), errGet)
 	}
 	if len(response.Permissions) == 0 {
 		return managed.ExternalObservation{
@@ -118,7 +118,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		CertificateAuthorityArn: cr.Spec.ForProvider.CertificateAuthorityARN,
 		Principal:               aws.String(principal),
 	}).Send(ctx)
-	return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
+	return managed.ExternalCreation{}, awsclient.Wrap(err, errCreate)
 
 }
 
@@ -139,5 +139,5 @@ func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
 		Principal:               aws.String(principal),
 	}).Send(ctx)
 
-	return errors.Wrap(resource.Ignore(acmpca.IsErrorNotFound, err), errDelete)
+	return awsclient.Wrap(resource.Ignore(acmpca.IsErrorNotFound, err), errDelete)
 }

--- a/pkg/controller/acmpca/certificateauthoritypermission/controller_test.go
+++ b/pkg/controller/acmpca/certificateauthoritypermission/controller_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	v1alpha1 "github.com/crossplane/provider-aws/apis/acmpca/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	acmpca "github.com/crossplane/provider-aws/pkg/clients/acmpca"
 	"github.com/crossplane/provider-aws/pkg/clients/acmpca/fake"
 )
@@ -126,7 +127,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  certificateAuthorityPermission(),
-				err: errors.Wrap(errBoom, errGet),
+				err: awsclient.Wrap(errBoom, errGet),
 			},
 		},
 	}
@@ -204,7 +205,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  certificateAuthorityPermission(withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -296,7 +297,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  certificateAuthorityPermission(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 		"ResourceDoesNotExist": {
@@ -320,7 +321,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  certificateAuthorityPermission(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(awserr.New(awsacmpca.ErrCodeResourceNotFoundException, "", nil), errDelete),
+				err: awsclient.Wrap(awserr.New(awsacmpca.ErrCodeResourceNotFoundException, "", nil), errDelete),
 			},
 		},
 	}

--- a/pkg/controller/cache/cachesubnetgroup/controller_test.go
+++ b/pkg/controller/cache/cachesubnetgroup/controller_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/cache/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/elasticache"
 	"github.com/crossplane/provider-aws/pkg/clients/elasticache/fake"
 )
@@ -147,7 +148,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  csg(),
-				err: errors.Wrap(errBoom, errDescribeSubnetGroup),
+				err: awsclient.Wrap(errBoom, errDescribeSubnetGroup),
 			},
 		},
 	}
@@ -221,7 +222,7 @@ func TestCreate(t *testing.T) {
 					SubnetIDs:   []string{subnetID},
 					Description: sgDescription,
 				})), withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreateSubnetGroup),
+				err: awsclient.Wrap(errBoom, errCreateSubnetGroup),
 			},
 		},
 	}
@@ -295,7 +296,7 @@ func TestUpdate(t *testing.T) {
 					SubnetIDs:   []string{subnetID},
 					Description: sgDescription,
 				}))),
-				err: errors.Wrap(errBoom, errModifySubnetGroup),
+				err: awsclient.Wrap(errBoom, errModifySubnetGroup),
 			},
 		},
 	}
@@ -368,7 +369,7 @@ func TestDelete(t *testing.T) {
 					SubnetIDs:   []string{subnetID},
 					Description: sgDescription,
 				})), withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDeleteSubnetGroup),
+				err: awsclient.Wrap(errBoom, errDeleteSubnetGroup),
 			},
 		},
 	}

--- a/pkg/controller/cache/cluster/controller_test.go
+++ b/pkg/controller/cache/cluster/controller_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/cache/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/elasticache"
 	"github.com/crossplane/provider-aws/pkg/clients/elasticache/fake"
 )
@@ -171,7 +172,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  cluster(),
-				err: errors.Wrap(errBoom, errDescribeCacheCluster),
+				err: awsclient.Wrap(errBoom, errDescribeCacheCluster),
 			},
 		},
 	}
@@ -247,7 +248,7 @@ func TestCreate(t *testing.T) {
 					CacheNodeType: nodeType,
 					NumCacheNodes: 2,
 				}), withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreateCacheCluster),
+				err: awsclient.Wrap(errBoom, errCreateCacheCluster),
 			},
 		},
 	}
@@ -331,7 +332,7 @@ func TestUpdate(t *testing.T) {
 					withStatus(v1alpha1.CacheClusterObservation{
 						CacheClusterStatus: v1alpha1.StatusAvailable,
 					})),
-				err: errors.Wrap(errBoom, errModifyCacheCluster),
+				err: awsclient.Wrap(errBoom, errModifyCacheCluster),
 			},
 		},
 		"NotAvailable": {
@@ -417,7 +418,7 @@ func TestDelete(t *testing.T) {
 			want: want{
 				cr: cluster(withExternalName(),
 					withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDeleteCacheCluster),
+				err: awsclient.Wrap(errBoom, errDeleteCacheCluster),
 			},
 		},
 	}

--- a/pkg/controller/cache/managed_test.go
+++ b/pkg/controller/cache/managed_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/cache/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/elasticache/fake"
 )
 
@@ -642,7 +643,7 @@ func TestInitialize(t *testing.T) {
 				kube: &test.MockClient{MockUpdate: test.NewMockUpdateFn(errorBoom)},
 			},
 			want: want{
-				err: errors.Wrap(errorBoom, errUpdateReplicationGroupCR),
+				err: awsclient.Wrap(errorBoom, errUpdateReplicationGroupCR),
 			},
 		},
 	}

--- a/pkg/controller/database/dbsubnetgroup/controller_test.go
+++ b/pkg/controller/database/dbsubnetgroup/controller_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	v1beta1 "github.com/crossplane/provider-aws/apis/database/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	dbsg "github.com/crossplane/provider-aws/pkg/clients/dbsubnetgroup"
 	"github.com/crossplane/provider-aws/pkg/clients/dbsubnetgroup/fake"
 )
@@ -194,7 +195,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  dbSubnetGroup(),
-				err: errors.Wrap(errBoom, errDescribe),
+				err: awsclient.Wrap(errBoom, errDescribe),
 			},
 		},
 		"NotFound": {
@@ -269,7 +270,7 @@ func TestObserve(t *testing.T) {
 				cr: dbSubnetGroup(
 					withDBSubnetGroupDescription(dbSubnetGroupDescription),
 				),
-				err: errors.Wrap(errBoom, errLateInit),
+				err: awsclient.Wrap(errBoom, errLateInit),
 			},
 		},
 	}
@@ -333,7 +334,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  dbSubnetGroup(withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -409,7 +410,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  dbSubnetGroup(),
-				err: errors.Wrap(errBoom, errUpdate),
+				err: awsclient.Wrap(errBoom, errUpdate),
 			},
 		},
 		"SuccessfulWithTags": {
@@ -536,7 +537,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  dbSubnetGroup(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 	}

--- a/pkg/controller/database/rdsinstance_test.go
+++ b/pkg/controller/database/rdsinstance_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/database/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/rds"
 	"github.com/crossplane/provider-aws/pkg/clients/rds/fake"
 )
@@ -211,7 +212,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  instance(),
-				err: errors.Wrap(errBoom, errDescribeFailed),
+				err: awsclient.Wrap(errBoom, errDescribeFailed),
 			},
 		},
 		"NotFound": {
@@ -288,7 +289,7 @@ func TestObserve(t *testing.T) {
 				cr: instance(
 					withEngineVersion(&engineVersion),
 				),
-				err: errors.Wrap(errBoom, errKubeUpdateFailed),
+				err: awsclient.Wrap(errBoom, errKubeUpdateFailed),
 			},
 		},
 	}
@@ -423,7 +424,7 @@ func TestCreate(t *testing.T) {
 					withMasterUsername(&masterUsername),
 					withPasswordSecretRef(xpv1.SecretKeySelector{}),
 					withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errGetPasswordSecretFailed),
+				err: awsclient.Wrap(errBoom, errGetPasswordSecretFailed),
 			},
 		},
 		"FailedRequest": {
@@ -439,7 +440,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  instance(withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreateFailed),
+				err: awsclient.Wrap(errBoom, errCreateFailed),
 			},
 		},
 	}
@@ -525,7 +526,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  instance(),
-				err: errors.Wrap(errBoom, errDescribeFailed),
+				err: awsclient.Wrap(errBoom, errDescribeFailed),
 			},
 		},
 		"FailedModify": {
@@ -548,7 +549,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  instance(),
-				err: errors.Wrap(errBoom, errModifyFailed),
+				err: awsclient.Wrap(errBoom, errModifyFailed),
 			},
 		},
 		"FailedAddTags": {
@@ -576,7 +577,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  instance(withTags(map[string]string{"foo": "bar"})),
-				err: errors.Wrap(errBoom, errAddTagsFailed),
+				err: awsclient.Wrap(errBoom, errAddTagsFailed),
 			},
 		},
 	}
@@ -685,7 +686,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  instance(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDeleteFailed),
+				err: awsclient.Wrap(errBoom, errDeleteFailed),
 			},
 		},
 	}
@@ -730,7 +731,7 @@ func TestInitialize(t *testing.T) {
 				kube: &test.MockClient{MockUpdate: test.NewMockUpdateFn(errBoom)},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errKubeUpdateFailed),
+				err: awsclient.Wrap(errBoom, errKubeUpdateFailed),
 			},
 		},
 	}

--- a/pkg/controller/ec2/elasticip/controller_test.go
+++ b/pkg/controller/ec2/elasticip/controller_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/crossplane/provider-aws/apis/ec2/v1alpha1"
 	"github.com/crossplane/provider-aws/apis/ec2/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/ec2"
 	"github.com/crossplane/provider-aws/pkg/clients/ec2/fake"
 )
@@ -183,7 +184,7 @@ func TestObserve(t *testing.T) {
 				cr: elasticIP(withSpec(v1alpha1.ElasticIPParameters{
 					Domain: &domainVpc,
 				}), withExternalName(allocationID)),
-				err: errors.Wrap(errBoom, errDescribe),
+				err: awsclient.Wrap(errBoom, errDescribe),
 			},
 		},
 	}
@@ -285,7 +286,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  elasticIP(withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -356,7 +357,7 @@ func TestUpdate(t *testing.T) {
 				cr: elasticIP(withSpec(v1alpha1.ElasticIPParameters{
 					Domain: &domainVpc,
 				})),
-				err: errors.Wrap(errBoom, errCreateTags),
+				err: awsclient.Wrap(errBoom, errCreateTags),
 			},
 		},
 	}
@@ -438,7 +439,7 @@ func TestRelease(t *testing.T) {
 			},
 			want: want{
 				cr:  elasticIP(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 	}

--- a/pkg/controller/ec2/internetgateway/controller_test.go
+++ b/pkg/controller/ec2/internetgateway/controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/ec2/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/ec2"
 	"github.com/crossplane/provider-aws/pkg/clients/ec2/fake"
 )
@@ -199,7 +200,7 @@ func TestObserve(t *testing.T) {
 					Attachments:       specAttachments(),
 				}),
 					withExternalName(igID)),
-				err: errors.Wrap(errBoom, errDescribe),
+				err: awsclient.Wrap(errBoom, errDescribe),
 			},
 		},
 	}
@@ -280,7 +281,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  ig(withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -425,7 +426,7 @@ func TestUpdate(t *testing.T) {
 				cr: ig(withSpec(v1beta1.InternetGatewayParameters{
 					VPCID: aws.String(anotherVpcID),
 				}), withExternalName(igID)),
-				err: errors.Wrap(errBoom, errDetach),
+				err: awsclient.Wrap(errBoom, errDetach),
 			},
 		},
 	}
@@ -530,7 +531,7 @@ func TestDelete(t *testing.T) {
 					Attachments:       specAttachments(),
 				}), withExternalName(igID),
 					withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDetach),
+				err: awsclient.Wrap(errBoom, errDetach),
 			},
 		},
 		"DeleteFail": {
@@ -558,7 +559,7 @@ func TestDelete(t *testing.T) {
 					Attachments:       specAttachments(),
 				}), withExternalName(igID),
 					withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 	}

--- a/pkg/controller/ec2/natgateway/controller_test.go
+++ b/pkg/controller/ec2/natgateway/controller_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/crossplane/provider-aws/apis/ec2/v1alpha1"
 	"github.com/crossplane/provider-aws/apis/ec2/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/ec2"
 	"github.com/crossplane/provider-aws/pkg/clients/ec2/fake"
 )
@@ -228,7 +229,7 @@ func TestObserve(t *testing.T) {
 			want: want{
 				cr:     nat(withExternalName(natGatewayID)),
 				result: managed.ExternalObservation{},
-				err:    errors.Wrap(errBoom, errDescribe),
+				err:    awsclient.Wrap(errBoom, errDescribe),
 			},
 		},
 		"ErrorMultipleNatAddresses": {
@@ -489,7 +490,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  nat(),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -711,7 +712,7 @@ func TestDelete(t *testing.T) {
 			want: want{
 				cr: nat(withExternalName(natGatewayID),
 					withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 	}

--- a/pkg/controller/ec2/routetable/controller_test.go
+++ b/pkg/controller/ec2/routetable/controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/ec2/v1alpha4"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/ec2"
 	"github.com/crossplane/provider-aws/pkg/clients/ec2/fake"
 )
@@ -150,7 +151,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  rt(withExternalName(rtID)),
-				err: errors.Wrap(errBoom, errDescribe),
+				err: awsclient.Wrap(errBoom, errDescribe),
 			},
 		},
 	}
@@ -231,7 +232,7 @@ func TestCreate(t *testing.T) {
 				cr: rt(withSpec(v1alpha4.RouteTableParameters{
 					VPCID: aws.String(vpcID),
 				})),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -346,7 +347,7 @@ func TestUpdate(t *testing.T) {
 					withStatus(v1alpha4.RouteTableObservation{
 						RouteTableID: rtID,
 					})),
-				err: errors.Wrap(errBoom, errCreateRoute),
+				err: awsclient.Wrap(errBoom, errCreateRoute),
 			},
 		},
 	}
@@ -415,7 +416,7 @@ func TestDelete(t *testing.T) {
 				cr: rt(withStatus(v1alpha4.RouteTableObservation{
 					RouteTableID: rtID,
 				}), withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 	}

--- a/pkg/controller/ec2/securitygroup/controller_test.go
+++ b/pkg/controller/ec2/securitygroup/controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/ec2/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/ec2"
 	"github.com/crossplane/provider-aws/pkg/clients/ec2/fake"
 )
@@ -187,7 +188,7 @@ func TestObserve(t *testing.T) {
 					SecurityGroupID: sgID,
 				}),
 					withExternalName(sgID)),
-				err: errors.Wrap(errBoom, errDescribe),
+				err: awsclient.Wrap(errBoom, errDescribe),
 			},
 		},
 	}
@@ -266,7 +267,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  sg(withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 		"RevokeFail": {
@@ -293,7 +294,7 @@ func TestCreate(t *testing.T) {
 				cr: sg(),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errRevokeEgress),
+				err: awsclient.Wrap(errBoom, errRevokeEgress),
 				cr: sg(withExternalName(sgID),
 					withConditions(xpv1.Creating())),
 			},
@@ -406,7 +407,7 @@ func TestUpdate(t *testing.T) {
 					withStatus(v1beta1.SecurityGroupObservation{
 						SecurityGroupID: sgID,
 					})),
-				err: errors.Wrap(errBoom, errAuthorizeIngress),
+				err: awsclient.Wrap(errBoom, errAuthorizeIngress),
 			},
 		},
 	}
@@ -490,7 +491,7 @@ func TestDelete(t *testing.T) {
 				cr: sg(withStatus(v1beta1.SecurityGroupObservation{
 					SecurityGroupID: sgID,
 				}), withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 	}

--- a/pkg/controller/ec2/subnet/controller_test.go
+++ b/pkg/controller/ec2/subnet/controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/ec2/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/ec2"
 	"github.com/crossplane/provider-aws/pkg/clients/ec2/fake"
 )
@@ -182,7 +183,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  subnet(withExternalName(subnetID)),
-				err: errors.Wrap(errBoom, errDescribe),
+				err: awsclient.Wrap(errBoom, errDescribe),
 			},
 		},
 	}
@@ -253,7 +254,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  subnet(),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -419,7 +420,7 @@ func TestDelete(t *testing.T) {
 				cr: subnet(withStatus(v1beta1.SubnetObservation{
 					SubnetID: subnetID,
 				}), withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 	}

--- a/pkg/controller/ec2/vpc/controller_test.go
+++ b/pkg/controller/ec2/vpc/controller_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 
 	"github.com/crossplane/provider-aws/apis/ec2/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/ec2"
 	"github.com/crossplane/provider-aws/pkg/clients/ec2/fake"
 )
@@ -197,7 +198,7 @@ func TestObserve(t *testing.T) {
 					InstanceTenancy: aws.String(tenancyDefault),
 					CIDRBlock:       cidr,
 				}), withExternalName(vpcID)),
-				err: errors.Wrap(errBoom, errDescribe),
+				err: awsclient.Wrap(errBoom, errDescribe),
 			},
 		},
 	}
@@ -270,7 +271,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  vpc(),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -360,7 +361,7 @@ func TestUpdate(t *testing.T) {
 				cr: vpc(withSpec(v1beta1.VPCParameters{
 					InstanceTenancy: aws.String(tenancyDefault),
 				})),
-				err: errors.Wrap(errBoom, errUpdate),
+				err: awsclient.Wrap(errBoom, errUpdate),
 			},
 		},
 	}
@@ -421,7 +422,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  vpc(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 	}

--- a/pkg/controller/ecr/repository/controller_test.go
+++ b/pkg/controller/ecr/repository/controller_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 
 	"github.com/crossplane/provider-aws/apis/ecr/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	ecr "github.com/crossplane/provider-aws/pkg/clients/ecr"
 	"github.com/crossplane/provider-aws/pkg/clients/ecr/fake"
 )
@@ -202,7 +203,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  repository(withSpec(v1alpha1.RepositoryParameters{}), withExternalName(repoName)),
-				err: errors.Wrap(errBoom, errDescribe),
+				err: awsclient.Wrap(errBoom, errDescribe),
 			},
 		},
 		"ListTagsFail": {
@@ -231,7 +232,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  repository(withSpec(v1alpha1.RepositoryParameters{}), withExternalName(repoName)),
-				err: errors.Wrap(errBoom, errListTags),
+				err: awsclient.Wrap(errBoom, errListTags),
 			},
 		},
 	}
@@ -307,7 +308,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  repository(withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -429,7 +430,7 @@ func TestUpdate(t *testing.T) {
 				cr: repository(withSpec(v1alpha1.RepositoryParameters{
 					Tags: []v1alpha1.Tag{testTag},
 				})),
-				err: errors.Wrap(errBoom, errCreateTags),
+				err: awsclient.Wrap(errBoom, errCreateTags),
 			},
 		},
 		"SuccessfulImageMutate": {
@@ -500,7 +501,7 @@ func TestUpdate(t *testing.T) {
 				cr: repository(withSpec(v1alpha1.RepositoryParameters{
 					ImageTagMutability: aws.String(string(awsecr.ImageTagMutabilityMutable)),
 				})),
-				err: errors.Wrap(errBoom, errUpdateMutability),
+				err: awsclient.Wrap(errBoom, errUpdateMutability),
 			},
 		},
 		"SuccessfulScanConfig": {
@@ -571,7 +572,7 @@ func TestUpdate(t *testing.T) {
 				cr: repository(withSpec(v1alpha1.RepositoryParameters{
 					ImageScanningConfiguration: &imageScanConfigTrue,
 				})),
-				err: errors.Wrap(errBoom, errUpdateScan),
+				err: awsclient.Wrap(errBoom, errUpdateScan),
 			},
 		},
 	}
@@ -632,7 +633,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  repository(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 	}

--- a/pkg/controller/eks/cluster_test.go
+++ b/pkg/controller/eks/cluster_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/eks/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/eks"
 	"github.com/crossplane/provider-aws/pkg/clients/eks/fake"
 )
@@ -191,7 +192,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  cluster(),
-				err: errors.Wrap(errBoom, errDescribeFailed),
+				err: awsclient.Wrap(errBoom, errDescribeFailed),
 			},
 		},
 		"NotFound": {
@@ -335,7 +336,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  cluster(withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreateFailed),
+				err: awsclient.Wrap(errBoom, errCreateFailed),
 			},
 		},
 	}
@@ -492,7 +493,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  cluster(),
-				err: errors.Wrap(errBoom, errDescribeFailed),
+				err: awsclient.Wrap(errBoom, errDescribeFailed),
 			},
 		},
 		"FailedUpdateConfig": {
@@ -515,7 +516,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  cluster(),
-				err: errors.Wrap(errBoom, errUpdateConfigFailed),
+				err: awsclient.Wrap(errBoom, errUpdateConfigFailed),
 			},
 		},
 		"FailedUpdateVersion": {
@@ -538,7 +539,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  cluster(withVersion(&version)),
-				err: errors.Wrap(errBoom, errUpdateVersionFailed),
+				err: awsclient.Wrap(errBoom, errUpdateVersionFailed),
 			},
 		},
 		"FailedRemoveTags": {
@@ -563,7 +564,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  cluster(),
-				err: errors.Wrap(errBoom, errAddTagsFailed),
+				err: awsclient.Wrap(errBoom, errAddTagsFailed),
 			},
 		},
 		"FailedAddTags": {
@@ -586,7 +587,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  cluster(withTags(map[string]string{"foo": "bar"})),
-				err: errors.Wrap(errBoom, errAddTagsFailed),
+				err: awsclient.Wrap(errBoom, errAddTagsFailed),
 			},
 		},
 	}
@@ -671,7 +672,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  cluster(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDeleteFailed),
+				err: awsclient.Wrap(errBoom, errDeleteFailed),
 			},
 		},
 	}

--- a/pkg/controller/eks/fargateprofile/controller_test.go
+++ b/pkg/controller/eks/fargateprofile/controller_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/eks/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/eks"
 	"github.com/crossplane/provider-aws/pkg/clients/eks/fake"
 )
@@ -160,7 +161,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  fargateProfile(),
-				err: errors.Wrap(errBoom, errDescribeFailed),
+				err: awsclient.Wrap(errBoom, errDescribeFailed),
 			},
 		},
 		"NotFound": {
@@ -280,7 +281,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  fargateProfile(withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreateFailed),
+				err: awsclient.Wrap(errBoom, errCreateFailed),
 			},
 		},
 	}
@@ -382,7 +383,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  fargateProfile(),
-				err: errors.Wrap(errBoom, errAddTagsFailed),
+				err: awsclient.Wrap(errBoom, errAddTagsFailed),
 			},
 		},
 		"FailedAddTags": {
@@ -405,7 +406,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  fargateProfile(withTags(map[string]string{"foo": "bar"})),
-				err: errors.Wrap(errBoom, errAddTagsFailed),
+				err: awsclient.Wrap(errBoom, errAddTagsFailed),
 			},
 		},
 	}
@@ -490,7 +491,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  fargateProfile(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDeleteFailed),
+				err: awsclient.Wrap(errBoom, errDeleteFailed),
 			},
 		},
 	}

--- a/pkg/controller/eks/nodegroup/controller_test.go
+++ b/pkg/controller/eks/nodegroup/controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/eks/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/eks"
 	"github.com/crossplane/provider-aws/pkg/clients/eks/fake"
 )
@@ -188,7 +189,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  nodeGroup(),
-				err: errors.Wrap(errBoom, errDescribeFailed),
+				err: awsclient.Wrap(errBoom, errDescribeFailed),
 			},
 		},
 		"NotFound": {
@@ -331,7 +332,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  nodeGroup(withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreateFailed),
+				err: awsclient.Wrap(errBoom, errCreateFailed),
 			},
 		},
 	}
@@ -486,7 +487,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  nodeGroup(),
-				err: errors.Wrap(errBoom, errDescribeFailed),
+				err: awsclient.Wrap(errBoom, errDescribeFailed),
 			},
 		},
 		"FailedUpdateConfig": {
@@ -509,7 +510,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  nodeGroup(),
-				err: errors.Wrap(errBoom, errUpdateConfigFailed),
+				err: awsclient.Wrap(errBoom, errUpdateConfigFailed),
 			},
 		},
 		"FailedUpdateVersion": {
@@ -532,7 +533,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  nodeGroup(withVersion(&version)),
-				err: errors.Wrap(errBoom, errUpdateVersionFailed),
+				err: awsclient.Wrap(errBoom, errUpdateVersionFailed),
 			},
 		},
 		"FailedRemoveTags": {
@@ -557,7 +558,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  nodeGroup(),
-				err: errors.Wrap(errBoom, errAddTagsFailed),
+				err: awsclient.Wrap(errBoom, errAddTagsFailed),
 			},
 		},
 		"FailedAddTags": {
@@ -580,7 +581,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  nodeGroup(withTags(map[string]string{"foo": "bar"})),
-				err: errors.Wrap(errBoom, errAddTagsFailed),
+				err: awsclient.Wrap(errBoom, errAddTagsFailed),
 			},
 		},
 	}
@@ -665,7 +666,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  nodeGroup(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDeleteFailed),
+				err: awsclient.Wrap(errBoom, errDeleteFailed),
 			},
 		},
 	}

--- a/pkg/controller/elasticloadbalancing/elb/controller_test.go
+++ b/pkg/controller/elasticloadbalancing/elb/controller_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/elasticloadbalancing/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/elasticloadbalancing/elb"
 	"github.com/crossplane/provider-aws/pkg/clients/elasticloadbalancing/elb/fake"
 )
@@ -174,7 +175,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  elbResource(withExternalName(elbName)),
-				err: errors.Wrap(errBoom, errDescribe),
+				err: awsclient.Wrap(errBoom, errDescribe),
 			},
 		},
 		"KubeClientError": {
@@ -205,7 +206,7 @@ func TestObserve(t *testing.T) {
 					withSpec(v1alpha1.ELBParameters{
 						AvailabilityZones: availabilityZones,
 					})),
-				err: errors.Wrap(errBoom, errSpecUpdate),
+				err: awsclient.Wrap(errBoom, errSpecUpdate),
 			},
 		},
 		"NotUptoDate": {
@@ -323,7 +324,7 @@ func TestCreate(t *testing.T) {
 						AvailabilityZones: availabilityZones,
 					}),
 					withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -612,7 +613,7 @@ func TestDelete(t *testing.T) {
 			want: want{
 				cr: elbResource(withExternalName(elbName),
 					withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 	}

--- a/pkg/controller/elasticloadbalancing/elbattachment/controller.go
+++ b/pkg/controller/elasticloadbalancing/elbattachment/controller.go
@@ -32,7 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplane/provider-aws/apis/elasticloadbalancing/v1alpha1"
-	awscommon "github.com/crossplane/provider-aws/pkg/clients"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/ec2"
 	"github.com/crossplane/provider-aws/pkg/clients/elasticloadbalancing/elb"
 )
@@ -71,7 +71,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if !ok {
 		return nil, errors.New(errUnexpectedObject)
 	}
-	cfg, err := awscommon.GetConfig(ctx, c.kube, mg, cr.Spec.ForProvider.Region)
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, cr.Spec.ForProvider.Region)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 		LoadBalancerNames: []string{cr.Spec.ForProvider.ELBName},
 	}).Send(ctx)
 	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(elb.IsELBNotFound, err), errDescribe)
+		return managed.ExternalObservation{}, awsclient.Wrap(resource.Ignore(elb.IsELBNotFound, err), errDescribe)
 	}
 
 	// in a successful response, there should be one and only one object
@@ -135,7 +135,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		LoadBalancerName: aws.String(cr.Spec.ForProvider.ELBName),
 	}).Send(ctx)
 
-	return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
+	return managed.ExternalCreation{}, awsclient.Wrap(err, errCreate)
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {
@@ -155,5 +155,5 @@ func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
 		LoadBalancerName: aws.String(cr.Spec.ForProvider.ELBName),
 	}).Send(ctx)
 
-	return errors.Wrap(resource.Ignore(ec2.IsVPCNotFoundErr, err), errDelete)
+	return awsclient.Wrap(resource.Ignore(ec2.IsVPCNotFoundErr, err), errDelete)
 }

--- a/pkg/controller/elasticloadbalancing/elbattachment/controller_test.go
+++ b/pkg/controller/elasticloadbalancing/elbattachment/controller_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/elasticloadbalancing/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/elasticloadbalancing/elb"
 	"github.com/crossplane/provider-aws/pkg/clients/elasticloadbalancing/elb/fake"
 )
@@ -166,7 +167,7 @@ func TestObserve(t *testing.T) {
 					ELBName:    elbName,
 					InstanceID: instanceID,
 				})),
-				err: errors.Wrap(errBoom, errDescribe),
+				err: awsclient.Wrap(errBoom, errDescribe),
 			},
 		},
 	}
@@ -247,7 +248,7 @@ func TestCreate(t *testing.T) {
 						InstanceID: instanceID,
 					}),
 					withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -311,7 +312,7 @@ func TestDelete(t *testing.T) {
 			want: want{
 				cr: elbAttachmentResource(withExternalName(elbName),
 					withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 	}

--- a/pkg/controller/identity/iamaccesskey/controller_test.go
+++ b/pkg/controller/identity/iamaccesskey/controller_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/identity/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/iam"
 	"github.com/crossplane/provider-aws/pkg/clients/iam/fake"
 )
@@ -201,7 +202,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  accesskey(withAccessKey("test")),
-				err: errors.Wrap(errBoom, errList),
+				err: awsclient.Wrap(errBoom, errList),
 			},
 		},
 	}
@@ -291,7 +292,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  accesskey(),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -363,7 +364,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  accesskey(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 		"ResourceDoesNotExist": {
@@ -446,7 +447,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  accesskey(withStatus(string(activeStatus))),
-				err: errors.Wrap(errBoom, errUpdate),
+				err: awsclient.Wrap(errBoom, errUpdate),
 			},
 		},
 	}

--- a/pkg/controller/identity/iamgroup/controller_test.go
+++ b/pkg/controller/identity/iamgroup/controller_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/identity/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/iam"
 	"github.com/crossplane/provider-aws/pkg/clients/iam/fake"
 )
@@ -137,7 +138,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  group(withExternalName(groupName)),
-				err: errors.Wrap(errBoom, errGet),
+				err: awsclient.Wrap(errBoom, errGet),
 			},
 		},
 	}
@@ -209,7 +210,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  group(withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -338,7 +339,7 @@ func TestDelete(t *testing.T) {
 			want: want{
 				cr: group(withExternalName(groupName),
 					withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 	}

--- a/pkg/controller/identity/iamgrouppolicyattachment/controller.go
+++ b/pkg/controller/identity/iamgrouppolicyattachment/controller.go
@@ -32,7 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplane/provider-aws/apis/identity/v1alpha1"
-	awscommon "github.com/crossplane/provider-aws/pkg/clients"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/iam"
 )
 
@@ -68,7 +68,7 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awscommon.GetConfig(ctx, c.kube, mg, awscommon.GlobalRegion)
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 		GroupName: &cr.Spec.ForProvider.GroupName,
 	}).Send(ctx)
 	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errGet)
+		return managed.ExternalObservation{}, awsclient.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errGet)
 	}
 
 	var attachedPolicyObject *awsiam.AttachedPolicy
@@ -132,7 +132,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		GroupName: &cr.Spec.ForProvider.GroupName,
 	}).Send(ctx)
 
-	return managed.ExternalCreation{}, errors.Wrap(err, errAttach)
+	return managed.ExternalCreation{}, awsclient.Wrap(err, errAttach)
 }
 
 func (e *external) Update(_ context.Context, _ resource.Managed) (managed.ExternalUpdate, error) {
@@ -159,5 +159,5 @@ func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
 		return nil
 	}
 
-	return errors.Wrap(err, errDetach)
+	return awsclient.Wrap(err, errDetach)
 }

--- a/pkg/controller/identity/iamgrouppolicyattachment/controller_test.go
+++ b/pkg/controller/identity/iamgrouppolicyattachment/controller_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/identity/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/iam"
 	"github.com/crossplane/provider-aws/pkg/clients/iam/fake"
 )
@@ -153,7 +154,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  groupPolicy(withGroupName(groupName)),
-				err: errors.Wrap(errBoom, errGet),
+				err: awsclient.Wrap(errBoom, errGet),
 			},
 		},
 	}
@@ -232,7 +233,7 @@ func TestCreate(t *testing.T) {
 				cr: groupPolicy(withGroupName(groupName),
 					withSpecPolicyArn(policyArn),
 					withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errAttach),
+				err: awsclient.Wrap(errBoom, errAttach),
 			},
 		},
 	}
@@ -310,7 +311,7 @@ func TestDelete(t *testing.T) {
 				cr: groupPolicy(withGroupName(groupName),
 					withSpecPolicyArn(policyArn),
 					withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDetach),
+				err: awsclient.Wrap(errBoom, errDetach),
 			},
 		},
 		"ResourceDoesNotExist": {
@@ -326,7 +327,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  groupPolicy(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errors.New(errGet), errDetach),
+				err: awsclient.Wrap(errors.New(errGet), errDetach),
 			},
 		},
 	}

--- a/pkg/controller/identity/iamgroupusermembership/controller.go
+++ b/pkg/controller/identity/iamgroupusermembership/controller.go
@@ -32,7 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplane/provider-aws/apis/identity/v1alpha1"
-	awscommon "github.com/crossplane/provider-aws/pkg/clients"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/iam"
 )
 
@@ -68,7 +68,7 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awscommon.GetConfig(ctx, c.kube, mg, awscommon.GlobalRegion)
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 		UserName: &cr.Spec.ForProvider.UserName,
 	}).Send(ctx)
 	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, errGet)
+		return managed.ExternalObservation{}, awsclient.Wrap(err, errGet)
 	}
 
 	var attachedGroupObject *awsiam.Group
@@ -132,7 +132,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		UserName:  &cr.Spec.ForProvider.UserName,
 	}).Send(ctx)
 
-	return managed.ExternalCreation{}, errors.Wrap(err, errAdd)
+	return managed.ExternalCreation{}, awsclient.Wrap(err, errAdd)
 }
 
 func (e *external) Update(_ context.Context, _ resource.Managed) (managed.ExternalUpdate, error) {
@@ -155,5 +155,5 @@ func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
 		UserName:  &cr.Spec.ForProvider.UserName,
 	}).Send(ctx)
 
-	return errors.Wrap(err, errRemove)
+	return awsclient.Wrap(err, errRemove)
 }

--- a/pkg/controller/identity/iamgroupusermembership/controller_test.go
+++ b/pkg/controller/identity/iamgroupusermembership/controller_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/identity/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/iam"
 	"github.com/crossplane/provider-aws/pkg/clients/iam/fake"
 )
@@ -154,7 +155,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  userGroup(withGroupName(groupName)),
-				err: errors.Wrap(errBoom, errGet),
+				err: awsclient.Wrap(errBoom, errGet),
 			},
 		},
 	}
@@ -233,7 +234,7 @@ func TestCreate(t *testing.T) {
 				cr: userGroup(withGroupName(groupName),
 					withSpecUserName(userName),
 					withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errAdd),
+				err: awsclient.Wrap(errBoom, errAdd),
 			},
 		},
 	}
@@ -311,7 +312,7 @@ func TestDelete(t *testing.T) {
 				cr: userGroup(withGroupName(userName),
 					withSpecUserName(userName),
 					withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errRemove),
+				err: awsclient.Wrap(errBoom, errRemove),
 			},
 		},
 		"ResourceDoesNotExist": {
@@ -327,7 +328,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  userGroup(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errors.New(errRemove), errRemove),
+				err: awsclient.Wrap(errors.New(errRemove), errRemove),
 			},
 		},
 	}

--- a/pkg/controller/identity/iampolicy/controller_test.go
+++ b/pkg/controller/identity/iampolicy/controller_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/identity/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/iam"
 	"github.com/crossplane/provider-aws/pkg/clients/iam/fake"
 )
@@ -160,7 +161,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  policy(withExterName(arn)),
-				err: errors.Wrap(errBoom, errGet),
+				err: awsclient.Wrap(errBoom, errGet),
 			},
 		},
 		"EmptySpecPolicy": {
@@ -278,7 +279,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  policy(),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -360,7 +361,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  policy(withExterName(arn)),
-				err: errors.Wrap(errBoom, errUpdate),
+				err: awsclient.Wrap(errBoom, errUpdate),
 			},
 		},
 		"CreateVersionError": {
@@ -386,7 +387,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  policy(withExterName(arn)),
-				err: errors.Wrap(errBoom, errUpdate),
+				err: awsclient.Wrap(errBoom, errUpdate),
 			},
 		},
 	}
@@ -479,7 +480,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  policy(withExterName(arn)),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 		"DeletePolicyError": {
@@ -506,7 +507,7 @@ func TestDelete(t *testing.T) {
 			want: want{
 				cr: policy(withExterName(arn),
 					withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 	}

--- a/pkg/controller/identity/iamrole/controller.go
+++ b/pkg/controller/identity/iamrole/controller.go
@@ -34,7 +34,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplane/provider-aws/apis/identity/v1beta1"
-	awscommon "github.com/crossplane/provider-aws/pkg/clients"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/iam"
 )
 
@@ -72,7 +72,7 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awscommon.GetConfig(ctx, c.kube, mg, awscommon.GlobalRegion)
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 	}).Send(ctx)
 
 	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errGet)
+		return managed.ExternalObservation{}, awsclient.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errGet)
 	}
 
 	if observed.Role == nil {
@@ -149,7 +149,7 @@ func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.Ex
 	}).Send(ctx)
 
 	if err != nil {
-		return managed.ExternalUpdate{}, errors.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errGet)
+		return managed.ExternalUpdate{}, awsclient.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errGet)
 	}
 
 	if observed.Role == nil {
@@ -166,7 +166,7 @@ func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.Ex
 		}).Send(ctx)
 
 		if err != nil {
-			return managed.ExternalUpdate{}, errors.Wrap(err, errUpdate)
+			return managed.ExternalUpdate{}, awsclient.Wrap(err, errUpdate)
 		}
 	}
 
@@ -177,7 +177,7 @@ func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.Ex
 		}).Send(ctx)
 	}
 
-	return managed.ExternalUpdate{}, errors.Wrap(err, errUpdate)
+	return managed.ExternalUpdate{}, awsclient.Wrap(err, errUpdate)
 }
 
 func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
@@ -192,5 +192,5 @@ func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
 		RoleName: aws.String(meta.GetExternalName(cr)),
 	}).Send(ctx)
 
-	return errors.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errDelete)
+	return awsclient.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errDelete)
 }

--- a/pkg/controller/identity/iamrole/controller_test.go
+++ b/pkg/controller/identity/iamrole/controller_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	v1beta1 "github.com/crossplane/provider-aws/apis/identity/v1beta1"
-	awsclients "github.com/crossplane/provider-aws/pkg/clients"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/iam"
 	"github.com/crossplane/provider-aws/pkg/clients/iam/fake"
 )
@@ -77,7 +77,7 @@ func withRoleName(s *string) roleModifier {
 
 func withPolicy() roleModifier {
 	return func(r *v1beta1.IAMRole) {
-		p, err := awsclients.CompactAndEscapeJSON(policy)
+		p, err := awsclient.CompactAndEscapeJSON(policy)
 		if err != nil {
 			return
 		}
@@ -156,7 +156,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  role(withRoleName(&roleName)),
-				err: errors.Wrap(errBoom, errGet),
+				err: awsclient.Wrap(errBoom, errGet),
 			},
 		},
 		"ResourceDoesNotExist": {
@@ -245,7 +245,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  role(withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -331,7 +331,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  role(withDescription()),
-				err: errors.Wrap(errBoom, errUpdate),
+				err: awsclient.Wrap(errBoom, errUpdate),
 			},
 		},
 		"ClientUpdatePolicyError": {
@@ -359,7 +359,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  role(withPolicy()),
-				err: errors.Wrap(errBoom, errUpdate),
+				err: awsclient.Wrap(errBoom, errUpdate),
 			},
 		},
 	}
@@ -431,7 +431,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  role(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 		"ResourceDoesNotExist": {

--- a/pkg/controller/identity/iamrolepolicyattachment/controller.go
+++ b/pkg/controller/identity/iamrolepolicyattachment/controller.go
@@ -33,7 +33,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplane/provider-aws/apis/identity/v1beta1"
-	awscommon "github.com/crossplane/provider-aws/pkg/clients"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/iam"
 )
 
@@ -69,7 +69,7 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awscommon.GetConfig(ctx, c.kube, mg, awscommon.GlobalRegion)
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 		RoleName: aws.String(cr.Spec.ForProvider.RoleName),
 	}).Send(ctx)
 	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errGet)
+		return managed.ExternalObservation{}, awsclient.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errGet)
 	}
 
 	var attachedPolicyObject *awsiam.AttachedPolicy
@@ -139,7 +139,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		RoleName:  aws.String(cr.Spec.ForProvider.RoleName),
 	}).Send(ctx)
 
-	return managed.ExternalCreation{}, errors.Wrap(err, errAttach)
+	return managed.ExternalCreation{}, awsclient.Wrap(err, errAttach)
 }
 
 func (e *external) Update(_ context.Context, _ resource.Managed) (managed.ExternalUpdate, error) {
@@ -164,5 +164,5 @@ func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
 		return nil
 	}
 
-	return errors.Wrap(err, errDetach)
+	return awsclient.Wrap(err, errDetach)
 }

--- a/pkg/controller/identity/iamrolepolicyattachment/controller_test.go
+++ b/pkg/controller/identity/iamrolepolicyattachment/controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	v1beta1 "github.com/crossplane/provider-aws/apis/identity/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/iam"
 	"github.com/crossplane/provider-aws/pkg/clients/iam/fake"
 )
@@ -138,7 +139,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  rolePolicy(withRoleName(&roleName)),
-				err: errors.Wrap(errBoom, errGet),
+				err: awsclient.Wrap(errBoom, errGet),
 			},
 		},
 		"ResourceDoesNotExist": {
@@ -232,7 +233,7 @@ func TestCreate(t *testing.T) {
 				cr: rolePolicy(withRoleName(&roleName),
 					withSpecPolicyArn(&specPolicyArn),
 					withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errAttach),
+				err: awsclient.Wrap(errBoom, errAttach),
 			},
 		},
 	}
@@ -365,7 +366,7 @@ func TestDelete(t *testing.T) {
 				cr: rolePolicy(withRoleName(&roleName),
 					withSpecPolicyArn(&specPolicyArn),
 					withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDetach),
+				err: awsclient.Wrap(errBoom, errDetach),
 			},
 		},
 		"ResourceDoesNotExist": {

--- a/pkg/controller/identity/iamuser/controller.go
+++ b/pkg/controller/identity/iamuser/controller.go
@@ -34,7 +34,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplane/provider-aws/apis/identity/v1alpha1"
-	awscommon "github.com/crossplane/provider-aws/pkg/clients"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/iam"
 )
 
@@ -71,7 +71,7 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awscommon.GetConfig(ctx, c.kube, mg, awscommon.GlobalRegion)
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 	}).Send(ctx)
 
 	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errGet)
+		return managed.ExternalObservation{}, awsclient.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errGet)
 	}
 
 	if observed.User == nil {
@@ -137,7 +137,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		Tags:                iam.BuildIAMTags(cr.Spec.ForProvider.Tags),
 		UserName:            aws.String(meta.GetExternalName(cr)),
 	}).Send(ctx)
-	return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
+	return managed.ExternalCreation{}, awsclient.Wrap(err, errCreate)
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {
@@ -151,7 +151,7 @@ func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.Ex
 		UserName: aws.String(meta.GetExternalName(cr)),
 	}).Send(ctx)
 
-	return managed.ExternalUpdate{}, errors.Wrap(err, errUpdate)
+	return managed.ExternalUpdate{}, awsclient.Wrap(err, errUpdate)
 }
 
 func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
@@ -166,5 +166,5 @@ func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
 		UserName: aws.String(meta.GetExternalName(cr)),
 	}).Send(ctx)
 
-	return errors.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errDelete)
+	return awsclient.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errDelete)
 }

--- a/pkg/controller/identity/iamuser/controller_test.go
+++ b/pkg/controller/identity/iamuser/controller_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/identity/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/iam"
 	"github.com/crossplane/provider-aws/pkg/clients/iam/fake"
 )
@@ -124,7 +125,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  user(withExternalName(userName)),
-				err: errors.Wrap(errBoom, errGet),
+				err: awsclient.Wrap(errBoom, errGet),
 			},
 		},
 	}
@@ -198,7 +199,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  user(withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -327,7 +328,7 @@ func TestDelete(t *testing.T) {
 			want: want{
 				cr: user(withExternalName(userName),
 					withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 	}

--- a/pkg/controller/identity/iamuserpolicyattachment/controller.go
+++ b/pkg/controller/identity/iamuserpolicyattachment/controller.go
@@ -33,7 +33,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplane/provider-aws/apis/identity/v1alpha1"
-	awscommon "github.com/crossplane/provider-aws/pkg/clients"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/iam"
 )
 
@@ -70,7 +70,7 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awscommon.GetConfig(ctx, c.kube, mg, awscommon.GlobalRegion)
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 		UserName: aws.String(cr.Spec.ForProvider.UserName),
 	}).Send(ctx)
 	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errGet)
+		return managed.ExternalObservation{}, awsclient.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errGet)
 	}
 
 	var attachedPolicyObject *awsiam.AttachedPolicy
@@ -142,7 +142,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		UserName:  aws.String(cr.Spec.ForProvider.UserName),
 	}).Send(ctx)
 
-	return managed.ExternalCreation{}, errors.Wrap(err, errAttach)
+	return managed.ExternalCreation{}, awsclient.Wrap(err, errAttach)
 }
 
 func (e *external) Update(_ context.Context, _ resource.Managed) (managed.ExternalUpdate, error) {
@@ -165,5 +165,5 @@ func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
 		UserName:  aws.String(cr.Spec.ForProvider.UserName),
 	}).Send(ctx)
 
-	return errors.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errDetach)
+	return awsclient.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errDetach)
 }

--- a/pkg/controller/identity/iamuserpolicyattachment/controller_test.go
+++ b/pkg/controller/identity/iamuserpolicyattachment/controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/identity/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/iam"
 	"github.com/crossplane/provider-aws/pkg/clients/iam/fake"
 )
@@ -154,7 +155,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  userPolicy(withUserName(userName)),
-				err: errors.Wrap(errBoom, errGet),
+				err: awsclient.Wrap(errBoom, errGet),
 			},
 		},
 	}
@@ -233,7 +234,7 @@ func TestCreate(t *testing.T) {
 				cr: userPolicy(withUserName(userName),
 					withSpecPolicyArn(policyArn),
 					withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errAttach),
+				err: awsclient.Wrap(errBoom, errAttach),
 			},
 		},
 	}
@@ -311,7 +312,7 @@ func TestDelete(t *testing.T) {
 				cr: userPolicy(withUserName(userName),
 					withSpecPolicyArn(policyArn),
 					withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDetach),
+				err: awsclient.Wrap(errBoom, errDetach),
 			},
 		},
 		"ResourceDoesNotExist": {

--- a/pkg/controller/notification/snssubscription/controller_test.go
+++ b/pkg/controller/notification/snssubscription/controller_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/notification/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/sns"
 	"github.com/crossplane/provider-aws/pkg/clients/sns/fake"
 )
@@ -164,7 +165,7 @@ func TestCreate(t *testing.T) {
 			want: want{
 				cr: subscription(
 					withSubARN(&subName)),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -282,7 +283,7 @@ func TestUpdate(t *testing.T) {
 				cr: subscription(
 					withSubARN(&subName),
 				),
-				err: errors.Wrap(errBoom, errUpdate),
+				err: awsclient.Wrap(errBoom, errUpdate),
 			},
 		},
 		"ClientSetSubscriptionAttributeError": {
@@ -320,7 +321,7 @@ func TestUpdate(t *testing.T) {
 				cr: subscription(
 					withSubARN(&subName),
 				),
-				err: errors.Wrap(errBoom, errUpdate),
+				err: awsclient.Wrap(errBoom, errUpdate),
 			},
 		},
 	}
@@ -408,7 +409,7 @@ func TestDelete(t *testing.T) {
 					withSubARN(&subName),
 					withConditions(xpv1.Deleting()),
 				),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 		"ResourceDoesNotExist": {

--- a/pkg/controller/notification/snstopic/controller_test.go
+++ b/pkg/controller/notification/snstopic/controller_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/notification/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/sns"
 	"github.com/crossplane/provider-aws/pkg/clients/sns/fake"
 )
@@ -173,7 +174,7 @@ func TestObserve(t *testing.T) {
 					ResourceExists:   false,
 					ResourceUpToDate: false,
 				},
-				err: errors.Wrap(errBoom, errGetTopicAttr),
+				err: awsclient.Wrap(errBoom, errGetTopicAttr),
 			},
 		},
 		"ClientGetTopicAttributesError": {
@@ -200,7 +201,7 @@ func TestObserve(t *testing.T) {
 					ResourceExists:   false,
 					ResourceUpToDate: false,
 				},
-				err: errors.Wrap(errBoom, errGetTopicAttr),
+				err: awsclient.Wrap(errBoom, errGetTopicAttr),
 			},
 		},
 		"ValidInputResourceNotUpToDate": {
@@ -333,7 +334,7 @@ func TestCreate(t *testing.T) {
 				cr: topic(
 					withDisplayName(&topicDisplayName),
 					withTopicName(&topicName)),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -446,7 +447,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  topic(withTopicName(&topicName)),
-				err: errors.Wrap(errBoom, errGetTopicAttr),
+				err: awsclient.Wrap(errBoom, errGetTopicAttr),
 			},
 		},
 		"ClientSetTopicAttributeError": {
@@ -481,7 +482,7 @@ func TestUpdate(t *testing.T) {
 					withDisplayName(&topicDisplayName),
 					withTopicName(&topicName),
 				),
-				err: errors.Wrap(errBoom, errUpdate),
+				err: awsclient.Wrap(errBoom, errUpdate),
 			},
 		},
 	}
@@ -561,7 +562,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  topic(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 		"ResourceDoesNotExist": {

--- a/pkg/controller/redshift/controller_test.go
+++ b/pkg/controller/redshift/controller_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/redshift/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/redshift"
 	"github.com/crossplane/provider-aws/pkg/clients/redshift/fake"
 )
@@ -213,7 +214,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  cluster(),
-				err: errors.Wrap(errBoom, errDescribeFailed),
+				err: awsclient.Wrap(errBoom, errDescribeFailed),
 			},
 		},
 		"NotFound": {
@@ -344,7 +345,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  cluster(withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreateFailed),
+				err: awsclient.Wrap(errBoom, errCreateFailed),
 			},
 		},
 	}
@@ -428,7 +429,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  cluster(),
-				err: errors.Wrap(errBoom, errDescribeFailed),
+				err: awsclient.Wrap(errBoom, errDescribeFailed),
 			},
 		},
 		"FailedModify": {
@@ -451,7 +452,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  cluster(),
-				err: errors.Wrap(errBoom, errModifyFailed),
+				err: awsclient.Wrap(errBoom, errModifyFailed),
 			},
 		},
 	}
@@ -572,7 +573,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  cluster(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDeleteFailed),
+				err: awsclient.Wrap(errBoom, errDeleteFailed),
 			},
 		},
 	}

--- a/pkg/controller/route53/hostedzone/controller_test.go
+++ b/pkg/controller/route53/hostedzone/controller_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/route53/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/hostedzone"
 	"github.com/crossplane/provider-aws/pkg/clients/hostedzone/fake"
 )
@@ -292,7 +293,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  instance(),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -435,7 +436,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  instance(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 		"ResourceDoesNotExist": {

--- a/pkg/controller/route53/resourcerecordset/controller_test.go
+++ b/pkg/controller/route53/resourcerecordset/controller_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/route53/v1alpha1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/resourcerecordset"
 	"github.com/crossplane/provider-aws/pkg/clients/resourcerecordset/fake"
 )
@@ -258,7 +259,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  instance(withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -321,7 +322,7 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr:  instance(),
-				err: errors.Wrap(errBoom, errUpdate),
+				err: awsclient.Wrap(errBoom, errUpdate),
 			},
 		},
 	}
@@ -383,7 +384,7 @@ func TestDelete(t *testing.T) {
 			},
 			want: want{
 				cr:  instance(withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 	}

--- a/pkg/controller/s3/bucket/CORSConfig_test.go
+++ b/pkg/controller/s3/bucket/CORSConfig_test.go
@@ -24,10 +24,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
-	aws "github.com/crossplane/provider-aws/pkg/clients"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	clients3 "github.com/crossplane/provider-aws/pkg/clients/s3"
 	"github.com/crossplane/provider-aws/pkg/clients/s3/fake"
 	s3Testing "github.com/crossplane/provider-aws/pkg/controller/s3/testing"
@@ -42,7 +41,7 @@ func generateCORSConfig() *v1beta1.CORSConfiguration {
 			AllowedMethods: []string{"GET"},
 			AllowedOrigins: []string{"test.origin"},
 			ExposeHeaders:  []string{"test.expose"},
-			MaxAgeSeconds:  aws.Int64(10),
+			MaxAgeSeconds:  awsclient.Int64(10),
 		},
 	},
 	}
@@ -55,7 +54,7 @@ func generateAWSCORS() *s3.CORSConfiguration {
 			AllowedMethods: []string{"GET"},
 			AllowedOrigins: []string{"test.origin"},
 			ExposeHeaders:  []string{"test.expose"},
-			MaxAgeSeconds:  aws.Int64(10),
+			MaxAgeSeconds:  awsclient.Int64(10),
 		},
 	},
 	}
@@ -89,7 +88,7 @@ func TestCORSObserve(t *testing.T) {
 			},
 			want: want{
 				status: NeedsUpdate,
-				err:    errors.Wrap(errBoom, corsGetFailed),
+				err:    awsclient.Wrap(errBoom, corsGetFailed),
 			},
 		},
 		"UpdateNeeded": {
@@ -213,7 +212,7 @@ func TestCORSCreateOrUpdate(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, corsPutFailed),
+				err: awsclient.Wrap(errBoom, corsPutFailed),
 			},
 		},
 		"InvalidConfig": {
@@ -284,7 +283,7 @@ func TestCORSDelete(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, corsDeleteFailed),
+				err: awsclient.Wrap(errBoom, corsDeleteFailed),
 			},
 		},
 		"SuccessfulDelete": {

--- a/pkg/controller/s3/bucket/accelerateConfig_test.go
+++ b/pkg/controller/s3/bucket/accelerateConfig_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/s3/fake"
 	s3Testing "github.com/crossplane/provider-aws/pkg/controller/s3/testing"
 )
@@ -68,7 +69,7 @@ func TestAccelerateObserve(t *testing.T) {
 			},
 			want: want{
 				status: NeedsUpdate,
-				err:    errors.Wrap(errBoom, accelGetFailed),
+				err:    awsclient.Wrap(errBoom, accelGetFailed),
 			},
 		},
 		"UpdateNeeded": {
@@ -160,7 +161,7 @@ func TestAccelerateCreateOrUpdate(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, accelPutFailed),
+				err: awsclient.Wrap(errBoom, accelPutFailed),
 			},
 		},
 		"InvalidConfig": {

--- a/pkg/controller/s3/bucket/lifecycleConfig_test.go
+++ b/pkg/controller/s3/bucket/lifecycleConfig_test.go
@@ -25,11 +25,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
-	aws "github.com/crossplane/provider-aws/pkg/clients"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	clients3 "github.com/crossplane/provider-aws/pkg/clients/s3"
 	"github.com/crossplane/provider-aws/pkg/clients/s3/fake"
 	s3Testing "github.com/crossplane/provider-aws/pkg/controller/s3/testing"
@@ -55,27 +54,27 @@ func generateLifecycleConfig() *v1beta1.BucketLifecycleConfiguration {
 				AbortIncompleteMultipartUpload: &v1beta1.AbortIncompleteMultipartUpload{DaysAfterInitiation: 1},
 				Expiration: &v1beta1.LifecycleExpiration{
 					Date:                      &date,
-					Days:                      aws.Int64(days),
-					ExpiredObjectDeleteMarker: aws.Bool(marker),
+					Days:                      awsclient.Int64(days),
+					ExpiredObjectDeleteMarker: awsclient.Bool(marker),
 				},
 				Filter: &v1beta1.LifecycleRuleFilter{
 					And: &v1beta1.LifecycleRuleAndOperator{
-						Prefix: aws.String(prefix),
+						Prefix: awsclient.String(prefix),
 						Tags:   tags,
 					},
-					Prefix: aws.String(prefix),
+					Prefix: awsclient.String(prefix),
 					Tag:    &tag,
 				},
-				ID:                          aws.String(id),
-				NoncurrentVersionExpiration: &v1beta1.NoncurrentVersionExpiration{NoncurrentDays: aws.Int64(days)},
+				ID:                          awsclient.String(id),
+				NoncurrentVersionExpiration: &v1beta1.NoncurrentVersionExpiration{NoncurrentDays: awsclient.Int64(days)},
 				NoncurrentVersionTransitions: []v1beta1.NoncurrentVersionTransition{{
-					NoncurrentDays: aws.Int64(days),
+					NoncurrentDays: awsclient.Int64(days),
 					StorageClass:   storage,
 				}},
 				Status: enabled,
 				Transitions: []v1beta1.Transition{{
 					Date:         &date,
-					Days:         aws.Int64(days),
+					Days:         awsclient.Int64(days),
 					StorageClass: storage,
 				}},
 			},
@@ -87,30 +86,30 @@ func generateAWSLifecycle(sortTag bool) *s3.BucketLifecycleConfiguration {
 	conf := &s3.BucketLifecycleConfiguration{
 		Rules: []s3.LifecycleRule{
 			{
-				AbortIncompleteMultipartUpload: &s3.AbortIncompleteMultipartUpload{DaysAfterInitiation: aws.Int64(1)},
+				AbortIncompleteMultipartUpload: &s3.AbortIncompleteMultipartUpload{DaysAfterInitiation: awsclient.Int64(1)},
 				Expiration: &s3.LifecycleExpiration{
 					Date:                      &awsDate,
-					Days:                      aws.Int64(days),
-					ExpiredObjectDeleteMarker: aws.Bool(marker),
+					Days:                      awsclient.Int64(days),
+					ExpiredObjectDeleteMarker: awsclient.Bool(marker),
 				},
 				Filter: &s3.LifecycleRuleFilter{
 					And: &s3.LifecycleRuleAndOperator{
-						Prefix: aws.String(prefix),
+						Prefix: awsclient.String(prefix),
 						Tags:   awsTags,
 					},
-					Prefix: aws.String(prefix),
+					Prefix: awsclient.String(prefix),
 					Tag:    &awsTag,
 				},
-				ID:                          aws.String(id),
-				NoncurrentVersionExpiration: &s3.NoncurrentVersionExpiration{NoncurrentDays: aws.Int64(days)},
+				ID:                          awsclient.String(id),
+				NoncurrentVersionExpiration: &s3.NoncurrentVersionExpiration{NoncurrentDays: awsclient.Int64(days)},
 				NoncurrentVersionTransitions: []s3.NoncurrentVersionTransition{{
-					NoncurrentDays: aws.Int64(days),
+					NoncurrentDays: awsclient.Int64(days),
 					StorageClass:   s3.TransitionStorageClassOnezoneIa,
 				}},
 				Status: s3.ExpirationStatusEnabled,
 				Transitions: []s3.Transition{{
 					Date:         &awsDate,
-					Days:         aws.Int64(days),
+					Days:         awsclient.Int64(days),
 					StorageClass: s3.TransitionStorageClassOnezoneIa,
 				}},
 			},
@@ -183,7 +182,7 @@ func TestLifecycleObserve(t *testing.T) {
 			},
 			want: want{
 				status: NeedsUpdate,
-				err:    errors.Wrap(errBoom, lifecycleGetFailed),
+				err:    awsclient.Wrap(errBoom, lifecycleGetFailed),
 			},
 		},
 		"UpdateNeeded": {
@@ -307,7 +306,7 @@ func TestLifecycleCreateOrUpdate(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, lifecyclePutFailed),
+				err: awsclient.Wrap(errBoom, lifecyclePutFailed),
 			},
 		},
 		"InvalidConfig": {
@@ -378,7 +377,7 @@ func TestLifecycleDelete(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, lifecycleDeleteFailed),
+				err: awsclient.Wrap(errBoom, lifecycleDeleteFailed),
 			},
 		},
 		"SuccessfulDelete": {

--- a/pkg/controller/s3/bucket/loggingConfig.go
+++ b/pkg/controller/s3/bucket/loggingConfig.go
@@ -23,13 +23,12 @@ import (
 
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
-	aws "github.com/crossplane/provider-aws/pkg/clients"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/s3"
 )
 
@@ -45,9 +44,9 @@ type LoggingConfigurationClient struct {
 
 // LateInitialize is responsible for initializing the resource based on the external value
 func (in *LoggingConfigurationClient) LateInitialize(ctx context.Context, bucket *v1beta1.Bucket) error {
-	external, err := in.client.GetBucketLoggingRequest(&awss3.GetBucketLoggingInput{Bucket: aws.String(meta.GetExternalName(bucket))}).Send(ctx)
+	external, err := in.client.GetBucketLoggingRequest(&awss3.GetBucketLoggingInput{Bucket: awsclient.String(meta.GetExternalName(bucket))}).Send(ctx)
 	if err != nil {
-		return errors.Wrap(err, loggingGetFailed)
+		return awsclient.Wrap(err, loggingGetFailed)
 	}
 	config := bucket.Spec.ForProvider.LoggingConfiguration
 	if external.LoggingEnabled == nil {
@@ -60,8 +59,8 @@ func (in *LoggingConfigurationClient) LateInitialize(ctx context.Context, bucket
 		config = bucket.Spec.ForProvider.LoggingConfiguration
 	}
 	// Late initialize the target Bucket and target prefix
-	config.TargetBucket = aws.LateInitializeStringPtr(config.TargetBucket, external.LoggingEnabled.TargetBucket)
-	config.TargetPrefix = aws.LateInitializeString(config.TargetPrefix, external.LoggingEnabled.TargetPrefix)
+	config.TargetBucket = awsclient.LateInitializeStringPtr(config.TargetBucket, external.LoggingEnabled.TargetBucket)
+	config.TargetPrefix = awsclient.LateInitializeString(config.TargetPrefix, external.LoggingEnabled.TargetPrefix)
 	// If the there is an external target grant list, and the local one does not exist
 	// we create the target grant list
 	if external.LoggingEnabled.TargetGrants != nil && len(config.TargetGrants) == 0 {
@@ -94,7 +93,7 @@ func GenerateAWSLogging(local *v1beta1.LoggingConfiguration) *awss3.LoggingEnabl
 	}
 	output := awss3.LoggingEnabled{
 		TargetBucket: local.TargetBucket,
-		TargetPrefix: aws.String(local.TargetPrefix),
+		TargetPrefix: awsclient.String(local.TargetPrefix),
 	}
 	if local.TargetGrants != nil {
 		output.TargetGrants = make([]awss3.TargetGrant, len(local.TargetGrants))
@@ -118,9 +117,9 @@ func GenerateAWSLogging(local *v1beta1.LoggingConfiguration) *awss3.LoggingEnabl
 
 // Observe checks if the resource exists and if it matches the local configuration
 func (in *LoggingConfigurationClient) Observe(ctx context.Context, bucket *v1beta1.Bucket) (ResourceStatus, error) {
-	external, err := in.client.GetBucketLoggingRequest(&awss3.GetBucketLoggingInput{Bucket: aws.String(meta.GetExternalName(bucket))}).Send(ctx)
+	external, err := in.client.GetBucketLoggingRequest(&awss3.GetBucketLoggingInput{Bucket: awsclient.String(meta.GetExternalName(bucket))}).Send(ctx)
 	if err != nil {
-		return NeedsUpdate, errors.Wrap(err, loggingGetFailed)
+		return NeedsUpdate, awsclient.Wrap(err, loggingGetFailed)
 	}
 	if !cmp.Equal(GenerateAWSLogging(bucket.Spec.ForProvider.LoggingConfiguration), external.LoggingEnabled,
 		cmpopts.IgnoreTypes(&xpv1.Reference{}, &xpv1.Selector{})) {
@@ -132,11 +131,11 @@ func (in *LoggingConfigurationClient) Observe(ctx context.Context, bucket *v1bet
 // GeneratePutBucketLoggingInput creates the input for the PutBucketLogging request for the S3 Client
 func GeneratePutBucketLoggingInput(name string, config *v1beta1.LoggingConfiguration) *awss3.PutBucketLoggingInput {
 	bci := &awss3.PutBucketLoggingInput{
-		Bucket: aws.String(name),
+		Bucket: awsclient.String(name),
 		BucketLoggingStatus: &awss3.BucketLoggingStatus{LoggingEnabled: &awss3.LoggingEnabled{
 			TargetBucket: config.TargetBucket,
 			TargetGrants: make([]awss3.TargetGrant, 0),
-			TargetPrefix: aws.String(config.TargetPrefix),
+			TargetPrefix: awsclient.String(config.TargetPrefix),
 		}},
 	}
 	for _, grant := range config.TargetGrants {
@@ -161,7 +160,7 @@ func (in *LoggingConfigurationClient) CreateOrUpdate(ctx context.Context, bucket
 	}
 	input := GeneratePutBucketLoggingInput(meta.GetExternalName(bucket), bucket.Spec.ForProvider.LoggingConfiguration)
 	_, err := in.client.PutBucketLoggingRequest(input).Send(ctx)
-	return errors.Wrap(err, loggingPutFailed)
+	return awsclient.Wrap(err, loggingPutFailed)
 }
 
 // Delete does nothing because there is no deletion call for logging config.

--- a/pkg/controller/s3/bucket/loggingConfig_test.go
+++ b/pkg/controller/s3/bucket/loggingConfig_test.go
@@ -23,9 +23,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/s3/fake"
 	s3Testing "github.com/crossplane/provider-aws/pkg/controller/s3/testing"
 )
@@ -102,7 +102,7 @@ func TestLoggingObserve(t *testing.T) {
 			},
 			want: want{
 				status: NeedsUpdate,
-				err:    errors.Wrap(errBoom, loggingGetFailed),
+				err:    awsclient.Wrap(errBoom, loggingGetFailed),
 			},
 		},
 		"UpdateNeeded": {
@@ -194,7 +194,7 @@ func TestLoggingCreateOrUpdate(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, loggingPutFailed),
+				err: awsclient.Wrap(errBoom, loggingPutFailed),
 			},
 		},
 		"InvalidConfig": {

--- a/pkg/controller/s3/bucket/notificationConfig_test.go
+++ b/pkg/controller/s3/bucket/notificationConfig_test.go
@@ -23,9 +23,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/s3/fake"
 	s3Testing "github.com/crossplane/provider-aws/pkg/controller/s3/testing"
 )
@@ -143,7 +143,7 @@ func TestNotificationObserve(t *testing.T) {
 			},
 			want: want{
 				status: NeedsUpdate,
-				err:    errors.Wrap(errBoom, notificationGetFailed),
+				err:    awsclient.Wrap(errBoom, notificationGetFailed),
 			},
 		},
 		"UpdateNeededFull": {
@@ -258,7 +258,7 @@ func TestNotificationCreateOrUpdate(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, notificationPutFailed),
+				err: awsclient.Wrap(errBoom, notificationPutFailed),
 			},
 		},
 		"InvalidConfig": {

--- a/pkg/controller/s3/bucket/replicationConfig_test.go
+++ b/pkg/controller/s3/bucket/replicationConfig_test.go
@@ -24,10 +24,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
-	aws "github.com/crossplane/provider-aws/pkg/clients"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	clients3 "github.com/crossplane/provider-aws/pkg/clients/s3"
 	"github.com/crossplane/provider-aws/pkg/clients/s3/fake"
 	s3Testing "github.com/crossplane/provider-aws/pkg/controller/s3/testing"
@@ -73,7 +72,7 @@ func generateReplicationConfig() *v1beta1.ReplicationConfiguration {
 				Tag:    &tag,
 			},
 			ID:                      &id,
-			Priority:                aws.Int64(priority),
+			Priority:                awsclient.Int64(priority),
 			SourceSelectionCriteria: &v1beta1.SourceSelectionCriteria{SseKmsEncryptedObjects: v1beta1.SseKmsEncryptedObjects{Status: enabled}},
 			Status:                  enabled,
 		}},
@@ -91,11 +90,11 @@ func generateAWSReplication() *s3.ReplicationConfiguration {
 				Bucket:                   &bucketName,
 				EncryptionConfiguration:  &s3.EncryptionConfiguration{ReplicaKmsKeyID: &kmsID},
 				Metrics: &s3.Metrics{
-					EventThreshold: &s3.ReplicationTimeValue{Minutes: aws.Int64(replicationTime)},
+					EventThreshold: &s3.ReplicationTimeValue{Minutes: awsclient.Int64(replicationTime)},
 					Status:         s3.MetricsStatusEnabled,
 				},
 				ReplicationTime: &s3.ReplicationTime{
-					Time:   &s3.ReplicationTimeValue{Minutes: aws.Int64(replicationTime)},
+					Time:   &s3.ReplicationTimeValue{Minutes: awsclient.Int64(replicationTime)},
 					Status: s3.ReplicationTimeStatusEnabled,
 				},
 				StorageClass: s3.StorageClassOnezoneIa,
@@ -110,7 +109,7 @@ func generateAWSReplication() *s3.ReplicationConfiguration {
 				Tag:    &awsTag,
 			},
 			ID:                      &id,
-			Priority:                aws.Int64(priority),
+			Priority:                awsclient.Int64(priority),
 			SourceSelectionCriteria: &s3.SourceSelectionCriteria{SseKmsEncryptedObjects: &s3.SseKmsEncryptedObjects{Status: s3.SseKmsEncryptedObjectsStatusEnabled}},
 			Status:                  s3.ReplicationRuleStatusEnabled,
 		}},
@@ -145,7 +144,7 @@ func TestReplicationObserve(t *testing.T) {
 			},
 			want: want{
 				status: NeedsUpdate,
-				err:    errors.Wrap(errBoom, replicationGetFailed),
+				err:    awsclient.Wrap(errBoom, replicationGetFailed),
 			},
 		},
 		"UpdateNeeded": {
@@ -269,7 +268,7 @@ func TestReplicationCreateOrUpdate(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, replicationPutFailed),
+				err: awsclient.Wrap(errBoom, replicationPutFailed),
 			},
 		},
 		"InvalidConfig": {
@@ -340,7 +339,7 @@ func TestReplicationDelete(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, replicationDeleteFailed),
+				err: awsclient.Wrap(errBoom, replicationDeleteFailed),
 			},
 		},
 		"SuccessfulDelete": {

--- a/pkg/controller/s3/bucket/requestPaymentConfig.go
+++ b/pkg/controller/s3/bucket/requestPaymentConfig.go
@@ -21,10 +21,9 @@ import (
 
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
-	"github.com/pkg/errors"
 
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
-	aws "github.com/crossplane/provider-aws/pkg/clients"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/s3"
 )
 
@@ -40,9 +39,9 @@ type RequestPaymentConfigurationClient struct {
 
 // LateInitialize is responsible for initializing the resource based on the external value
 func (in *RequestPaymentConfigurationClient) LateInitialize(ctx context.Context, bucket *v1beta1.Bucket) error {
-	external, err := in.client.GetBucketRequestPaymentRequest(&awss3.GetBucketRequestPaymentInput{Bucket: aws.String(meta.GetExternalName(bucket))}).Send(ctx)
+	external, err := in.client.GetBucketRequestPaymentRequest(&awss3.GetBucketRequestPaymentInput{Bucket: awsclient.String(meta.GetExternalName(bucket))}).Send(ctx)
 	if err != nil {
-		return errors.Wrap(err, paymentGetFailed)
+		return awsclient.Wrap(err, paymentGetFailed)
 	}
 
 	if len(external.Payer) == 0 {
@@ -53,7 +52,7 @@ func (in *RequestPaymentConfigurationClient) LateInitialize(ctx context.Context,
 		bucket.Spec.ForProvider.PayerConfiguration = &v1beta1.PaymentConfiguration{}
 		config = bucket.Spec.ForProvider.PayerConfiguration
 	}
-	config.Payer = aws.LateInitializeString(config.Payer, aws.String(string(external.Payer)))
+	config.Payer = awsclient.LateInitializeString(config.Payer, awsclient.String(string(external.Payer)))
 	return nil
 }
 
@@ -64,9 +63,9 @@ func NewRequestPaymentConfigurationClient(client s3.BucketClient) *RequestPaymen
 
 // Observe checks if the resource exists and if it matches the local configuration
 func (in *RequestPaymentConfigurationClient) Observe(ctx context.Context, bucket *v1beta1.Bucket) (ResourceStatus, error) {
-	external, err := in.client.GetBucketRequestPaymentRequest(&awss3.GetBucketRequestPaymentInput{Bucket: aws.String(meta.GetExternalName(bucket))}).Send(ctx)
+	external, err := in.client.GetBucketRequestPaymentRequest(&awss3.GetBucketRequestPaymentInput{Bucket: awsclient.String(meta.GetExternalName(bucket))}).Send(ctx)
 	if err != nil {
-		return NeedsUpdate, errors.Wrap(err, paymentGetFailed)
+		return NeedsUpdate, awsclient.Wrap(err, paymentGetFailed)
 	}
 	config := bucket.Spec.ForProvider.PayerConfiguration
 
@@ -85,23 +84,23 @@ func (in *RequestPaymentConfigurationClient) Observe(ctx context.Context, bucket
 // GeneratePutBucketPaymentInput creates the input for the BucketRequestPayment request for the S3 Client
 func GeneratePutBucketPaymentInput(name string, config *v1beta1.PaymentConfiguration) *awss3.PutBucketRequestPaymentInput {
 	bci := &awss3.PutBucketRequestPaymentInput{
-		Bucket:                      aws.String(name),
+		Bucket:                      awsclient.String(name),
 		RequestPaymentConfiguration: &awss3.RequestPaymentConfiguration{Payer: awss3.Payer(config.Payer)},
 	}
 	return bci
 }
 
-// CreateOrUpdate sends a request to have resource created on AWS.
+// CreateOrUpdate sends a request to have resource created on awsclient.
 func (in *RequestPaymentConfigurationClient) CreateOrUpdate(ctx context.Context, bucket *v1beta1.Bucket) error {
 	if bucket.Spec.ForProvider.PayerConfiguration == nil {
 		return nil
 	}
 	input := GeneratePutBucketPaymentInput(meta.GetExternalName(bucket), bucket.Spec.ForProvider.PayerConfiguration)
 	_, err := in.client.PutBucketRequestPaymentRequest(input).Send(ctx)
-	return errors.Wrap(err, paymentPutFailed)
+	return awsclient.Wrap(err, paymentPutFailed)
 }
 
-// Delete does nothing since there is no corresponding deletion call in AWS.
+// Delete does nothing since there is no corresponding deletion call in awsclient.
 func (*RequestPaymentConfigurationClient) Delete(_ context.Context, _ *v1beta1.Bucket) error {
 	return nil
 }

--- a/pkg/controller/s3/bucket/requestPaymentConfig_test.go
+++ b/pkg/controller/s3/bucket/requestPaymentConfig_test.go
@@ -23,9 +23,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/s3/fake"
 	s3Testing "github.com/crossplane/provider-aws/pkg/controller/s3/testing"
 )
@@ -75,7 +75,7 @@ func TestRequestPaymentObserve(t *testing.T) {
 			},
 			want: want{
 				status: NeedsUpdate,
-				err:    errors.Wrap(errBoom, paymentGetFailed),
+				err:    awsclient.Wrap(errBoom, paymentGetFailed),
 			},
 		},
 		"UpdateNeeded": {
@@ -151,7 +151,7 @@ func TestRequestPaymentCreateOrUpdate(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, paymentPutFailed),
+				err: awsclient.Wrap(errBoom, paymentPutFailed),
 			},
 		},
 		"InvalidConfig": {

--- a/pkg/controller/s3/bucket/sseConfig_test.go
+++ b/pkg/controller/s3/bucket/sseConfig_test.go
@@ -24,10 +24,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
-	aws "github.com/crossplane/provider-aws/pkg/clients"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	clients3 "github.com/crossplane/provider-aws/pkg/clients/s3"
 	"github.com/crossplane/provider-aws/pkg/clients/s3/fake"
 	s3Testing "github.com/crossplane/provider-aws/pkg/controller/s3/testing"
@@ -47,7 +46,7 @@ func generateSSEConfig() *v1beta1.ServerSideEncryptionConfiguration {
 		Rules: []v1beta1.ServerSideEncryptionRule{
 			{
 				ApplyServerSideEncryptionByDefault: v1beta1.ServerSideEncryptionByDefault{
-					KMSMasterKeyID: aws.String(keyID),
+					KMSMasterKeyID: awsclient.String(keyID),
 					SSEAlgorithm:   sseAlgo,
 				},
 			},
@@ -60,7 +59,7 @@ func generateAWSSSE() *s3.ServerSideEncryptionConfiguration {
 		Rules: []s3.ServerSideEncryptionRule{
 			{
 				ApplyServerSideEncryptionByDefault: &s3.ServerSideEncryptionByDefault{
-					KMSMasterKeyID: aws.String(keyID),
+					KMSMasterKeyID: awsclient.String(keyID),
 					SSEAlgorithm:   s3.ServerSideEncryptionAes256,
 				},
 			},
@@ -96,7 +95,7 @@ func TestSSEObserve(t *testing.T) {
 			},
 			want: want{
 				status: NeedsUpdate,
-				err:    errors.Wrap(errBoom, sseGetFailed),
+				err:    awsclient.Wrap(errBoom, sseGetFailed),
 			},
 		},
 		"UpdateNeeded": {
@@ -220,7 +219,7 @@ func TestSSECreateOrUpdate(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, ssePutFailed),
+				err: awsclient.Wrap(errBoom, ssePutFailed),
 			},
 		},
 		"InvalidConfig": {
@@ -291,7 +290,7 @@ func TestSSEDelete(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, sseDeleteFailed),
+				err: awsclient.Wrap(errBoom, sseDeleteFailed),
 			},
 		},
 		"SuccessfulDelete": {

--- a/pkg/controller/s3/bucket/taggingConfig_test.go
+++ b/pkg/controller/s3/bucket/taggingConfig_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	clients3 "github.com/crossplane/provider-aws/pkg/clients/s3"
 	"github.com/crossplane/provider-aws/pkg/clients/s3/fake"
 	s3Testing "github.com/crossplane/provider-aws/pkg/controller/s3/testing"
@@ -104,7 +104,7 @@ func TestTaggingObserve(t *testing.T) {
 			},
 			want: want{
 				status: NeedsUpdate,
-				err:    errors.Wrap(errBoom, taggingGetFailed),
+				err:    awsclient.Wrap(errBoom, taggingGetFailed),
 			},
 		},
 		"UpdateNeeded": {
@@ -244,7 +244,7 @@ func TestTaggingCreateOrUpdate(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, taggingPutFailed),
+				err: awsclient.Wrap(errBoom, taggingPutFailed),
 			},
 		},
 		"InvalidConfig": {
@@ -315,7 +315,7 @@ func TestTaggingDelete(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, taggingDeleteFailed),
+				err: awsclient.Wrap(errBoom, taggingDeleteFailed),
 			},
 		},
 		"SuccessfulDelete": {

--- a/pkg/controller/s3/bucket/versioningConfig_test.go
+++ b/pkg/controller/s3/bucket/versioningConfig_test.go
@@ -23,10 +23,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
-	aws "github.com/crossplane/provider-aws/pkg/clients"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/s3/fake"
 	s3Testing "github.com/crossplane/provider-aws/pkg/controller/s3/testing"
 )
@@ -39,7 +38,7 @@ var (
 func generateVersioningConfig() *v1beta1.VersioningConfiguration {
 	return &v1beta1.VersioningConfiguration{
 		MFADelete: &mfadelete,
-		Status:    aws.String(enabled),
+		Status:    awsclient.String(enabled),
 	}
 }
 
@@ -78,7 +77,7 @@ func TestVersioningObserve(t *testing.T) {
 			},
 			want: want{
 				status: NeedsUpdate,
-				err:    errors.Wrap(errBoom, versioningGetFailed),
+				err:    awsclient.Wrap(errBoom, versioningGetFailed),
 			},
 		},
 		"UpdateNeededFull": {
@@ -173,7 +172,7 @@ func TestVersioningCreateOrUpdate(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, versioningPutFailed),
+				err: awsclient.Wrap(errBoom, versioningPutFailed),
 			},
 		},
 		"InvalidConfig": {

--- a/pkg/controller/s3/bucket/websiteConfig_test.go
+++ b/pkg/controller/s3/bucket/websiteConfig_test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	clients3 "github.com/crossplane/provider-aws/pkg/clients/s3"
 	"github.com/crossplane/provider-aws/pkg/clients/s3/fake"
 	s3Testing "github.com/crossplane/provider-aws/pkg/controller/s3/testing"
@@ -125,7 +125,7 @@ func TestWebsiteObserve(t *testing.T) {
 			},
 			want: want{
 				status: NeedsUpdate,
-				err:    errors.Wrap(errBoom, websiteGetFailed),
+				err:    awsclient.Wrap(errBoom, websiteGetFailed),
 			},
 		},
 		"UpdateNeededFull": {
@@ -277,7 +277,7 @@ func TestWebsiteCreateOrUpdate(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, websitePutFailed),
+				err: awsclient.Wrap(errBoom, websitePutFailed),
 			},
 		},
 		"InvalidConfig": {
@@ -348,7 +348,7 @@ func TestWebsiteDelete(t *testing.T) {
 				}),
 			},
 			want: want{
-				err: errors.Wrap(errBoom, websiteDeleteFailed),
+				err: awsclient.Wrap(errBoom, websiteDeleteFailed),
 			},
 		},
 		"SuccessfulDelete": {

--- a/pkg/controller/s3/bucket_test.go
+++ b/pkg/controller/s3/bucket_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/s3"
 	"github.com/crossplane/provider-aws/pkg/clients/s3/fake"
 	s3Testing "github.com/crossplane/provider-aws/pkg/controller/s3/testing"
@@ -87,7 +88,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  s3Testing.Bucket(),
-				err: errors.Wrap(errBoom, errHead),
+				err: awsclient.Wrap(errBoom, errHead),
 			},
 		},
 		"ResourceDoesNotExist": {
@@ -270,7 +271,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:  s3Testing.Bucket(s3Testing.WithConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreate),
+				err: awsclient.Wrap(errBoom, errCreate),
 			},
 		},
 	}
@@ -368,7 +369,7 @@ func TestUpdate(t *testing.T) {
 				cr: s3Testing.Bucket(
 					s3Testing.WithPayerConfig(&v1beta1.PaymentConfiguration{Payer: "Requester"}),
 				),
-				err:    errors.Wrap(errors.Wrap(errBoom, "cannot put Bucket payment"), errCreateOrUpdate),
+				err:    errors.Wrap(awsclient.Wrap(errBoom, "cannot put Bucket payment"), errCreateOrUpdate),
 				result: managed.ExternalUpdate{},
 			},
 		},
@@ -390,10 +391,10 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr: s3Testing.Bucket(
-					s3Testing.WithConditions(xpv1.ReconcileError(errors.Wrap(errBoom, "cannot get request payment configuration"))),
+					s3Testing.WithConditions(xpv1.ReconcileError(awsclient.Wrap(errBoom, "cannot get request payment configuration"))),
 					s3Testing.WithPayerConfig(&v1beta1.PaymentConfiguration{Payer: "Requester"}),
 				),
-				err:    errors.Wrap(errBoom, "cannot get request payment configuration"),
+				err:    awsclient.Wrap(errBoom, "cannot get request payment configuration"),
 				result: managed.ExternalUpdate{},
 			},
 		},
@@ -463,7 +464,7 @@ func TestUpdate(t *testing.T) {
 				cr: s3Testing.Bucket(
 					s3Testing.WithSSEConfig(nil),
 				),
-				err:    errors.Wrap(errors.Wrap(errBoom, "cannot delete Bucket encryption configuration"), errDelete),
+				err:    errors.Wrap(awsclient.Wrap(errBoom, "cannot delete Bucket encryption configuration"), errDelete),
 				result: managed.ExternalUpdate{},
 			},
 		},
@@ -496,10 +497,10 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				cr: s3Testing.Bucket(
-					s3Testing.WithConditions(xpv1.ReconcileError(errors.Wrap(errBoom, "cannot get Bucket encryption configuration"))),
+					s3Testing.WithConditions(xpv1.ReconcileError(awsclient.Wrap(errBoom, "cannot get Bucket encryption configuration"))),
 					s3Testing.WithSSEConfig(nil),
 				),
-				err:    errors.Wrap(errBoom, "cannot get Bucket encryption configuration"),
+				err:    awsclient.Wrap(errBoom, "cannot get Bucket encryption configuration"),
 				result: managed.ExternalUpdate{},
 			},
 		},

--- a/pkg/controller/s3/bucketpolicy/bucketpolicy_test.go
+++ b/pkg/controller/s3/bucketpolicy/bucketpolicy_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/s3/v1alpha3"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/s3"
 	"github.com/crossplane/provider-aws/pkg/clients/s3/fake"
 )
@@ -145,7 +146,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  bucketPolicy(withPolicy(&params)),
-				err: errors.Wrap(errBoom, errGet),
+				err: awsclient.Wrap(errBoom, errGet),
 			},
 		},
 		"ResourceDoesNotExist": {
@@ -236,7 +237,7 @@ func TestCreate(t *testing.T) {
 				cr: bucketPolicy(
 					withPolicy(&params),
 					withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errAttach),
+				err: awsclient.Wrap(errBoom, errAttach),
 			},
 		},
 	}
@@ -356,7 +357,7 @@ func TestDelete(t *testing.T) {
 			want: want{
 				cr: bucketPolicy(withPolicy(&params),
 					withConditions(xpv1.Deleting())),
-				err: errors.Wrap(errBoom, errDelete),
+				err: awsclient.Wrap(errBoom, errDelete),
 			},
 		},
 		"ResourceDoesNotExist": {

--- a/pkg/controller/sqs/queue/controller_test.go
+++ b/pkg/controller/sqs/queue/controller_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/crossplane/provider-aws/apis/sqs/v1beta1"
+	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/sqs"
 	"github.com/crossplane/provider-aws/pkg/clients/sqs/fake"
 )
@@ -153,7 +154,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  queue(withExternalName(queueName)),
-				err: errors.Wrap(errBoom, errGetQueueAttributesFailed),
+				err: awsclient.Wrap(errBoom, errGetQueueAttributesFailed),
 			},
 		},
 		"ListTagsFail": {
@@ -183,7 +184,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr:  queue(withExternalName(queueName)),
-				err: errors.Wrap(errBoom, errListQueueTagsFailed),
+				err: awsclient.Wrap(errBoom, errListQueueTagsFailed),
 			},
 		},
 	}
@@ -258,7 +259,7 @@ func TestCreate(t *testing.T) {
 			want: want{
 				cr: queue(withExternalName(queueURL),
 					withConditions(xpv1.Creating())),
-				err: errors.Wrap(errBoom, errCreateFailed),
+				err: awsclient.Wrap(errBoom, errCreateFailed),
 			},
 		},
 	}
@@ -382,7 +383,7 @@ func TestUpdate(t *testing.T) {
 				cr: queue(withStatus(v1beta1.QueueObservation{
 					URL: queueURL,
 				})),
-				err: errors.Wrap(errBoom, errUpdateFailed),
+				err: awsclient.Wrap(errBoom, errUpdateFailed),
 			},
 		},
 	}
@@ -455,7 +456,7 @@ func TestDelete(t *testing.T) {
 					withStatus(v1beta1.QueueObservation{
 						URL: queueURL,
 					})),
-				err: errors.Wrap(errBoom, errDeleteFailed),
+				err: awsclient.Wrap(errBoom, errDeleteFailed),
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: chris <chris.vodak@gmail.com>


### Description of your changes
Attempt to strip AWS request ID's from errors to prevent fast reconcilation. While going through aligned all the various controllers to awsclient naming (since looks like that is in the ack template going forward)

**DID NOT TOUCH ACK GENERATED CONTROLLERS** - will need another MR for this did not know if should touch or update the ack template

Fixes #461 

I have:

- [x ] Read and followed Crossplane's [contribution process].
- [x ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Tested using the VPC example in #461. Ran unit tests. 
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
