### PR TITLE
write sqs queue url to connection secret ref

### DIFF
--- a/pkg/clients/sqs/queue.go
+++ b/pkg/clients/sqs/queue.go
@@ -26,6 +26,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/google/go-cmp/cmp"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+
 	"github.com/crossplane/provider-aws/apis/sqs/v1beta1"
 	awsclients "github.com/crossplane/provider-aws/pkg/clients"
 )
@@ -255,4 +258,14 @@ func int64Ptr(s string) *int64 {
 		return nil
 	}
 	return &v
+}
+
+// GetConnectionDetails extracts managed.ConnectionDetails out of v1beta1.Queue.
+func GetConnectionDetails(in v1beta1.Queue) managed.ConnectionDetails {
+	if in.Status.AtProvider.URL == "" {
+		return nil
+	}
+	return managed.ConnectionDetails{
+		xpv1.ResourceCredentialsSecretEndpointKey: []byte(in.Status.AtProvider.URL),
+	}
 }

--- a/pkg/controller/sqs/queue/controller_test.go
+++ b/pkg/controller/sqs/queue/controller_test.go
@@ -127,6 +127,9 @@ func TestObserve(t *testing.T) {
 				result: managed.ExternalObservation{
 					ResourceExists:   true,
 					ResourceUpToDate: true,
+					ConnectionDetails: managed.ConnectionDetails{
+						xpv1.ResourceCredentialsSecretEndpointKey: []byte(queueURL),
+					},
 				},
 			},
 		},
@@ -233,6 +236,11 @@ func TestCreate(t *testing.T) {
 			want: want{
 				cr: queue(withExternalName(queueURL),
 					withConditions(xpv1.Creating())),
+				result: managed.ExternalCreation{
+					ConnectionDetails: managed.ConnectionDetails{
+						xpv1.ResourceCredentialsSecretEndpointKey: []byte(queueURL),
+					},
+				},
 			},
 		},
 		"CreateFail": {


### PR DESCRIPTION
Signed-off-by: S.Cavallo <smcavallo@hotmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Per the [provider-aws docs](https://doc.crds.dev/github.com/crossplane/provider-aws/sqs.aws.crossplane.io/Queue/v1beta1@v0.16.0#spec-writeConnectionSecretToRef) Queue supports `writeConnectionSecretToRef` but does not write any connection details.  This PR writes the queue URL to the endpoint value in the connection secret.


I have:

- [X ] Read and followed Crossplane's [contribution process].
- [X ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit tests and manual testing

[contribution process]: https://git.io/fj2m9
