### PR TITLE
bucket: versioning + replication configuration sub resource ordering fix

### DIFF
--- a/pkg/controller/s3/bucket/subresources.go
+++ b/pkg/controller/s3/bucket/subresources.go
@@ -34,6 +34,9 @@ type SubresourceClient interface {
 // NewSubresourceClients creates the array of all clients for a given BucketProvider
 func NewSubresourceClients(client s3.BucketClient) []SubresourceClient {
 	return []SubresourceClient{
+		// Note: Moved VersioningClient up, since ReplicationConfiguration may be blocked
+		// by an invalid VersioningConfig, see https://github.com/crossplane/provider-aws/issues/553
+		NewVersioningConfigurationClient(client),
 		NewAccelerateConfigurationClient(client),
 		NewCORSConfigurationClient(client),
 		NewLifecycleConfigurationClient(client),
@@ -43,7 +46,6 @@ func NewSubresourceClients(client s3.BucketClient) []SubresourceClient {
 		NewRequestPaymentConfigurationClient(client),
 		NewSSEConfigurationClient(client),
 		NewTaggingConfigurationClient(client),
-		NewVersioningConfigurationClient(client),
 		NewWebsiteConfigurationClient(client),
 	}
 }


### PR DESCRIPTION
### Description of your changes

Fixes #553 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [] Run `make reviewable test` to ensure this PR is ready for review.

Previously the reconciliation would be blocked since the versioning could never complete because of a replication error based on the fact that there is no versioning. This is resolved now by fixing the ordering in the `subresource.go` folder.

### How has this code been tested

I did manual testing with two S3 buckets, I can provide the gists if that would be helpful. But essentially, the first was a regular S3 bucket, and the second was an S3 bucket with versioning enabled, as well as a replication configuration pointing to the first bucket. There was a role that had access to both buckets, set up on the replication configuration as well. 

Previously, the 2nd bucket would never finish reconciling, but that is resolved now.

[contribution process]: https://git.io/fj2m9
