### PR TITLE
ec2.securitygroup: fix add, implement revoke/update ingress and egress rules

### DIFF
--- a/apis/ec2/v1beta1/referencers.go
+++ b/apis/ec2/v1beta1/referencers.go
@@ -88,10 +88,54 @@ func (mg *SecurityGroup) ResolveReferences(ctx context.Context, c client.Reader)
 				Extract:      reference.ExternalName(),
 			})
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("spec.forProvider.ingress[%d].userIdGroupPairs[%d]", i, j))
+				return errors.Wrap(err, fmt.Sprintf("spec.forProvider.ingress[%d].userIdGroupPairs[%d].vpcId", i, j))
 			}
 			mg.Spec.ForProvider.Ingress[i].UserIDGroupPairs[j].VPCID = reference.ToPtrValue(rsp.ResolvedValue)
 			mg.Spec.ForProvider.Ingress[i].UserIDGroupPairs[j].VPCIDRef = rsp.ResolvedReference
+
+			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+				CurrentValue: reference.FromPtrValue(pair.GroupID),
+				Reference:    pair.GroupIDRef,
+				Selector:     pair.GroupIDSelector,
+				To:           reference.To{Managed: &SecurityGroup{}, List: &SecurityGroupList{}},
+				Extract:      reference.ExternalName(),
+			})
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("spec.forProvider.ingress[%d].userIdGroupPairs[%d].groupId", i, j))
+			}
+			mg.Spec.ForProvider.Ingress[i].UserIDGroupPairs[j].GroupID = reference.ToPtrValue(rsp.ResolvedValue)
+			mg.Spec.ForProvider.Ingress[i].UserIDGroupPairs[j].GroupIDRef = rsp.ResolvedReference
+		}
+	}
+
+	for i, egr := range mg.Spec.ForProvider.Egress {
+		for j, pair := range egr.UserIDGroupPairs {
+			// Resolve spec.forProvider.egress[*].userIdGroupPairs[*]
+			rsp, err := r.Resolve(ctx, reference.ResolutionRequest{
+				CurrentValue: reference.FromPtrValue(pair.VPCID),
+				Reference:    pair.VPCIDRef,
+				Selector:     pair.VPCIDSelector,
+				To:           reference.To{Managed: &VPC{}, List: &VPCList{}},
+				Extract:      reference.ExternalName(),
+			})
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("spec.forProvider.egress[%d].userIdGroupPairs[%d].vpcId", i, j))
+			}
+			mg.Spec.ForProvider.Egress[i].UserIDGroupPairs[j].VPCID = reference.ToPtrValue(rsp.ResolvedValue)
+			mg.Spec.ForProvider.Egress[i].UserIDGroupPairs[j].VPCIDRef = rsp.ResolvedReference
+
+			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+				CurrentValue: reference.FromPtrValue(pair.GroupID),
+				Reference:    pair.GroupIDRef,
+				Selector:     pair.GroupIDSelector,
+				To:           reference.To{Managed: &SecurityGroup{}, List: &SecurityGroupList{}},
+				Extract:      reference.ExternalName(),
+			})
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("spec.forProvider.egress[%d].userIdGroupPairs[%d].groupId", i, j))
+			}
+			mg.Spec.ForProvider.Egress[i].UserIDGroupPairs[j].GroupID = reference.ToPtrValue(rsp.ResolvedValue)
+			mg.Spec.ForProvider.Egress[i].UserIDGroupPairs[j].GroupIDRef = rsp.ResolvedReference
 		}
 	}
 

