### PR TITLE
ec2.securitygroup: add security group resolver

### DIFF
--- a/apis/ec2/v1beta1/referencers.go
+++ b/apis/ec2/v1beta1/referencers.go
@@ -89,10 +89,54 @@ func (mg *SecurityGroup) ResolveReferences(ctx context.Context, c client.Reader)
 				Extract:      reference.ExternalName(),
 			})
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("spec.forProvider.ingress[%d].userIdGroupPairs[%d]", i, j))
+				return errors.Wrap(err, fmt.Sprintf("spec.forProvider.ingress[%d].userIdGroupPairs[%d].vpcId", i, j))
 			}
 			mg.Spec.ForProvider.Ingress[i].UserIDGroupPairs[j].VPCID = reference.ToPtrValue(rsp.ResolvedValue)
 			mg.Spec.ForProvider.Ingress[i].UserIDGroupPairs[j].VPCIDRef = rsp.ResolvedReference
+
+			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+				CurrentValue: reference.FromPtrValue(pair.GroupID),
+				Reference:    pair.GroupIDRef,
+				Selector:     pair.GroupIDSelector,
+				To:           reference.To{Managed: &SecurityGroup{}, List: &SecurityGroupList{}},
+				Extract:      reference.ExternalName(),
+			})
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("spec.forProvider.ingress[%d].userIdGroupPairs[%d].groupId", i, j))
+			}
+			mg.Spec.ForProvider.Ingress[i].UserIDGroupPairs[j].GroupID = reference.ToPtrValue(rsp.ResolvedValue)
+			mg.Spec.ForProvider.Ingress[i].UserIDGroupPairs[j].GroupIDRef = rsp.ResolvedReference
+		}
+	}
+
+	for i, egr := range mg.Spec.ForProvider.Egress {
+		for j, pair := range egr.UserIDGroupPairs {
+			// Resolve spec.forProvider.egress[*].userIdGroupPairs[*]
+			rsp, err := r.Resolve(ctx, reference.ResolutionRequest{
+				CurrentValue: reference.FromPtrValue(pair.VPCID),
+				Reference:    pair.VPCIDRef,
+				Selector:     pair.VPCIDSelector,
+				To:           reference.To{Managed: &VPC{}, List: &VPCList{}},
+				Extract:      reference.ExternalName(),
+			})
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("spec.forProvider.egress[%d].userIdGroupPairs[%d].vpcId", i, j))
+			}
+			mg.Spec.ForProvider.Egress[i].UserIDGroupPairs[j].VPCID = reference.ToPtrValue(rsp.ResolvedValue)
+			mg.Spec.ForProvider.Egress[i].UserIDGroupPairs[j].VPCIDRef = rsp.ResolvedReference
+
+			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+				CurrentValue: reference.FromPtrValue(pair.GroupID),
+				Reference:    pair.GroupIDRef,
+				Selector:     pair.GroupIDSelector,
+				To:           reference.To{Managed: &SecurityGroup{}, List: &SecurityGroupList{}},
+				Extract:      reference.ExternalName(),
+			})
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("spec.forProvider.egress[%d].userIdGroupPairs[%d].groupId", i, j))
+			}
+			mg.Spec.ForProvider.Egress[i].UserIDGroupPairs[j].GroupID = reference.ToPtrValue(rsp.ResolvedValue)
+			mg.Spec.ForProvider.Egress[i].UserIDGroupPairs[j].GroupIDRef = rsp.ResolvedReference
 		}
 	}
 

