### PR TITLE
Fix for 558, only send vpc attributes if set

### DIFF
--- a/pkg/clients/ec2/vpc.go
+++ b/pkg/clients/ec2/vpc.go
@@ -100,12 +100,18 @@ func GenerateVpcObservation(vpc ec2.Vpc) v1beta1.VPCObservation {
 }
 
 // LateInitializeVPC fills the empty fields in *v1beta1.VPCParameters with
-// the values seen in ec2.Vpc.
-func LateInitializeVPC(in *v1beta1.VPCParameters, v *ec2.Vpc) { // nolint:gocyclo
+// the values seen in ec2.Vpc and ec2.DescribeVpcAttributeOutput.
+func LateInitializeVPC(in *v1beta1.VPCParameters, v *ec2.Vpc, attributes *ec2.DescribeVpcAttributeOutput) { // nolint:gocyclo
 	if v == nil {
 		return
 	}
 
 	in.CIDRBlock = awsclients.LateInitializeString(in.CIDRBlock, v.CidrBlock)
 	in.InstanceTenancy = awsclients.LateInitializeStringPtr(in.InstanceTenancy, aws.String(string(v.InstanceTenancy)))
+	if attributes.EnableDnsHostnames != nil {
+		in.EnableDNSHostNames = awsclients.LateInitializeBoolPtr(in.EnableDNSHostNames, attributes.EnableDnsHostnames.Value)
+	}
+	if attributes.EnableDnsHostnames != nil {
+		in.EnableDNSSupport = awsclients.LateInitializeBoolPtr(in.EnableDNSSupport, attributes.EnableDnsSupport.Value)
+	}
 }


### PR DESCRIPTION
Signed-off-by: chris <cvodak@ea.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #558 Only send vpc attributes if set. Also added lateInitialization as EnableDnsSupport has a default of true if not set.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Ran and added to unit tests. Created a test vpc setting neither enableDnsHostNames or  enableDnsSupport of the values in the issue. Modified the vpc changing values to ensure they were updated in aws correctly.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
