### PR TITLE
Support custom Docker registry when building the Docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ GO111MODULE = on
 # ====================================================================================
 # Setup Images
 
-DOCKER_REGISTRY = crossplane
+DOCKER_REGISTRY ?= crossplane
 IMAGES = provider-aws provider-aws-controller
 -include build/makelib/image.mk
 

--- a/cluster/images/provider-aws/Makefile
+++ b/cluster/images/provider-aws/Makefile
@@ -6,6 +6,7 @@ include ../../../build/makelib/common.mk
 
 # ====================================================================================
 #  Options
+DOCKER_REGISTRY ?= crossplane
 IMAGE = $(BUILD_REGISTRY)/provider-aws-$(ARCH)
 OSBASEIMAGE = scratch
 include ../../../build/makelib/image.mk
@@ -19,6 +20,7 @@ img.build:
 	@cp -R ../../../package $(IMAGE_TEMP_DIR) || $(FAIL)
 	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|BASEIMAGE|$(OSBASEIMAGE)|g' Dockerfile || $(FAIL)
 	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|VERSION|$(VERSION)|g' package/crossplane.yaml || $(FAIL)
+	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|DOCKER_REGISTRY|$(DOCKER_REGISTRY)|g' package/crossplane.yaml || $(FAIL)
 	@cd $(IMAGE_TEMP_DIR) && find package -type f -name '*.yaml' -exec cat {} >> 'package.yaml' \; -exec printf '\n---\n' \; || $(FAIL)
 	@docker build $(BUILD_ARGS) \
 		--build-arg ARCH=$(ARCH) \

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -30,4 +30,4 @@ metadata:
 
 spec:
   controller:
-    image: crossplane/provider-aws-controller:VERSION
+    image: DOCKER_REGISTRY/provider-aws-controller:VERSION


### PR DESCRIPTION
### Description of your changes

I would like to run a custom build of the AWS provider and for this I would like to upload the built Docker images to my own Docker registry.

The current setup has the following limitations:
 - the value of DOCKER_REGISTRY can not be overridden when running make targets - this is just an inconvenience as it's easy to tag the built images
 - the Docker image name for the controller is baked in as `crossplane/provider-aws-controller:VERSION` - this is again a minor inconvenience because you can override the image using the ControllerConfig CRD.

Still it's more convenient if I can do a full build, upload both images and I only have to update the spec.package on the Provider object.

For reference I was running the following commands:

```
PLATFORMS=linux_amd64 DOCKER_REGISTRY=quay.io/acme VERSION=v0.16.0-p1 make build publish

docker tag quay.io/acme/provider-aws-amd64:v0.16.0-p1 quay.io/acme/provider-aws:v0.16.0-p1
docker push quay.io/acme/provider-aws:v0.16.0-p1
docker tag quay.io/acme/provider-aws-controller-amd64:v0.16.0-p1 quay.io/acme/provider-aws-controller:v0.16.0-p1
docker push quay.io/acme/provider-aws-controller:v0.16.0-p1
```

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I deployed my own images and verified that the provider works.

Also I've ran the make targets without setting DOCKER_REGISTRY and verified that it uses "crossplane" correctly everywere.