### PR TITLE
Bugfix/s3 website configuration

### DIFF
--- a/apis/s3/v1beta1/websiteConfiguration_types.go
+++ b/apis/s3/v1beta1/websiteConfiguration_types.go
@@ -61,7 +61,7 @@ type RedirectAllRequestsTo struct {
 	// Protocol to use when redirecting requests. The default is the protocol that
 	// is used in the original request.
 	// +kubebuilder:validation:Enum=http;https
-	Protocol string `json:"protocol"`
+	Protocol string `json:"protocol,omitempty"`
 }
 
 // RoutingRule specifies the redirect behavior and when a redirect is applied.
@@ -114,7 +114,7 @@ type Redirect struct {
 
 	// Protocol to use when redirecting requests. The default is the protocol that
 	// is used in the original request.
-	Protocol string `json:"protocol"`
+	Protocol string `json:"protocol,omitempty"`
 
 	// The object key prefix to use in the redirect request. For example, to redirect
 	// requests for all pages with prefix docs/ (objects in the docs/ folder) to

--- a/package/crds/s3.aws.crossplane.io_buckets.yaml
+++ b/package/crds/s3.aws.crossplane.io_buckets.yaml
@@ -885,7 +885,6 @@ spec:
                             type: string
                         required:
                         - hostName
-                        - protocol
                         type: object
                       routingRules:
                         description: Rules that define when a redirect is applied and the redirect behavior.
@@ -920,8 +919,6 @@ spec:
                                 replaceKeyWith:
                                   description: The specific object key to use in the redirect request. For example, redirect request to error.html. Not required if one of the siblings is present. Can be present only if ReplaceKeyPrefixWith is not provided.
                                   type: string
-                              required:
-                              - protocol
                               type: object
                           required:
                           - redirect


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Slack Thread: https://crossplane.slack.com/archives/CEF5N8X08/p1620143654284900
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane/provider-aws/issues/650

I have:

- [x] Read and followed Crossplane's [contribution process]
- [x] Run `make reviewable test` to ensure this PR is ready for review.

To Note, i have removed `protocol` as a required parameter because even the description states it defaults to what the inbound request is yet the Spec states its required which goes against the given description

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

- I have been trying to use the website configuration on the bucket resource within a composition. I noticed that it worked if i passed routing rules but didn't when i only passed the index and error documents (things i have already done before in terraform but i am moving the bucket creation to crossplane 🚀 )


- `make test` - ✅ 
- `make e2e` - ✅ 
![Screenshot 2021-05-04 at 21 09 59](https://user-images.githubusercontent.com/39212456/117063723-1f8e2c00-ad1d-11eb-88f8-b99f34cdc7cc.png)

- `make reviewable` - ✅ 
- `make` - ✅ 
