### PR TITLE
cache.replicationgroup: Support pattern matching for engine version

### DIFF
--- a/pkg/clients/elasticache/elasticache.go
+++ b/pkg/clients/elasticache/elasticache.go
@@ -19,6 +19,7 @@ package elasticache
 import (
 	"reflect"
 	"strconv"
+	"strings"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
@@ -219,9 +220,22 @@ func automaticFailoverEnabled(af elasticache.AutomaticFailoverStatus) *bool {
 	return &r
 }
 
+func versionMatches(kubeVersion *string, awsVersion *string) bool {
+	switch {
+	case clients.StringValue(kubeVersion) == clients.StringValue(awsVersion):
+		return true
+
+	case kubeVersion == nil || awsVersion == nil:
+		return false
+
+	default:
+		return strings.HasSuffix(*kubeVersion, ".x") && strings.HasPrefix(*awsVersion, strings.TrimSuffix(*kubeVersion, "x"))
+	}
+}
+
 func cacheClusterNeedsUpdate(kube v1beta1.ReplicationGroupParameters, cc elasticache.CacheCluster) bool { // nolint:gocyclo
 	// AWS will set and return a default version if we don't specify one.
-	if !reflect.DeepEqual(kube.EngineVersion, cc.EngineVersion) {
+	if !versionMatches(kube.EngineVersion, cc.EngineVersion) {
 		return true
 	}
 	if pg, name := cc.CacheParameterGroup, kube.CacheParameterGroupName; pg != nil && !reflect.DeepEqual(name, pg.CacheParameterGroupName) {

--- a/pkg/clients/elasticache/elasticache_test.go
+++ b/pkg/clients/elasticache/elasticache_test.go
@@ -956,3 +956,70 @@ func TestIsSubnetGroupUpToDate(t *testing.T) {
 		})
 	}
 }
+
+func TestVersionMatches(t *testing.T) {
+	cases := []struct {
+		name        string
+		kubeVersion *string
+		awsVersion  *string
+		want        bool
+	}{
+		{
+			name:        "Same value",
+			kubeVersion: aws.String("5.0.8"),
+			awsVersion:  aws.String("5.0.8"),
+			want:        true,
+		},
+		{
+			name:        "Same pattern", // currently this will never happen, but if it does it should match..
+			kubeVersion: aws.String("6.x"),
+			awsVersion:  aws.String("6.x"),
+			want:        true,
+		},
+		{
+			name:        "Same with nil",
+			kubeVersion: nil,
+			awsVersion:  nil,
+			want:        true,
+		},
+		{
+			name:        "nil in kubernetes",
+			kubeVersion: nil,
+			awsVersion:  aws.String("5.0.8"),
+			want:        false,
+		},
+		{
+			name:        "nil from aws",
+			kubeVersion: aws.String("5.0.8"),
+			awsVersion:  nil,
+			want:        false,
+		},
+		{
+			name:        "mismatch",
+			kubeVersion: aws.String("5.0.8"),
+			awsVersion:  aws.String("5.0.9"),
+			want:        false,
+		},
+		{
+			name:        "pattern match",
+			kubeVersion: aws.String("6.x"),
+			awsVersion:  aws.String("6.0.5"),
+			want:        true,
+		},
+		{
+			name:        "pattern mismatch",
+			kubeVersion: aws.String("6.x"),
+			awsVersion:  aws.String("5.0.8"),
+			want:        false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := versionMatches(tc.kubeVersion, tc.awsVersion)
+			if got != tc.want {
+				t.Errorf("versionMatches(%+v) - got %v", tc, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
At the moment, it is only possible to send in version 6.x for redis
engine version on redis 6, but AWS will return back a specific version
like 6.0.5.

In this case, redis will never become ready.

### Description of your changes

Change the controller to consider the resource up to date when we
specify 6.x and have 6.0.5.

Fixes #622

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
* added unit test
* created redis 6.x cluster and check that it is ready

```
k get replicationgroup 
NAME                               READY   SYNCED   STATE       VERSION   AGE
redis-s9c9r-vw7mx                  True    True     available   6.x       3h3m
```

[contribution process]: https://git.io/fj2m9