--- a/apis/ec2/v1beta1/securitygroup_types.go
+++ b/apis/ec2/v1beta1/securitygroup_types.go
@@ -126,6 +126,15 @@ type UserIDGroupPair struct {
 	// +optional
 	GroupID *string `json:"groupId,omitempty"`
 
+	// GroupIDRef reference a security group to retrieve its GroupID
+	// +optional
+	// +immutable
+	GroupIDRef *xpv1.Reference `json:"groupIdRef,omitempty"`
+
+	// GroupIDSelector selects reference to a security group to retrieve its GroupID
+	// +optional
+	GroupIDSelector *xpv1.Selector `json:"groupIdSelector,omitempty"`
+
 	// The name of the security group. In a request, use this parameter for a security
 	// group in EC2-Classic or a default VPC only. For a security group in a nondefault
 	// VPC, use the security group ID.
@@ -162,6 +171,14 @@ type UserIDGroupPair struct {
 	// The ID of the VPC peering connection, if applicable.
 	// +optional
 	VPCPeeringConnectionID *string `json:"vpcPeeringConnectionId,omitempty"`
+}
+
+// ClearRefSelectors nils out ref and selectors
+func (u *UserIDGroupPair) ClearRefSelectors() {
+	u.VPCIDRef = nil
+	u.VPCIDSelector = nil
+	u.GroupIDRef = nil
+	u.GroupIDSelector = nil
 }
 
 // IPPermission Describes a set of permissions for a security group rule.

--- a/apis/ec2/v1beta1/zz_generated.deepcopy.go
+++ b/apis/ec2/v1beta1/zz_generated.deepcopy.go
@@ -1327,6 +1327,16 @@ func (in *UserIDGroupPair) DeepCopyInto(out *UserIDGroupPair) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.GroupIDRef != nil {
+		in, out := &in.GroupIDRef, &out.GroupIDRef
+		*out = new(v1.Reference)
+		**out = **in
+	}
+	if in.GroupIDSelector != nil {
+		in, out := &in.GroupIDSelector, &out.GroupIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.GroupName != nil {
 		in, out := &in.GroupName, &out.GroupName
 		*out = new(string)

--- a/package/crds/ec2.aws.crossplane.io_securitygroups.yaml
+++ b/package/crds/ec2.aws.crossplane.io_securitygroups.yaml
@@ -210,6 +210,32 @@ spec:
                               groupId:
                                 description: The ID of the security group.
                                 type: string
+                              groupIdRef:
+                                description: GroupIDRef reference a security group
+                                  to retrieve its GroupID
+                                properties:
+                                  name:
+                                    description: Name of the referenced object.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              groupIdSelector:
+                                description: GroupIDSelector selects reference to
+                                  a security group to retrieve its GroupID
+                                properties:
+                                  matchControllerRef:
+                                    description: MatchControllerRef ensures an object
+                                      with the same controller reference as the selecting
+                                      object is selected.
+                                    type: boolean
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: MatchLabels ensures an object with
+                                      matching labels is selected.
+                                    type: object
+                                type: object
                               groupName:
                                 description: "The name of the security group. In a
                                   request, use this parameter for a security group
@@ -384,6 +410,32 @@ spec:
                               groupId:
                                 description: The ID of the security group.
                                 type: string
+                              groupIdRef:
+                                description: GroupIDRef reference a security group
+                                  to retrieve its GroupID
+                                properties:
+                                  name:
+                                    description: Name of the referenced object.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              groupIdSelector:
+                                description: GroupIDSelector selects reference to
+                                  a security group to retrieve its GroupID
+                                properties:
+                                  matchControllerRef:
+                                    description: MatchControllerRef ensures an object
+                                      with the same controller reference as the selecting
+                                      object is selected.
+                                    type: boolean
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: MatchLabels ensures an object with
+                                      matching labels is selected.
+                                    type: object
+                                type: object
                               groupName:
                                 description: "The name of the security group. In a
                                   request, use this parameter for a security group

--- a/pkg/clients/ec2/fake/securitygroup.go
+++ b/pkg/clients/ec2/fake/securitygroup.go
@@ -34,6 +34,7 @@ type MockSecurityGroupClient struct {
 	MockDescribe         func(ctx context.Context, input *ec2.DescribeSecurityGroupsInput, opts []func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error)
 	MockAuthorizeIngress func(ctx context.Context, input *ec2.AuthorizeSecurityGroupIngressInput, opts []func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupIngressOutput, error)
 	MockAuthorizeEgress  func(ctx context.Context, input *ec2.AuthorizeSecurityGroupEgressInput, opts []func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupEgressOutput, error)
+	MockRevokeIngress    func(ctx context.Context, input *ec2.RevokeSecurityGroupIngressInput, opts []func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error)
 	MockRevokeEgress     func(ctx context.Context, input *ec2.RevokeSecurityGroupEgressInput, opts []func(*ec2.Options)) (*ec2.RevokeSecurityGroupEgressOutput, error)
 	MockCreateTags       func(ctx context.Context, input *ec2.CreateTagsInput, opts []func(*ec2.Options)) (*ec2.CreateTagsOutput, error)
 	MockDeleteTags       func(ctx context.Context, input *ec2.DeleteTagsInput, opts []func(*ec2.Options)) (*ec2.DeleteTagsOutput, error)
@@ -67,6 +68,11 @@ func (m *MockSecurityGroupClient) AuthorizeSecurityGroupEgress(ctx context.Conte
 // RevokeSecurityGroupEgress mocks RevokeSecurityGroupEgress method
 func (m *MockSecurityGroupClient) RevokeSecurityGroupEgress(ctx context.Context, input *ec2.RevokeSecurityGroupEgressInput, opts ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupEgressOutput, error) {
 	return m.MockRevokeEgress(ctx, input, opts)
+}
+
+// RevokeSecurityGroupIngress mocks RevokeSecurityGroupIngress method
+func (m *MockSecurityGroupClient) RevokeSecurityGroupIngress(ctx context.Context, input *ec2.RevokeSecurityGroupIngressInput, opts ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	return m.MockRevokeIngress(ctx, input, opts)
 }
 
 // CreateTags mocks CreateTagsInput method

--- a/pkg/clients/ec2/securitygroup.go
+++ b/pkg/clients/ec2/securitygroup.go
@@ -3,7 +3,6 @@ package ec2
 import (
 	"context"
 	"errors"
-	"sort"
 
 	awsgo "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -95,54 +94,6 @@ func GenerateEC2Permissions(objectPerms []v1beta1.IPPermission) []ec2types.IpPer
 		}
 		permissions[i] = ipPerm
 	}
-	return permissions
-}
-
-// GenerateIPPermissions converts object EC2 Permissions to IPPermission format
-func GenerateIPPermissions(objectPerms []ec2types.IpPermission) []v1beta1.IPPermission {
-	if len(objectPerms) == 0 {
-		return nil
-	}
-	permissions := make([]v1beta1.IPPermission, len(objectPerms))
-	for i, p := range objectPerms {
-		ipPerm := v1beta1.IPPermission{
-			FromPort:   p.FromPort,
-			IPProtocol: aws.StringValue(p.IpProtocol),
-			ToPort:     p.ToPort,
-		}
-		for _, c := range p.IpRanges {
-			ipPerm.IPRanges = append(ipPerm.IPRanges, v1beta1.IPRange{
-				CIDRIP:      aws.StringValue(c.CidrIp),
-				Description: c.Description,
-			})
-		}
-		for _, c := range p.Ipv6Ranges {
-			ipPerm.IPv6Ranges = append(ipPerm.IPv6Ranges, v1beta1.IPv6Range{
-				CIDRIPv6:    aws.StringValue(c.CidrIpv6),
-				Description: c.Description,
-			})
-		}
-		for _, c := range p.PrefixListIds {
-			ipPerm.PrefixListIDs = append(ipPerm.PrefixListIDs, v1beta1.PrefixListID{
-				Description:  c.Description,
-				PrefixListID: aws.StringValue(c.PrefixListId),
-			})
-		}
-		for _, c := range p.UserIdGroupPairs {
-			ipPerm.UserIDGroupPairs = append(ipPerm.UserIDGroupPairs, v1beta1.UserIDGroupPair{
-				Description:            c.Description,
-				GroupID:                c.GroupId,
-				GroupName:              c.GroupName,
-				UserID:                 c.UserId,
-				VPCID:                  c.VpcId,
-				VPCPeeringConnectionID: c.VpcPeeringConnectionId,
-			})
-		}
-		permissions[i] = ipPerm
-	}
-	sort.Slice(permissions, func(i, j int) bool {
-		return awsgo.ToInt32(permissions[i].FromPort) < awsgo.ToInt32(permissions[j].FromPort)
-	})
 	return permissions
 }
 

--- a/pkg/clients/ec2/securitygroup_diff.go
+++ b/pkg/clients/ec2/securitygroup_diff.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ec2
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// ruleKey represents the unique tuple (protocol, from-to port) in a
+// format supported as a map key
+type ruleKey struct {
+	protocol string // lower case
+	fromPort int32  // -1 for nil
+	toPort   int32  // -1 for nil
+}
+
+func getInt32Key(port *int32) int32 {
+	if port == nil {
+		return -1
+	}
+	return *port
+}
+
+func getKey(perm ec2types.IpPermission) ruleKey {
+	return ruleKey{
+		protocol: strings.ToLower(aws.ToString(perm.IpProtocol)),
+		fromPort: getInt32Key(perm.FromPort),
+		toPort:   getInt32Key(perm.ToPort),
+	}
+}
+
+func compareObjects(a, b []*string) int {
+	for i := range a {
+		if a[i] == nil && b[i] != nil {
+			return -1
+		}
+		switch strings.Compare(aws.ToString(a[i]), aws.ToString(b[i])) {
+		case -1:
+			return -1
+		case 1:
+			return 1
+		case 0:
+			// continue
+		}
+	}
+	return 0 // eq
+}
+
+func userIDGroupPairCmp(i, j ec2types.UserIdGroupPair) int {
+	return compareObjects(
+		[]*string{i.Description, i.GroupId, i.GroupName, i.PeeringStatus, i.UserId, i.VpcId, i.VpcPeeringConnectionId},
+		[]*string{j.Description, j.GroupId, j.GroupName, j.PeeringStatus, j.UserId, j.VpcId, j.VpcPeeringConnectionId})
+}
+
+type ipPermissionMap struct {
+	FromPort   *int32
+	ToPort     *int32
+	IPProtocol *string
+
+	ipRanges        map[string]*string
+	ipv6Ranges      map[string]*string
+	prefixListIDs   map[string]*string
+	userIDGroupPair []ec2types.UserIdGroupPair
+}
+
+// merge adds rules from the permission set m into this permission
+// set. The caller must ensure that the permission set is for the same
+// protocol and port range.
+func (i *ipPermissionMap) merge(m ec2types.IpPermission) { // nolint:gocyclo
+	i.FromPort = m.FromPort
+	i.ToPort = m.ToPort
+	i.IPProtocol = m.IpProtocol
+
+	for _, r := range m.IpRanges {
+		i.ipRanges[aws.ToString(r.CidrIp)] = r.Description
+	}
+
+	for _, r := range m.Ipv6Ranges {
+		i.ipv6Ranges[aws.ToString(r.CidrIpv6)] = r.Description
+	}
+
+	for _, r := range m.PrefixListIds {
+		i.prefixListIDs[aws.ToString(r.PrefixListId)] = r.Description
+	}
+
+	for _, r := range m.UserIdGroupPairs {
+		idx := sort.Search(len(i.userIDGroupPair), func(idx int) bool {
+			return userIDGroupPairCmp(i.userIDGroupPair[idx], r) <= 0
+		})
+
+		if idx == len(i.userIDGroupPair) { // nil or after last element
+			i.userIDGroupPair = append(i.userIDGroupPair, r)
+		} else if userIDGroupPairCmp(i.userIDGroupPair[idx], r) != 0 {
+			// not present, insert at idx
+			i.userIDGroupPair = append(i.userIDGroupPair[:idx+1], i.userIDGroupPair[idx:]...) // index < len(a)
+			i.userIDGroupPair[idx] = r
+		}
+	}
+}
+
+// diff returns rules that should be added or removed.
+func (i ipPermissionMap) diff(other ipPermissionMap) (add ec2types.IpPermission, remove ec2types.IpPermission) {
+	add.IpProtocol = i.IPProtocol
+	add.FromPort = i.FromPort
+	add.ToPort = i.ToPort
+	remove = add
+
+	add.IpRanges = i.diffRanges(other)
+	remove.IpRanges = other.diffRanges(i)
+
+	add.Ipv6Ranges = i.diffIPv6Ranges(other)
+	remove.Ipv6Ranges = other.diffIPv6Ranges(i)
+
+	add.PrefixListIds = i.diffPrefixListIDs(other)
+	remove.PrefixListIds = other.diffPrefixListIDs(i)
+
+	add.UserIdGroupPairs = i.diffUserIDGroupPair(other)
+	remove.UserIdGroupPairs = other.diffUserIDGroupPair(i)
+
+	return add, remove
+}
+
+func (i ipPermissionMap) diffRanges(other ipPermissionMap) []ec2types.IpRange {
+	var ret []ec2types.IpRange
+	for cidr, description := range i.ipRanges {
+		cidr := cidr
+		description2, ok := other.ipRanges[cidr]
+		if !ok || aws.ToString(description) != aws.ToString(description2) {
+			ret = append(ret, ec2types.IpRange{CidrIp: &cidr, Description: description})
+		}
+	}
+	return ret
+}
+
+func (i ipPermissionMap) diffIPv6Ranges(other ipPermissionMap) []ec2types.Ipv6Range {
+	var ret []ec2types.Ipv6Range
+	for cidr, description := range i.ipv6Ranges {
+		cidr := cidr
+		description2, ok := other.ipv6Ranges[cidr]
+		if !ok || aws.ToString(description) != aws.ToString(description2) {
+			ret = append(ret, ec2types.Ipv6Range{CidrIpv6: &cidr, Description: description})
+		}
+	}
+	return ret
+}
+
+func (i ipPermissionMap) diffPrefixListIDs(other ipPermissionMap) []ec2types.PrefixListId {
+	var ret []ec2types.PrefixListId
+	for id, description := range i.prefixListIDs {
+		id := id
+		description2, ok := other.prefixListIDs[id]
+		if !ok || aws.ToString(description) != aws.ToString(description2) {
+			ret = append(ret, ec2types.PrefixListId{PrefixListId: &id, Description: description})
+		}
+	}
+	return ret
+}
+
+func (i ipPermissionMap) diffUserIDGroupPair(other ipPermissionMap) []ec2types.UserIdGroupPair {
+	var ret []ec2types.UserIdGroupPair
+	for _, r := range i.userIDGroupPair {
+		idx := sort.Search(len(other.userIDGroupPair), func(idx int) bool {
+			return userIDGroupPairCmp(other.userIDGroupPair[idx], r) <= 0
+		})
+		if idx == len(other.userIDGroupPair) || userIDGroupPairCmp(other.userIDGroupPair[idx], r) != 0 {
+			ret = append(ret, r) // not found
+		}
+	}
+	return ret
+}
+
+func convertToMaps(rules []ec2types.IpPermission) map[ruleKey]*ipPermissionMap {
+	ret := make(map[ruleKey]*ipPermissionMap)
+
+	for _, rule := range rules {
+		k := getKey(rule)
+		normalized, ok := ret[k]
+		if !ok {
+			normalized = &ipPermissionMap{}
+			normalized.ipRanges = make(map[string]*string)
+			normalized.ipv6Ranges = make(map[string]*string)
+			normalized.prefixListIDs = make(map[string]*string)
+			ret[k] = normalized
+		}
+
+		normalized.merge(rule)
+	}
+
+	return ret
+}
+
+func hasRules(perm ec2types.IpPermission) bool {
+	return perm.IpRanges != nil || perm.Ipv6Ranges != nil || perm.UserIdGroupPairs != nil || perm.PrefixListIds != nil
+}
+
+func DiffPermissions(want, have []ec2types.IpPermission) (add, remove []ec2types.IpPermission) {
+	// Convert the rule matrix to a map of arrays.
+
+	// We do this to avoid O(n^2) lookup if the rule sets are large,
+	// and also because the user might represent two rules
+	//
+	//   [(proto,port,[iprange1,iprange2])]
+	// as
+	//   [(proto,port,[iprange1]), (proto,port,[iprange2])]
+	//
+	// By converting to maps and merging rules we can get the compact
+	// first form and easily check if rules are present or not.
+	wantMap := convertToMaps(want)
+	haveMap := convertToMaps(have)
+
+	for key, have := range haveMap {
+		want, ok := wantMap[key]
+		if !ok {
+			want = &ipPermissionMap{}
+		}
+
+		removeRules, addRules := have.diff(*want)
+
+		if hasRules(addRules) {
+			add = append(add, addRules)
+		}
+
+		if hasRules(removeRules) {
+			remove = append(remove, removeRules)
+		}
+	}
+
+	for key, want := range wantMap {
+		if _, ok := haveMap[key]; !ok {
+			addRules, _ := want.diff(ipPermissionMap{})
+			add = append(add, addRules)
+		}
+	}
+
+	return add, remove
+}

--- a/pkg/clients/ec2/securitygroup_diff_test.go
+++ b/pkg/clients/ec2/securitygroup_diff_test.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ec2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/smithy-go/document"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+var (
+	port80  int32 = 80
+	port100 int32 = 100
+
+	tcpProtocol = "tcp"
+)
+
+func sgPermissions(port int32, cidrs ...string) []ec2types.IpPermission {
+	ranges := make([]ec2types.IpRange, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		ranges = append(ranges, ec2types.IpRange{
+			CidrIp: aws.String(cidr),
+		})
+	}
+	return []ec2types.IpPermission{
+		{
+			FromPort:   aws.Int32(port),
+			ToPort:     aws.Int32(port),
+			IpProtocol: aws.String(tcpProtocol),
+			IpRanges:   ranges,
+		},
+	}
+}
+
+// NOTE(muvaf): Sending -1 as FromPort or ToPort is valid but the returned
+// object does not have that value. So, in case we have sent -1, we assume
+// that the returned value is also -1 in case if it's nil.
+// See the following about usage of -1
+// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-security-group-egress.html
+//mOne := int64(-1)
+
+func TestDiffPermissions(t *testing.T) {
+	type testCase struct {
+		name string
+
+		want, have  []ec2types.IpPermission
+		add, remove []ec2types.IpPermission
+	}
+
+	cases := []testCase{
+		{
+			name:   "Same",
+			want:   sgPermissions(port100, cidr),
+			have:   sgPermissions(port100, cidr),
+			add:    nil,
+			remove: nil,
+		},
+		{
+			name:   "Add",
+			want:   sgPermissions(port100, cidr),
+			have:   nil,
+			add:    sgPermissions(port100, cidr),
+			remove: nil,
+		},
+		{
+			name:   "Remove",
+			want:   nil,
+			have:   sgPermissions(port100, cidr),
+			add:    nil,
+			remove: sgPermissions(port100, cidr),
+		},
+		{
+			name:   "Replace",
+			want:   sgPermissions(99, cidr),
+			have:   sgPermissions(port100, cidr),
+			add:    sgPermissions(99, cidr),
+			remove: sgPermissions(port100, cidr),
+		},
+		{
+			name:   "Add block",
+			want:   sgPermissions(port100, cidr, "192.168.0.1/32"),
+			have:   sgPermissions(port100, cidr),
+			add:    sgPermissions(port100, "192.168.0.1/32"),
+			remove: nil,
+		},
+		{
+			name:   "Remove block",
+			want:   sgPermissions(port100, cidr),
+			have:   sgPermissions(port100, cidr, "192.168.0.1/32"),
+			add:    nil,
+			remove: sgPermissions(port100, "192.168.0.1/32"),
+		},
+		{
+			name:   "Replace block",
+			want:   sgPermissions(port100, cidr, "172.240.1.1/32", "192.168.0.1/32"),
+			have:   sgPermissions(port100, cidr, "172.240.2.2/32", "192.168.0.1/32"),
+			add:    sgPermissions(port100, "172.240.1.1/32"),
+			remove: sgPermissions(port100, "172.240.2.2/32"),
+		},
+		/*
+			{
+				name:   "Dedupe want",
+				want:   append(sgPersmissions(port100, cidr, "172.240.1.1/32", "172.240.1.1/32", "192.168.0.1/32"), sgPersmissions(port100, cidr, "172.240.1.1/32", "172.240.1.1/32", "192.168.0.1/32")...),
+				have:   sgPersmissions(port100, cidr, "172.240.2.2/32", "192.168.0.1/32"),
+				add:    sgPersmissions(port100, "172.240.1.1/32"),
+				remove: sgPersmissions(port100, "172.240.2.2/32"),
+			},
+		*/
+		{
+			name:   "Merge want",
+			want:   append(sgPermissions(port100, "192.168.0.1/32"), sgPermissions(port100, "172.240.1.1/32")...),
+			have:   nil,
+			add:    sgPermissions(port100, "192.168.0.1/32", "172.240.1.1/32"),
+			remove: nil,
+		},
+		{
+			name:   "Ignore order",
+			want:   sgPermissions(port100, "172.240.1.1/32", "192.168.0.1/32", cidr),
+			have:   sgPermissions(port100, "192.168.0.1/32", cidr, "172.240.1.1/32"),
+			add:    nil,
+			remove: nil,
+		},
+		{
+			name: "Ignore protocol case",
+			want: []ec2types.IpPermission{
+				{
+					IpProtocol: aws.String("TCP"),
+					FromPort:   &port100,
+					ToPort:     &port100,
+					IpRanges:   []ec2types.IpRange{{CidrIp: aws.String(cidr)}},
+				},
+			},
+			have: []ec2types.IpPermission{
+				{
+					IpProtocol: aws.String("tcp"),
+					FromPort:   &port100,
+					ToPort:     &port100,
+					IpRanges:   []ec2types.IpRange{{CidrIp: aws.String(cidr)}},
+				},
+			},
+			add:    nil,
+			remove: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			add, remove := DiffPermissions(tc.want, tc.have)
+
+			if diff := cmp.Diff(tc.add, add, cmpopts.IgnoreTypes(document.NoSerde{})); diff != "" {
+				t.Errorf("r add: -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.remove, remove, cmpopts.IgnoreTypes(document.NoSerde{})); diff != "" {
+				t.Errorf("r remove: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func BenchmarkDiffPermissions(b *testing.B) {
+	var ranges, ranges2, ranges3 []ec2types.IpRange
+	for i := 1; i < 255; i++ {
+		for j := 0; j < 10; j++ {
+			ranges = append(ranges, ec2types.IpRange{
+				CidrIp: aws.String(fmt.Sprintf("%d.%d.0.0/24", i, j)),
+			})
+		}
+		ranges2 = append(ranges, ec2types.IpRange{
+			CidrIp: aws.String(fmt.Sprintf("%d.1.1.0/24", i)),
+		})
+		ranges3 = append(ranges, ec2types.IpRange{
+			CidrIp: aws.String(fmt.Sprintf("%d.2.2.0/24", i)),
+		})
+	}
+
+	want := []ec2types.IpPermission{
+		{
+			IpProtocol: aws.String("TCP"),
+			FromPort:   &port100,
+			ToPort:     &port100,
+			IpRanges:   ranges,
+		},
+		{
+			IpProtocol: aws.String("TCP"),
+			FromPort:   &port100,
+			ToPort:     &port100,
+			IpRanges:   ranges,
+		},
+		{
+			IpProtocol: aws.String("TCP"),
+			FromPort:   &port100,
+			ToPort:     &port100,
+			IpRanges:   ranges2,
+		},
+	}
+
+	have := []ec2types.IpPermission{
+		{
+			IpProtocol: aws.String("tcp"),
+			FromPort:   &port100,
+			ToPort:     &port100,
+			IpRanges:   ranges,
+		},
+		{
+			IpProtocol: aws.String("TCP"),
+			FromPort:   &port100,
+			ToPort:     &port100,
+			IpRanges:   ranges,
+		},
+		{
+			IpProtocol: aws.String("tcp"),
+			FromPort:   &port100,
+			ToPort:     &port100,
+			IpRanges:   ranges3,
+		},
+	}
+
+	for i := 0; i < b.N; i++ {
+		DiffPermissions(want, have)
+	}
+}

--- a/pkg/clients/ec2/securitygroup_test.go
+++ b/pkg/clients/ec2/securitygroup_test.go
@@ -117,7 +117,7 @@ func TestIsSGUpToDate(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got, _ := IsSGUpToDate(tc.args.p, tc.args.sg)
+			got := IsSGUpToDate(tc.args.p, tc.args.sg)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
 			}
@@ -155,98 +155,6 @@ func TestGenerateSGObservation(t *testing.T) {
 			r := GenerateSGObservation(tc.in)
 			if diff := cmp.Diff(r, tc.out); diff != "" {
 				t.Errorf("GenerateNetworkObservation(...): -want, +got:\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestCreateSGPatch(t *testing.T) {
-	type args struct {
-		sg ec2types.SecurityGroup
-		p  *v1beta1.SecurityGroupParameters
-	}
-
-	type want struct {
-		patch *v1beta1.SecurityGroupParameters
-	}
-
-	cases := map[string]struct {
-		args
-		want
-	}{
-		"SameFields": {
-			args: args{
-				sg: ec2types.SecurityGroup{
-					Description:         aws.String(sgDesc),
-					GroupName:           aws.String(sgName),
-					IpPermissions:       sgIPPermission(80),
-					IpPermissionsEgress: sgIPPermission(80),
-					VpcId:               aws.String(sgVpc),
-				},
-				p: &v1beta1.SecurityGroupParameters{
-					Description: sgDesc,
-					GroupName:   sgName,
-					Egress:      specIPPermission(80),
-					Ingress:     specIPPermission(80),
-					VPCID:       aws.String(sgVpc),
-				},
-			},
-			want: want{
-				patch: &v1beta1.SecurityGroupParameters{},
-			},
-		},
-		"SameFieldsNilPort": {
-			args: args{
-				sg: ec2types.SecurityGroup{
-					Description:         aws.String(sgDesc),
-					GroupName:           aws.String(sgName),
-					IpPermissions:       nil,
-					IpPermissionsEgress: append(sgIPPermission(80), ec2types.IpPermission{IpProtocol: aws.String("-1")}),
-					VpcId:               aws.String(sgVpc),
-				},
-				p: &v1beta1.SecurityGroupParameters{
-					Description: sgDesc,
-					GroupName:   sgName,
-					Egress:      append(specIPPermission(80), v1beta1.IPPermission{IPProtocol: "-1"}),
-					Ingress:     nil,
-					VPCID:       aws.String(sgVpc),
-				},
-			},
-			want: want{
-				patch: &v1beta1.SecurityGroupParameters{},
-			},
-		},
-		"DifferentFields": {
-			args: args{
-				sg: ec2types.SecurityGroup{
-					Description:         aws.String(sgDesc),
-					GroupName:           aws.String(sgName),
-					IpPermissions:       sgIPPermission(80),
-					IpPermissionsEgress: sgIPPermission(80),
-					VpcId:               aws.String(sgVpc),
-				},
-				p: &v1beta1.SecurityGroupParameters{
-					Description: sgDesc,
-					GroupName:   sgName,
-					Egress:      specIPPermission(100),
-					Ingress:     specIPPermission(100),
-					VPCID:       aws.String(sgVpc),
-				},
-			},
-			want: want{
-				patch: &v1beta1.SecurityGroupParameters{
-					Egress:  specIPPermission(100),
-					Ingress: specIPPermission(100),
-				},
-			},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			result, _ := CreateSGPatch(tc.args.sg, *tc.args.p)
-			if diff := cmp.Diff(tc.want.patch, result); diff != "" {
-				t.Errorf("r: -want, +got:\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
### Description of your changes

Implement a "diff rules" function.

When adding a rule, we should not send the complete rule set, only the
new rule.

When updating a rule, we must first delete it. And with that done, we
also support deleting rules.

Fixes #503
Fixes #300

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
- manually added/modified/removed simple ingress rules with cidr blocks.
- unit tests (for IP-ranges)

TODO
- [x] add unit tests
- [x] handle TODO in code
- [x] consider performance
- [x] handle tcp vs TCP in diff
- [x] ignore order in arrays in diff function ([1.1.1.1, 2.2.2.2] == [2.2.2.2, 1.1.1.1])
- [x] check how diff function handles all types, not just cidr blocks
- [x] ignore order in arrays in unit tests ([1.1.1.1, 2.2.2.2] == [2.2.2.2, 1.1.1.1])

[contribution process]: https://git.io/fj2m9
