### PR TITLE
Provider config partition

### DIFF
--- a/apis/v1beta1/providerconfig_types.go
+++ b/apis/v1beta1/providerconfig_types.go
@@ -34,6 +34,11 @@ type ProviderCredentials struct {
 	// +kubebuilder:validation:Enum=None;Secret;InjectedIdentity;Environment;Filesystem
 	Source xpv1.CredentialsSource `json:"source"`
 
+	// Partition the provider credentials should be used in.
+	// This applies to clients and resources where a global region is used (iam, sts, route53, etc)
+	// +optional
+	Partition string `json:"partition,omitempty"`
+
 	xpv1.CommonCredentialSelectors `json:",inline"`
 }
 

--- a/package/crds/aws.crossplane.io_providerconfigs.yaml
+++ b/package/crds/aws.crossplane.io_providerconfigs.yaml
@@ -63,6 +63,9 @@ spec:
                     required:
                     - path
                     type: object
+                  partition:
+                    description: Partition the provider credentials should be used in. This applies to clients and resources where a global region is used (iam, sts, route53, etc)
+                    type: string
                   secretRef:
                     description: A SecretRef is a reference to a secret key that contains the credentials that must be used to connect to the provider.
                     properties:

--- a/pkg/clients/aws.go
+++ b/pkg/clients/aws.go
@@ -55,9 +55,28 @@ import (
 // DefaultSection for INI files.
 const DefaultSection = ini.DefaultSection
 
-// GlobalRegion is the region name used for AWS services that do not have a notion
-// of region.
-const GlobalRegion = "aws-global"
+// GetGlobalRegion returns the global region for AWS services that do not have a notion
+// of region.  Ex. iam
+// Defaults to 'aws' partition
+func GetGlobalRegion(partition string) string {
+	// Global regions are convention based by partition
+	// Ex. "aws-global"
+	if partition == "" {
+		return "aws-global"
+	}
+	return partition + "-global"
+}
+
+// GetGlobalRegionForProviderConfig returns the global region for a provider config
+func GetGlobalRegionForProviderConfig(ctx context.Context, c client.Client, mg resource.Managed) (string, error) {
+	pc, err := GetProviderConfig(ctx, c, mg)
+	if err != nil {
+		return "", err
+	}
+	partition := pc.Spec.Credentials.Partition
+	region := GetGlobalRegion(partition)
+	return region, nil
+}
 
 // A FieldOption determines how common Go types are translated to the types
 // required by the AWS Go SDK.
@@ -85,11 +104,19 @@ func GetConfig(ctx context.Context, c client.Client, mg resource.Managed, region
 	}
 }
 
