### PR TITLE
ec2.securitygroup: fix update/delete/add tags

### DIFF
--- a/pkg/clients/ec2/fake/securitygroup.go
+++ b/pkg/clients/ec2/fake/securitygroup.go
@@ -34,6 +34,7 @@ type MockSecurityGroupClient struct {
 	MockAuthorizeEgress func(*ec2.AuthorizeSecurityGroupEgressInput) ec2.AuthorizeSecurityGroupEgressRequest
 	MockRevokeEgress    func(*ec2.RevokeSecurityGroupEgressInput) ec2.RevokeSecurityGroupEgressRequest
 	MockCreateTags      func(*ec2.CreateTagsInput) ec2.CreateTagsRequest
+	MockDeleteTags      func(*ec2.DeleteTagsInput) ec2.DeleteTagsRequest
 }
 
 // CreateSecurityGroupRequest mocks CreateSecurityGroupRequest method
@@ -69,4 +70,9 @@ func (m *MockSecurityGroupClient) RevokeSecurityGroupEgressRequest(input *ec2.Re
 // CreateTagsRequest mocks CreateTagsInput method
 func (m *MockSecurityGroupClient) CreateTagsRequest(input *ec2.CreateTagsInput) ec2.CreateTagsRequest {
 	return m.MockCreateTags(input)
+}
+
+// DeleteTagsRequest mocks DeleteTagsInput method
+func (m *MockSecurityGroupClient) DeleteTagsRequest(input *ec2.DeleteTagsInput) ec2.DeleteTagsRequest {
+	return m.MockDeleteTags(input)
 }

--- a/pkg/clients/ec2/securitygroup.go
+++ b/pkg/clients/ec2/securitygroup.go
@@ -35,6 +35,7 @@ type SecurityGroupClient interface {
 	AuthorizeSecurityGroupEgressRequest(input *ec2.AuthorizeSecurityGroupEgressInput) ec2.AuthorizeSecurityGroupEgressRequest
 	RevokeSecurityGroupEgressRequest(input *ec2.RevokeSecurityGroupEgressInput) ec2.RevokeSecurityGroupEgressRequest
 	CreateTagsRequest(input *ec2.CreateTagsInput) ec2.CreateTagsRequest
+	DeleteTagsRequest(input *ec2.DeleteTagsInput) ec2.DeleteTagsRequest
 }
 
 // NewSecurityGroupClient generates client for AWS Security Group API


### PR DESCRIPTION
Fixes #504

### Description of your changes

Use tag helper function to detect added/removed/updated tags, and call the delete tag API before we call the create tag API.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
- created object with tags
- mutated one tag
- delete multiple tags
- delete all tags (fails, see #625)

[contribution process]: https://git.io/fj2m9
