### PR TITLE
Optional region for iam and route53 resources to support non-aws partitions

### DIFF
--- a/apis/identity/v1alpha1/iamaccesskey_types.go
+++ b/apis/identity/v1alpha1/iamaccesskey_types.go
@@ -37,6 +37,12 @@ type IAMAccessKeyParameters struct {
 	// +optional
 	IAMUsernameSelector *xpv1.Selector `json:"userNameSelector,omitempty"`
 
+	// Region can be used to supply an optional region.
+	// If no region is defined, aws-global region will be used
+	// which is the default region for IAM resources in the aws partition
+	// +optional
+	Region string `json:"region,omitempty"`
+
 	// The current status of this IAMAccessKey on the AWS
 	// Must be either Active or Inactive.
 	// +kubebuilder:validation:Enum=Active;Inactive

--- a/apis/identity/v1alpha1/iamgroup_types.go
+++ b/apis/identity/v1alpha1/iamgroup_types.go
@@ -27,6 +27,12 @@ type IAMGroupParameters struct {
 	// The path for the group name.
 	// +optional
 	Path *string `json:"path,omitempty"`
+
+	// Region can be used to supply an optional region.
+	// If no region is defined, aws-global region will be used
+	// which is the default region for IAM resources in the aws partition
+	// +optional
+	Region string `json:"region,omitempty"`
 }
 
 // An IAMGroupSpec defines the desired state of an IAM Group.

--- a/apis/identity/v1alpha1/iamgrouppolicyattachment_types.go
+++ b/apis/identity/v1alpha1/iamgrouppolicyattachment_types.go
@@ -50,6 +50,12 @@ type IAMGroupPolicyAttachmentParameters struct {
 	// GroupNameSelector selects a reference to an IAMGroup to retrieve its groupName
 	// +optional
 	GroupNameSelector *xpv1.Selector `json:"groupNameSelector,omitempty"`
+
+	// Region can be used to supply an optional region.
+	// If no region is defined, aws-global region will be used
+	// which is the default region for IAM resources in the aws partition
+	// +optional
+	Region string `json:"region,omitempty"`
 }
 
 // An IAMGroupPolicyAttachmentSpec defines the desired state of an

--- a/apis/identity/v1alpha1/iamgroupusermembership_types.go
+++ b/apis/identity/v1alpha1/iamgroupusermembership_types.go
@@ -51,6 +51,12 @@ type IAMGroupUserMembershipParameters struct {
 	// UserNameSelector selects a reference to an IAMUser to retrieve its userName
 	// +optional
 	UserNameSelector *xpv1.Selector `json:"userNameSelector,omitempty"`
+
+	// Region can be used to supply an optional region.
+	// If no region is defined, aws-global region will be used
+	// which is the default region for IAM resources in the aws partition
+	// +optional
+	Region string `json:"region,omitempty"`
 }
 
 // An IAMGroupUserMembershipSpec defines the desired state of an

--- a/apis/identity/v1alpha1/iampolicy_types.go
+++ b/apis/identity/v1alpha1/iampolicy_types.go
@@ -37,6 +37,12 @@ type IAMPolicyParameters struct {
 
 	// The name of the policy.
 	Name string `json:"name"`
+
+	// Region can be used to supply an optional region.
+	// If no region is defined, aws-global region will be used
+	// which is the default region for IAM resources in the aws partition
+	// +optional
+	Region string `json:"region,omitempty"`
 }
 
 // An IAMPolicySpec defines the desired state of an IAMPolicy.

--- a/apis/identity/v1alpha1/iamuser_types.go
+++ b/apis/identity/v1alpha1/iamuser_types.go
@@ -36,6 +36,12 @@ type IAMUserParameters struct {
 	// A list of tags that you want to attach to the newly created user.
 	// +optional
 	Tags []Tag `json:"tags,omitempty"`
+
+	// Region can be used to supply an optional region.
+	// If no region is defined, aws-global region will be used
+	// which is the default region for IAM resources in the aws partition
+	// +optional
+	Region string `json:"region,omitempty"`
 }
 
 // An IAMUserSpec defines the desired state of an IAM User.

--- a/apis/identity/v1alpha1/iamuserpolicyattachment_types.go
+++ b/apis/identity/v1alpha1/iamuserpolicyattachment_types.go
@@ -50,6 +50,12 @@ type IAMUserPolicyAttachmentParameters struct {
 	// UserNameSelector selects a reference to an IAMUser to retrieve its userName
 	// +optional
 	UserNameSelector *xpv1.Selector `json:"userNameSelector,omitempty"`
+
+	// Region can be used to supply an optional region.
+	// If no region is defined, aws-global region will be used
+	// which is the default region for IAM resources in the aws partition
+	// +optional
+	Region string `json:"region,omitempty"`
 }
 
 // An IAMUserPolicyAttachmentSpec defines the desired state of an

--- a/apis/identity/v1beta1/iamrole_types.go
+++ b/apis/identity/v1beta1/iamrole_types.go
@@ -80,6 +80,12 @@ type IAMRoleParameters struct {
 	// +immutable
 	// +optional
 	Tags []Tag `json:"tags,omitempty"`
+
+	// Region can be used to supply an optional region.
+	// If no region is defined, aws-global region will be used
+	// which is the default region for IAM resources in the aws partition
+	// +optional
+	Region string `json:"region,omitempty"`
 }
 
 // An IAMRoleSpec defines the desired state of an IAMRole.

--- a/apis/identity/v1beta1/iamrolepolicyattachment_types.go
+++ b/apis/identity/v1beta1/iamrolepolicyattachment_types.go
@@ -51,6 +51,12 @@ type IAMRolePolicyAttachmentParameters struct {
 	// RoleNameSelector selects a reference to an IAMRole to retrieve its Name
 	// +optional
 	RoleNameSelector *xpv1.Selector `json:"roleNameSelector,omitempty"`
+
+	// Region can be used to supply an optional region.
+	// If no region is defined, aws-global region will be used
+	// which is the default region for IAM resources in the aws partition
+	// +optional
+	Region string `json:"region,omitempty"`
 }
 
 // An IAMRolePolicyAttachmentSpec defines the desired state of an

--- a/apis/route53/v1alpha1/hostedzone_types.go
+++ b/apis/route53/v1alpha1/hostedzone_types.go
@@ -89,6 +89,12 @@ type HostedZoneParameters struct {
 	// +immutable
 	// +optional
 	VPC *VPC `json:"vpc,omitempty"`
+
+	// Region can be used to supply an optional region.
+	// If no region is defined, aws-global region will be used
+	// which is the default region for IAM resources in the aws partition
+	// +optional
+	Region string `json:"region,omitempty"`
 }
 
 // Config represents the configuration of a Hosted Zone.

--- a/package/crds/identity.aws.crossplane.io_iamaccesskeys.yaml
+++ b/package/crds/identity.aws.crossplane.io_iamaccesskeys.yaml
@@ -62,6 +62,9 @@ spec:
                     - Active
                     - Inactive
                     type: string
+                  region:
+                    description: Region can be used to supply an optional region. If no region is defined, aws-global region will be used which is the default region for IAM resources in the aws partition
+                    type: string
                   userName:
                     description: IAMUsername contains the name of the IAMUser.
                     type: string

--- a/package/crds/identity.aws.crossplane.io_iamgrouppolicyattachments.yaml
+++ b/package/crds/identity.aws.crossplane.io_iamgrouppolicyattachments.yaml
@@ -107,6 +107,9 @@ spec:
                         description: MatchLabels ensures an object with matching labels is selected.
                         type: object
                     type: object
+                  region:
+                    description: Region can be used to supply an optional region. If no region is defined, aws-global region will be used which is the default region for IAM resources in the aws partition
+                    type: string
                 type: object
               providerConfigRef:
                 description: ProviderConfigReference specifies how the provider that will be used to create, observe, update, and delete this managed resource should be configured.

--- a/package/crds/identity.aws.crossplane.io_iamgroups.yaml
+++ b/package/crds/identity.aws.crossplane.io_iamgroups.yaml
@@ -62,6 +62,9 @@ spec:
                   path:
                     description: The path for the group name.
                     type: string
+                  region:
+                    description: Region can be used to supply an optional region. If no region is defined, aws-global region will be used which is the default region for IAM resources in the aws partition
+                    type: string
                 type: object
               providerConfigRef:
                 description: ProviderConfigReference specifies how the provider that will be used to create, observe, update, and delete this managed resource should be configured.

--- a/package/crds/identity.aws.crossplane.io_iamgroupusermemberships.yaml
+++ b/package/crds/identity.aws.crossplane.io_iamgroupusermemberships.yaml
@@ -83,6 +83,9 @@ spec:
                         description: MatchLabels ensures an object with matching labels is selected.
                         type: object
                     type: object
+                  region:
+                    description: Region can be used to supply an optional region. If no region is defined, aws-global region will be used which is the default region for IAM resources in the aws partition
+                    type: string
                   userName:
                     description: UserName presents the name of the IAMUser.
                     type: string

--- a/package/crds/identity.aws.crossplane.io_iampolicies.yaml
+++ b/package/crds/identity.aws.crossplane.io_iampolicies.yaml
@@ -68,6 +68,9 @@ spec:
                   path:
                     description: The path to the policy.
                     type: string
+                  region:
+                    description: Region can be used to supply an optional region. If no region is defined, aws-global region will be used which is the default region for IAM resources in the aws partition
+                    type: string
                 required:
                 - document
                 - name

--- a/package/crds/identity.aws.crossplane.io_iamrolepolicyattachments.yaml
+++ b/package/crds/identity.aws.crossplane.io_iamrolepolicyattachments.yaml
@@ -83,6 +83,9 @@ spec:
                         description: MatchLabels ensures an object with matching labels is selected.
                         type: object
                     type: object
+                  region:
+                    description: Region can be used to supply an optional region. If no region is defined, aws-global region will be used which is the default region for IAM resources in the aws partition
+                    type: string
                   roleName:
                     description: RoleName presents the name of the IAM role.
                     type: string

--- a/package/crds/identity.aws.crossplane.io_iamroles.yaml
+++ b/package/crds/identity.aws.crossplane.io_iamroles.yaml
@@ -69,6 +69,9 @@ spec:
                   permissionsBoundary:
                     description: PermissionsBoundary is the ARN of the policy that is used to set the permissions boundary for the role.
                     type: string
+                  region:
+                    description: Region can be used to supply an optional region. If no region is defined, aws-global region will be used which is the default region for IAM resources in the aws partition
+                    type: string
                   tags:
                     description: Tags. For more information about tagging, see Tagging IAM Identities (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the IAM User Guide.
                     items:

--- a/package/crds/identity.aws.crossplane.io_iamuserpolicyattachments.yaml
+++ b/package/crds/identity.aws.crossplane.io_iamuserpolicyattachments.yaml
@@ -83,6 +83,9 @@ spec:
                         description: MatchLabels ensures an object with matching labels is selected.
                         type: object
                     type: object
+                  region:
+                    description: Region can be used to supply an optional region. If no region is defined, aws-global region will be used which is the default region for IAM resources in the aws partition
+                    type: string
                   userName:
                     description: UserName presents the name of the IAMUser.
                     type: string

--- a/package/crds/identity.aws.crossplane.io_iamusers.yaml
+++ b/package/crds/identity.aws.crossplane.io_iamusers.yaml
@@ -65,6 +65,9 @@ spec:
                   permissionsBoundary:
                     description: The ARN of the policy that is used to set the permissions boundary for the user.
                     type: string
+                  region:
+                    description: Region can be used to supply an optional region. If no region is defined, aws-global region will be used which is the default region for IAM resources in the aws partition
+                    type: string
                   tags:
                     description: A list of tags that you want to attach to the newly created user.
                     items:

--- a/package/crds/route53.aws.crossplane.io_hostedzones.yaml
+++ b/package/crds/route53.aws.crossplane.io_hostedzones.yaml
@@ -75,6 +75,9 @@ spec:
                   name:
                     description: "The name of the domain. Specify a fully qualified domain name, for example, www.example.com. The trailing dot is optional; Amazon Route 53 assumes that the domain name is fully qualified. This means that Route 53 treats www.example.com (without a trailing dot) and www.example.com. (with a trailing dot) as identical. \n If you're creating a public hosted zone, this is the name you have registered with your DNS registrar. If your domain name is registered with a registrar other than Route 53, change the name servers for your domain to the set of NameServers that CreateHostedHostedZone returns in DelegationSet."
                     type: string
+                  region:
+                    description: Region can be used to supply an optional region. If no region is defined, aws-global region will be used which is the default region for IAM resources in the aws partition
+                    type: string
                   vpc:
                     description: "(Private hosted zones only) A complex type that contains information about the Amazon VPC that you're associating with this hosted zone. \n You can specify only one Amazon VPC when you create a private hosted zone. To associate additional Amazon VPCs with the hosted zone, use AssociateVPCWithHostedZone (https://docs.aws.amazon.com/Route53/latest/APIReference/API_AssociateVPCWithHostedZone.html) after you create a hosted zone."
                     properties:

--- a/pkg/controller/identity/iamaccesskey/controller.go
+++ b/pkg/controller/identity/iamaccesskey/controller.go
@@ -72,7 +72,15 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	cr, ok := mg.(*v1alpha1.IAMAccessKey)
+	region := awsclient.GlobalRegion
+	if cr.Spec.ForProvider.Region != "" {
+		region = cr.Spec.ForProvider.Region
+	}
+	if !ok {
+		return nil, errors.New(errUnexpectedObject)
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/identity/iamgroup/controller.go
+++ b/pkg/controller/identity/iamgroup/controller.go
@@ -75,7 +75,15 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	cr, ok := mg.(*v1alpha1.IAMGroup)
+	region := awsclient.GlobalRegion
+	if cr.Spec.ForProvider.Region != "" {
+		region = cr.Spec.ForProvider.Region
+	}
+	if !ok {
+		return nil, errors.New(errUnexpectedObject)
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/identity/iamgrouppolicyattachment/controller.go
+++ b/pkg/controller/identity/iamgrouppolicyattachment/controller.go
@@ -74,7 +74,15 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	cr, ok := mg.(*v1alpha1.IAMGroupPolicyAttachment)
+	region := awsclient.GlobalRegion
+	if cr.Spec.ForProvider.Region != "" {
+		region = cr.Spec.ForProvider.Region
+	}
+	if !ok {
+		return nil, errors.New(errUnexpectedObject)
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/identity/iamgroupusermembership/controller.go
+++ b/pkg/controller/identity/iamgroupusermembership/controller.go
@@ -74,7 +74,15 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	cr, ok := mg.(*v1alpha1.IAMGroupUserMembership)
+	region := awsclient.GlobalRegion
+	if cr.Spec.ForProvider.Region != "" {
+		region = cr.Spec.ForProvider.Region
+	}
+	if !ok {
+		return nil, errors.New(errUnexpectedObject)
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/identity/iampolicy/controller.go
+++ b/pkg/controller/identity/iampolicy/controller.go
@@ -77,7 +77,15 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	cr, ok := mg.(*v1alpha1.IAMPolicy)
+	region := awsclient.GlobalRegion
+	if cr.Spec.ForProvider.Region != "" {
+		region = cr.Spec.ForProvider.Region
+	}
+	if !ok {
+		return nil, errors.New(errUnexpectedObject)
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/identity/iamrole/controller.go
+++ b/pkg/controller/identity/iamrole/controller.go
@@ -79,7 +79,15 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	cr, ok := mg.(*v1beta1.IAMRole)
+	region := awsclient.GlobalRegion
+	if cr.Spec.ForProvider.Region != "" {
+		region = cr.Spec.ForProvider.Region
+	}
+	if !ok {
+		return nil, errors.New(errUnexpectedObject)
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/identity/iamrolepolicyattachment/controller.go
+++ b/pkg/controller/identity/iamrolepolicyattachment/controller.go
@@ -75,7 +75,15 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	cr, ok := mg.(*v1beta1.IAMRolePolicyAttachment)
+	region := awsclient.GlobalRegion
+	if cr.Spec.ForProvider.Region != "" {
+		region = cr.Spec.ForProvider.Region
+	}
+	if !ok {
+		return nil, errors.New(errUnexpectedObject)
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/identity/iamuser/controller.go
+++ b/pkg/controller/identity/iamuser/controller.go
@@ -77,7 +77,15 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	cr, ok := mg.(*v1alpha1.IAMUser)
+	region := awsclient.GlobalRegion
+	if cr.Spec.ForProvider.Region != "" {
+		region = cr.Spec.ForProvider.Region
+	}
+	if !ok {
+		return nil, errors.New(errUnexpectedObject)
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/identity/iamuserpolicyattachment/controller.go
+++ b/pkg/controller/identity/iamuserpolicyattachment/controller.go
@@ -76,7 +76,15 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	cr, ok := mg.(*v1alpha1.IAMUserPolicyAttachment)
+	region := awsclient.GlobalRegion
+	if cr.Spec.ForProvider.Region != "" {
+		region = cr.Spec.ForProvider.Region
+	}
+	if !ok {
+		return nil, errors.New(errUnexpectedObject)
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/route53/hostedzone/controller.go
+++ b/pkg/controller/route53/hostedzone/controller.go
@@ -78,7 +78,15 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	cr, ok := mg.(*v1alpha1.HostedZone)
+	region := awsclient.GlobalRegion
+	if cr.Spec.ForProvider.Region != "" {
+		region = cr.Spec.ForProvider.Region
+	}
+	if !ok {
+		return nil, errors.New(errUnexpectedObject)
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/route53/resourcerecordset/controller.go
+++ b/pkg/controller/route53/resourcerecordset/controller.go
@@ -75,7 +75,15 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	cr, ok := mg.(*v1alpha1.ResourceRecordSet)
+	region := awsclient.GlobalRegion
+	if cr.Spec.ForProvider.Region != "" {
+		region = cr.Spec.ForProvider.Region
+	}
+	if !ok {
+		return nil, errors.New(errUnexpectedObject)
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Expose optional region on iam and route53 resources.  Can be used in non aws partitions (gov|cn) to override the global region default which only applies to aws partition.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #
https://github.com/crossplane/provider-aws/issues/596

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
* Unit tests
* Testing IAMRole against gov partition
* Testing IAMRole in aws partition without region set
* Testing IAMRole in aws partition with us-east-[1-2] as the region
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
