### PR TITLE
Update authentication documentation

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -130,8 +130,8 @@ read -r -d '' TRUST_RELATIONSHIP <<EOF
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
-        "StringEquals": {
-          "${OIDC_PROVIDER}:sub": "system:serviceaccount:${SERVICE_ACCOUNT_NAMESPACE}:${SERVICE_ACCOUNT_NAME}"
+        "StringLike": {
+          "${OIDC_PROVIDER}:sub": "system:serviceaccount:${SERVICE_ACCOUNT_NAMESPACE}:provider-aws-*"
         }
       }
     }
@@ -140,6 +140,9 @@ read -r -d '' TRUST_RELATIONSHIP <<EOF
 EOF
 echo "${TRUST_RELATIONSHIP}" > trust.json
 ```
+
+> The default service account name is the provider-aws revision and changes with every provider release. The conditional above wildcard matches the default service account name in order to keep the role consistent across provider releases.
+The above policy assumes a service account name of `provider-aws-*` 
 
 Create IAM role:
 


### PR DESCRIPTION
Update authentication documentation with serviceAccount recommendation for provider upgrade
Signed-off-by: smcavallo <smcavallo@hotmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
We use pod-iam which requires assigning the service account name to the aws role.  The problem is that the service account name is the provider-aws revision and it changes during the release, breaking crossplane permissions
Ex.  v.0.16.0 - provider-aws-6b36ca882d8e and v.0.17.0 - provider-aws-4ebd5d8c7cb7
Using a static `StringEquals` condition with a hard coded provider will break when the `SERVICE_ACCOUNT_NAME` changes when the provider is upgraded
```
"StringEquals": {
          "${OIDC_PROVIDER}:sub": "system:serviceaccount:${SERVICE_ACCOUNT_NAMESPACE}:${SERVICE_ACCOUNT_NAME}"
        }
```
This condition can be avoided by using an alternative IAM policy which uses `StringLike` and a wildcard `SERVICE_ACCOUNT_NAME`:
```
"StringLike": {
          "${OIDC_PROVIDER}:sub": "system:serviceaccount:${SERVICE_ACCOUNT_NAMESPACE}:provider-aws-*"
        }
```
This trust policy would cover both service account names - `provider-aws-6b36ca882d8e` and `provider-aws-4ebd5d8c7cb7`
As long as provider-aws- will not change as part of a release the above should cover future cases of provider names changing during a release without needing to update the role trust policy.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
