### PR TITLE
Add endpoint to RDS DBCluster connection details

### DIFF
--- a/pkg/controller/rds/dbcluster/setup.go
+++ b/pkg/controller/rds/dbcluster/setup.go
@@ -99,7 +99,8 @@ func (e *custom) postCreate(ctx context.Context, cr *svcapitypes.DBCluster, _ *s
 		return managed.ExternalCreation{}, err
 	}
 	conn := managed.ConnectionDetails{
-		xpv1.ResourceCredentialsSecretUserKey: []byte(aws.StringValue(cr.Spec.ForProvider.MasterUsername)),
+		xpv1.ResourceCredentialsSecretEndpointKey: []byte(aws.StringValue(cr.Status.AtProvider.Endpoint)),
+		xpv1.ResourceCredentialsSecretUserKey:     []byte(aws.StringValue(cr.Spec.ForProvider.MasterUsername)),
 	}
 	pw, _, err := rds.GetPassword(ctx, e.kube, &cr.Spec.ForProvider.MasterUserPasswordSecretRef, cr.Spec.WriteConnectionSecretToReference)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Endpoint was not being copied into the connection details of the generated RDS `DBCluster` reconciler. This adds the endpoint field as it is trivially available in the `status` of the resource, and returns the FQDN (minus port) of the instance.

This does _not_ set the port as well, as it is not exposed by the status. I suspect in most cases this is defaulted from the AWS side, and it doesn't look like late init is implemented for this reconciler yet (so we potentially have no value to populate).

Fixes #695 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Test suite passes but I don't think this particular method is directly targeted. Will be using the built image to test on a live cluster.

[contribution process]: https://git.io/fj2m9
