### PR TITLE
database.rdsinstance: add DBSubnetParameterGroupName to late init

### DIFF
--- a/examples/database/rdsinstance.yaml
+++ b/examples/database/rdsinstance.yaml
@@ -4,6 +4,7 @@ metadata:
   name: example-rds
 spec:
   forProvider:
+    region: us-east-1
     allocatedStorage: 20
     autoMinorVersionUpgrade: true
     backupRetentionPeriod: 0
@@ -20,8 +21,6 @@ spec:
     masterUsername: admin
     multiAZ: true
     port: 3306
-    preferredBackupWindow: 06:15-06:45
-    preferredMaintenanceWindow: sat:09:21-sat:09:51
     publiclyAccessible: false
     storageEncrypted: false
     storageType: gp2

--- a/pkg/clients/rds/rds.go
+++ b/pkg/clients/rds/rds.go
@@ -442,6 +442,14 @@ func LateInitialize(in *v1beta1.RDSInstanceParameters, db *rds.DBInstance) { // 
 	if strings.HasPrefix(aws.StringValue(db.EngineVersion), aws.StringValue(in.EngineVersion)) {
 		in.EngineVersion = db.EngineVersion
 	}
+	if in.DBParameterGroupName == nil {
+		for i := range db.DBParameterGroups {
+			if db.DBParameterGroups[i].DBParameterGroupName != nil {
+				in.DBParameterGroupName = db.DBParameterGroups[i].DBParameterGroupName
+				break
+			}
+		}
+	}
 }
 
 // IsUpToDate checks whether there is a change in any of the modifiable fields.


### PR DESCRIPTION
### Description of your changes

Seems like it wasn't used in late-init because observation object returns an array. It's safe to assign the first value since there is more than value only during a change and that doesn't happen in creation where late-init is used.

Fixes https://github.com/crossplane/crossplane/issues/2187

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually tested.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