--- a/apis/ec2/v1beta1/referencers.go
+++ b/apis/ec2/v1beta1/referencers.go
@@ -80,7 +80,7 @@ func (mg *SecurityGroup) ResolveReferences(ctx context.Context, c client.Reader)
 
 	for i, ing := range mg.Spec.ForProvider.Ingress {
 		for j, pair := range ing.UserIDGroupPairs {
-			// Resolve spec.forProvider.ingress[*].userIdGroupPairs[*]
+			// Resolve spec.forProvider.ingress[*].userIdGroupPairs[*].vpcId
 			rsp, err := r.Resolve(ctx, reference.ResolutionRequest{
 				CurrentValue: reference.FromPtrValue(pair.VPCID),
 				Reference:    pair.VPCIDRef,
@@ -94,6 +94,7 @@ func (mg *SecurityGroup) ResolveReferences(ctx context.Context, c client.Reader)
 			mg.Spec.ForProvider.Ingress[i].UserIDGroupPairs[j].VPCID = reference.ToPtrValue(rsp.ResolvedValue)
 			mg.Spec.ForProvider.Ingress[i].UserIDGroupPairs[j].VPCIDRef = rsp.ResolvedReference
 
+			// Resolve spec.forProvider.ingress[*].userIdGroupPairs[*].groupId
 			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 				CurrentValue: reference.FromPtrValue(pair.GroupID),
 				Reference:    pair.GroupIDRef,
@@ -111,7 +112,7 @@ func (mg *SecurityGroup) ResolveReferences(ctx context.Context, c client.Reader)
 
 	for i, egr := range mg.Spec.ForProvider.Egress {
 		for j, pair := range egr.UserIDGroupPairs {
-			// Resolve spec.forProvider.egress[*].userIdGroupPairs[*]
+			// Resolve spec.forProvider.egress[*].userIdGroupPairs[*].vpcId
 			rsp, err := r.Resolve(ctx, reference.ResolutionRequest{
 				CurrentValue: reference.FromPtrValue(pair.VPCID),
 				Reference:    pair.VPCIDRef,
@@ -125,6 +126,7 @@ func (mg *SecurityGroup) ResolveReferences(ctx context.Context, c client.Reader)
 			mg.Spec.ForProvider.Egress[i].UserIDGroupPairs[j].VPCID = reference.ToPtrValue(rsp.ResolvedValue)
 			mg.Spec.ForProvider.Egress[i].UserIDGroupPairs[j].VPCIDRef = rsp.ResolvedReference
 
+			// Resolve spec.forProvider.egress[*].userIdGroupPairs[*].groupId
 			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 				CurrentValue: reference.FromPtrValue(pair.GroupID),
 				Reference:    pair.GroupIDRef,

--- a/apis/ec2/v1beta1/securitygroup_types.go
+++ b/apis/ec2/v1beta1/securitygroup_types.go
@@ -173,6 +173,14 @@ type UserIDGroupPair struct {
 	VPCPeeringConnectionID *string `json:"vpcPeeringConnectionId,omitempty"`
 }
 
+// ClearRefSelectors nils out ref and selectors
+func (u *UserIDGroupPair) ClearRefSelectors() {
+	u.VPCIDRef = nil
+	u.VPCIDSelector = nil
+	u.GroupIDRef = nil
+	u.GroupIDSelector = nil
+}
+
 // IPPermission Describes a set of permissions for a security group rule.
 type IPPermission struct {
 	// The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6

--- a/apis/ec2/v1beta1/securitygroup_types.go
+++ b/apis/ec2/v1beta1/securitygroup_types.go
@@ -126,6 +126,15 @@ type UserIDGroupPair struct {
 	// +optional
 	GroupID *string `json:"groupId,omitempty"`
 
+	// GroupIDRef reference a security group to retrieve its GroupID
+	// +optional
+	// +immutable
+	GroupIDRef *xpv1.Reference `json:"groupIdRef,omitempty"`
+
+	// GroupIDSelector selects reference to a security group to retrieve its GroupID
+	// +optional
+	GroupIDSelector *xpv1.Selector `json:"groupIdSelector,omitempty"`
+
 	// The name of the security group. In a request, use this parameter for a security
 	// group in EC2-Classic or a default VPC only. For a security group in a nondefault
 	// VPC, use the security group ID.

--- a/apis/ec2/v1beta1/zz_generated.deepcopy.go
+++ b/apis/ec2/v1beta1/zz_generated.deepcopy.go
@@ -1320,6 +1320,16 @@ func (in *UserIDGroupPair) DeepCopyInto(out *UserIDGroupPair) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.GroupIDRef != nil {
+		in, out := &in.GroupIDRef, &out.GroupIDRef
+		*out = new(v1.Reference)
+		**out = **in
+	}
+	if in.GroupIDSelector != nil {
+		in, out := &in.GroupIDSelector, &out.GroupIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.GroupName != nil {
 		in, out := &in.GroupName, &out.GroupName
 		*out = new(string)

--- a/package/crds/ec2.aws.crossplane.io_securitygroups.yaml
+++ b/package/crds/ec2.aws.crossplane.io_securitygroups.yaml
@@ -134,6 +134,27 @@ spec:
                               groupId:
                                 description: The ID of the security group.
                                 type: string
+                              groupIdRef:
+                                description: GroupIDRef reference a security group to retrieve its GroupID
+                                properties:
+                                  name:
+                                    description: Name of the referenced object.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              groupIdSelector:
+                                description: GroupIDSelector selects reference to a security group to retrieve its GroupID
+                                properties:
+                                  matchControllerRef:
+                                    description: MatchControllerRef ensures an object with the same controller reference as the selecting object is selected.
+                                    type: boolean
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: MatchLabels ensures an object with matching labels is selected.
+                                    type: object
+                                type: object
                               groupName:
                                 description: "The name of the security group. In a request, use this parameter for a security group in EC2-Classic or a default VPC only. For a security group in a nondefault VPC, use the security group ID. \n For a referenced security group in another VPC, this value is not returned if the referenced security group is deleted."
                                 type: string
@@ -248,6 +269,27 @@ spec:
                               groupId:
                                 description: The ID of the security group.
                                 type: string
+                              groupIdRef:
+                                description: GroupIDRef reference a security group to retrieve its GroupID
+                                properties:
+                                  name:
+                                    description: Name of the referenced object.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              groupIdSelector:
+                                description: GroupIDSelector selects reference to a security group to retrieve its GroupID
+                                properties:
+                                  matchControllerRef:
+                                    description: MatchControllerRef ensures an object with the same controller reference as the selecting object is selected.
+                                    type: boolean
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: MatchLabels ensures an object with matching labels is selected.
+                                    type: object
+                                type: object
                               groupName:
                                 description: "The name of the security group. In a request, use this parameter for a security group in EC2-Classic or a default VPC only. For a security group in a nondefault VPC, use the security group ID. \n For a referenced security group in another VPC, this value is not returned if the referenced security group is deleted."
                                 type: string


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add possibility to refer to security group kubernetes objects in ingress/egress rules.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #592 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested in AWS by creating two security groups and using a named reference. Resolvers do not seem to have
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
