### PR TITLE
Make sure we compare KMSMasterKeyID correctly in the s3/sseConfig subresource

### DIFF
--- a/pkg/controller/s3/bucket/sseConfig.go
+++ b/pkg/controller/s3/bucket/sseConfig.go
@@ -75,7 +75,7 @@ func (in *SSEConfigurationClient) Observe(ctx context.Context, bucket *v1beta1.B
 
 	for i, Rule := range config.Rules {
 		outputRule := external.ServerSideEncryptionConfiguration.Rules[i].ApplyServerSideEncryptionByDefault
-		if outputRule.KMSMasterKeyID != Rule.ApplyServerSideEncryptionByDefault.KMSMasterKeyID {
+		if aws.StringValue(outputRule.KMSMasterKeyID) != aws.StringValue(Rule.ApplyServerSideEncryptionByDefault.KMSMasterKeyID) {
 			return NeedsUpdate, nil
 		}
 		if string(outputRule.SSEAlgorithm) != Rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm {

--- a/pkg/controller/s3/bucket/sseConfig_test.go
+++ b/pkg/controller/s3/bucket/sseConfig_test.go
@@ -27,15 +27,19 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
+	aws "github.com/crossplane/provider-aws/pkg/clients"
 	clients3 "github.com/crossplane/provider-aws/pkg/clients/s3"
 	"github.com/crossplane/provider-aws/pkg/clients/s3/fake"
 	s3Testing "github.com/crossplane/provider-aws/pkg/controller/s3/testing"
 )
 
+const (
+	keyID   = "test-key-id"
+	sseAlgo = "AES256"
+)
+
 var (
-	sseAlgo                   = "AES256"
-	keyID                     = "test-key-id"
-	_       SubresourceClient = &SSEConfigurationClient{}
+	_ SubresourceClient = &SSEConfigurationClient{}
 )
 
 func generateSSEConfig() *v1beta1.ServerSideEncryptionConfiguration {
@@ -43,7 +47,7 @@ func generateSSEConfig() *v1beta1.ServerSideEncryptionConfiguration {
 		Rules: []v1beta1.ServerSideEncryptionRule{
 			{
 				ApplyServerSideEncryptionByDefault: v1beta1.ServerSideEncryptionByDefault{
-					KMSMasterKeyID: &keyID,
+					KMSMasterKeyID: aws.String(keyID),
 					SSEAlgorithm:   sseAlgo,
 				},
 			},
@@ -56,7 +60,7 @@ func generateAWSSSE() *s3.ServerSideEncryptionConfiguration {
 		Rules: []s3.ServerSideEncryptionRule{
 			{
 				ApplyServerSideEncryptionByDefault: &s3.ServerSideEncryptionByDefault{
-					KMSMasterKeyID: &keyID,
+					KMSMasterKeyID: aws.String(keyID),
 					SSEAlgorithm:   s3.ServerSideEncryptionAes256,
 				},
 			},


### PR DESCRIPTION
### Description of your changes

Make sure we compare KMSMasterKeyID correctly in the s3/sseConfig subresource

When Observing the server side encryption configuration the code was comparing string pointers when checking whether the KMSMasterKeyID needs updating.

Fixes #496 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

As this is a fairly trivial fix, I haven't done additional tests. Used TDD to verify the test failure first.