### PR TITLE
Fix VPC CIDR Block Deletion

### DIFF
--- a/pkg/controller/ec2/vpccidrblock/controller.go
+++ b/pkg/controller/ec2/vpccidrblock/controller.go
@@ -104,8 +104,11 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 	response, err := e.client.DescribeVpcsRequest(&awsec2.DescribeVpcsInput{
 		VpcIds: []string{aws.StringValue(cr.Spec.ForProvider.VPCID)},
 	}).Send(ctx)
-	if err != nil && !ec2.IsCIDRNotFound(err) {
-		return managed.ExternalObservation{}, awsclient.Wrap(err, errDescribe)
+
+	if err != nil {
+		return managed.ExternalObservation{
+			ResourceExists: false,
+		}, awsclient.Wrap(resource.Ignore(ec2.IsVPCNotFoundErr, err), errDescribe)
 	}
 
 	// in a successful response, there should be one and only one object


### PR DESCRIPTION
Signed-off-by: Amna Irfan <amirfan@ea.com>

### Description of your changes

CIDR blocks are attached to VPCs so deleting a VPC in Crossplane automatically deletes the CIDR block in AWS. However the CIDR resource does not get deleted in Crossplane. The deletion gets stuck in a loop since AWS first tries to get the VPC and when the VPC doesn't exist it sends a VPC not found error while the code is waiting for a CIDR not found error.
We just need to account for the VPC not found error while deleting a CIDR block.

Fixes #677

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

1. Create a VPC in Crossplane
2. Create a CIDR block for that VPC
3. Delete the VPC in Crossplane (it wont ask you to delete the CIDR block)
4. Delete the CIDR block in Crossplane (it will no longer give an error that vpc doesn't exist)

