### PR TITLE
allow region configuration using ProviderConfig

### DIFF
--- a/apis/v1beta1/providerconfig_types.go
+++ b/apis/v1beta1/providerconfig_types.go
@@ -36,7 +36,7 @@ type ProviderCredentials struct {
 
 	// Region the provider credentials should be used in.
 	// This applies to all clients and resources - iam, sts, anywhere a region is used
-	Region string `json:"region",omitempty`
+	Region string `json:"region,omitempty"`
 
 	xpv1.CommonCredentialSelectors `json:",inline"`
 }

--- a/apis/v1beta1/providerconfig_types.go
+++ b/apis/v1beta1/providerconfig_types.go
@@ -34,6 +34,10 @@ type ProviderCredentials struct {
 	// +kubebuilder:validation:Enum=None;Secret;InjectedIdentity;Environment;Filesystem
 	Source xpv1.CredentialsSource `json:"source"`
 
+	// Region the provider credentials should be used in.
+	// This applies to all clients and resources - iam, sts, anywhere a region is used
+	Region string `json:"region",omitempty`
+
 	xpv1.CommonCredentialSelectors `json:",inline"`
 }
 

--- a/package/crds/aws.crossplane.io_providerconfigs.yaml
+++ b/package/crds/aws.crossplane.io_providerconfigs.yaml
@@ -63,6 +63,9 @@ spec:
                     required:
                     - path
                     type: object
+                  region:
+                    description: Region the provider credentials should be used in. This applies to all clients and resources - iam, sts, anywhere a region is used
+                    type: string
                   secretRef:
                     description: A SecretRef is a reference to a secret key that contains the credentials that must be used to connect to the provider.
                     properties:
@@ -90,6 +93,7 @@ spec:
                     - Filesystem
                     type: string
                 required:
+                - region
                 - source
                 type: object
             required:

--- a/package/crds/aws.crossplane.io_providerconfigs.yaml
+++ b/package/crds/aws.crossplane.io_providerconfigs.yaml
@@ -93,7 +93,6 @@ spec:
                     - Filesystem
                     type: string
                 required:
-                - region
                 - source
                 type: object
             required:

--- a/pkg/clients/aws.go
+++ b/pkg/clients/aws.go
@@ -96,6 +96,11 @@ func UseProviderConfig(ctx context.Context, c client.Client, mg resource.Managed
 		return nil, errors.Wrap(err, "cannot track ProviderConfig usage")
 	}
 
+	// Use the region set in the provider config, if set
+	if pc.Spec.Credentials.Region != "" {
+		region = pc.Spec.Credentials.Region
+	}
+
 	switch s := pc.Spec.Credentials.Source; s { //nolint:exhaustive
 	case xpv1.CredentialsSourceInjectedIdentity:
 		cfg, err := UsePodServiceAccount(ctx, []byte{}, DefaultSection, region)


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Allow configuration of region in ProviderConfig.  Region set in ProviderConfig overrides all other region settings (with the exception of region being set via annotations.)  
This mirrors some of the functionality of the aws sdk where a default region can be set for all clients/calls.
This fixes cases where it's not feasible/possible to override the region at the resource level.  Ex. Calls to STS and other non-resource based requests where the region is not directly exposed or cannot specifically be configured.

Calls to resources where the region is not exposed (iam, route53) can be worked around today using pod annotations to set the endpoint and region, but having to set annotations on each and every resource is not ideal.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane/provider-aws/issues/596

I have:

- [X ] Read and followed Crossplane's [contribution process].
- [X ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

* Unit tests
* Creating IAM roles in gov cloud using access keys from local kubernetes environment

[contribution process]: https://git.io/fj2m9
