### PR TITLE
s3.bucketpolicy: Ignore string order

### DIFF
--- a/pkg/controller/s3/bucketpolicy/bucketpolicy.go
+++ b/pkg/controller/s3/bucketpolicy/bucketpolicy.go
@@ -119,8 +119,26 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 	// If our version and the external version are the same, we return ResourceUpToDate: true
 	return managed.ExternalObservation{
 		ResourceExists:   true,
-		ResourceUpToDate: cmp.Equal(*policyData, *resp.Policy),
+		ResourceUpToDate: IsBucketPolicyUpToDate(policyData, resp.Policy),
 	}, nil
+}
+
+// IsBucketPolicyUpToDate Marshall policies to json for a compare to get around string ordering
+func IsBucketPolicyUpToDate(local, remote *string) bool {
+	var localUnmarshalled interface{}
+	var remoteUnmarshalled interface{}
+
+	var err error
+	err = json.Unmarshal([]byte(*local), &localUnmarshalled)
+	if err != nil {
+		return false
+	}
+	err = json.Unmarshal([]byte(*remote), &remoteUnmarshalled)
+	if err != nil {
+		return false
+	}
+
+	return cmp.Equal(localUnmarshalled, remoteUnmarshalled)
 }
 
 // formatBucketPolicy parses and formats the bucket.Spec.BucketPolicy struct


### PR DESCRIPTION
When checking if two policies are identical, we must ignore string
order. Idea for the fix from the ECR policy check.

Do we want to move this method to a shared library to avoid duplicating it for all controllers with resource based policies?

### Description of your changes
I have:
- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
- Added unit tests

[contribution process]: https://git.io/fj2m9