-// UseProviderConfig to produce a config that can be used to authenticate to AWS.
-func UseProviderConfig(ctx context.Context, c client.Client, mg resource.Managed, region string) (*aws.Config, error) {
+func GetProviderConfig(ctx context.Context, c client.Client, mg resource.Managed) (*v1beta1.ProviderConfig, error) {
 	pc := &v1beta1.ProviderConfig{}
 	if err := c.Get(ctx, types.NamespacedName{Name: mg.GetProviderConfigReference().Name}, pc); err != nil {
 		return nil, errors.Wrap(err, "cannot get referenced Provider")
+	}
+	return pc, nil
+}
+
+// UseProviderConfig to produce a config that can be used to authenticate to AWS.
+func UseProviderConfig(ctx context.Context, c client.Client, mg resource.Managed, region string) (*aws.Config, error) {
+	pc, err := GetProviderConfig(ctx, c, mg)
+	if err != nil {
+		return nil, err
 	}
 
 	t := resource.NewProviderConfigUsageTracker(c, &v1beta1.ProviderConfigUsage{})

--- a/pkg/clients/aws.go
+++ b/pkg/clients/aws.go
@@ -104,6 +104,7 @@ func GetConfig(ctx context.Context, c client.Client, mg resource.Managed, region
 	}
 }
 
+// GetProviderConfig retrieves the providerConfig from kubernetes associated with a managed resource
 func GetProviderConfig(ctx context.Context, c client.Client, mg resource.Managed) (*v1beta1.ProviderConfig, error) {
 	pc := &v1beta1.ProviderConfig{}
 	if err := c.Get(ctx, types.NamespacedName{Name: mg.GetProviderConfigReference().Name}, pc); err != nil {

--- a/pkg/clients/aws_test.go
+++ b/pkg/clients/aws_test.go
@@ -19,19 +19,21 @@ package aws
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
-	"github.com/crossplane/provider-aws/apis/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	. "github.com/onsi/gomega"
+
+	"github.com/crossplane/provider-aws/apis/v1beta1"
 )
 
 const (

--- a/pkg/controller/identity/iamaccesskey/controller.go
+++ b/pkg/controller/identity/iamaccesskey/controller.go
@@ -72,7 +72,11 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	region, err := awsclient.GetGlobalRegionForProviderConfig(ctx, c.kube, mg)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/identity/iamgroup/controller.go
+++ b/pkg/controller/identity/iamgroup/controller.go
@@ -75,7 +75,11 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	region, err := awsclient.GetGlobalRegionForProviderConfig(ctx, c.kube, mg)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/identity/iamgrouppolicyattachment/controller.go
+++ b/pkg/controller/identity/iamgrouppolicyattachment/controller.go
@@ -74,7 +74,11 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	region, err := awsclient.GetGlobalRegionForProviderConfig(ctx, c.kube, mg)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/identity/iamgroupusermembership/controller.go
+++ b/pkg/controller/identity/iamgroupusermembership/controller.go
@@ -74,7 +74,11 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	region, err := awsclient.GetGlobalRegionForProviderConfig(ctx, c.kube, mg)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/identity/iampolicy/controller.go
+++ b/pkg/controller/identity/iampolicy/controller.go
@@ -77,7 +77,11 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	region, err := awsclient.GetGlobalRegionForProviderConfig(ctx, c.kube, mg)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/identity/iamrole/controller.go
+++ b/pkg/controller/identity/iamrole/controller.go
@@ -79,7 +79,11 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	region, err := awsclient.GetGlobalRegionForProviderConfig(ctx, c.kube, mg)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/identity/iamrolepolicyattachment/controller.go
+++ b/pkg/controller/identity/iamrolepolicyattachment/controller.go
@@ -75,7 +75,11 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	region, err := awsclient.GetGlobalRegionForProviderConfig(ctx, c.kube, mg)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/identity/iamuser/controller.go
+++ b/pkg/controller/identity/iamuser/controller.go
@@ -77,7 +77,11 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	region, err := awsclient.GetGlobalRegionForProviderConfig(ctx, c.kube, mg)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/identity/iamuserpolicyattachment/controller.go
+++ b/pkg/controller/identity/iamuserpolicyattachment/controller.go
@@ -76,7 +76,11 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	region, err := awsclient.GetGlobalRegionForProviderConfig(ctx, c.kube, mg)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/route53/hostedzone/controller.go
+++ b/pkg/controller/route53/hostedzone/controller.go
@@ -78,7 +78,11 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	region, err := awsclient.GetGlobalRegionForProviderConfig(ctx, c.kube, mg)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/route53/resourcerecordset/controller.go
+++ b/pkg/controller/route53/resourcerecordset/controller.go
@@ -75,7 +75,11 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, awsclient.GlobalRegion)
+	region, err := awsclient.GetGlobalRegionForProviderConfig(ctx, c.kube, mg)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := awsclient.GetConfig(ctx, c.kube, mg, region)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Expose optional partition on iam and route53 resources.  Can be used in non aws partitions (gov|cn) to override the global region default which only applies to aws partition.

Since [global resources can't be shared across roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html), setting the partition on the providerConfig was preferred over the following:
https://github.com/crossplane/provider-aws/pull/605
https://github.com/crossplane/provider-aws/pull/608

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #
https://github.com/crossplane/provider-aws/issues/596

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
* Unit tests
* Testing IAMRole in aws partition without providerConfig partition set - success
* Testing IAMRole in aws partition with `aws` providerConfig partition set - success
* Testing IAMRole in aws partition with `aws-test` providerConfig partition set - fail
* Testing IAMRole in aws-us-gov partition without providerConfig partition set - fail
* Testing IAMRole in aws-us-gov partition with `aws` providerConfig partition set - fail
* Testing IAMRole in aws-us-gov partition with `aws-us-gov` providerConfig partition set - success
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
