### PR TITLE
ec2.securitygroup: Handle nil fromPort/toPort (ipProtocol -1)

### DIFF
--- a/pkg/clients/ec2/securitygroup.go
+++ b/pkg/clients/ec2/securitygroup.go
@@ -150,7 +150,7 @@ func GenerateIPPermissions(objectPerms []ec2.IpPermission) []v1beta1.IPPermissio
 		permissions[i] = ipPerm
 	}
 	sort.Slice(permissions, func(i, j int) bool {
-		return *permissions[i].FromPort < *permissions[j].FromPort
+		return aws.Int64Value(permissions[i].FromPort) < aws.Int64Value(permissions[j].FromPort)
 	})
 	return permissions
 }
@@ -304,10 +304,10 @@ func CreateSGPatch(in ec2.SecurityGroup, target v1beta1.SecurityGroupParameters)
 	}
 
 	sort.Slice(target.Egress, func(i, j int) bool {
-		return *target.Egress[i].FromPort < *target.Egress[j].FromPort
+		return aws.Int64Value(target.Egress[i].FromPort) < aws.Int64Value(target.Egress[j].FromPort)
 	})
 	sort.Slice(target.Ingress, func(i, j int) bool {
-		return *target.Ingress[i].FromPort < *target.Ingress[j].FromPort
+		return aws.Int64Value(target.Ingress[i].FromPort) < aws.Int64Value(target.Ingress[j].FromPort)
 	})
 
 	jsonPatch, err := awsclients.CreateJSONPatch(*currentParams, target)


### PR DESCRIPTION
### Description of your changes

When ipProtocol is -1, fromPort/toPort will be nil. This causes a panic
when sorting ingress/egress rules. We just need a stable sort so we can
use an aws helper to get 0 for the value in that case.

Also add a normal test for the sort functions (have more than one item so we will sort something).

Fixes #616

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

* Unit test
* YAML from #616

[contribution process]: https://git.io/fj2m9
