### PR TITLE
Regenerate APIs with required spec, optional status.atProvider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ crds.clean:
 	@find package/crds -name '*.yaml.sed' -delete || $(FAIL)
 	@$(OK) cleaned generated CRDs
 
-generate.run: go.generate crds.clean
+generate.init: services.all
+generate.done: crds.clean
 
 manifests:
 	@$(WARN) Deprecated. Please run make generate instead.

--- a/Makefile
+++ b/Makefile
@@ -79,16 +79,6 @@ crds.clean:
 
 generate.run: go.generate crds.clean
 
-# Ensure a PR is ready for review.
-reviewable: services.all generate lint
-	@go mod tidy
-
-# Ensure branch is clean.
-check-diff: reviewable
-	@$(INFO) checking that branch is clean
-	@test -z "$$(git status --porcelain)" || $(FAIL)
-	@$(OK) branch is clean
-
 manifests:
 	@$(WARN) Deprecated. Please run make generate instead.
 
@@ -114,7 +104,7 @@ run: go.build
 	@# To see other arguments that can be provided, run the command with --help instead
 	$(GO_OUT_DIR)/provider --debug
 
-.PHONY: cobertura reviewable manifests submodules fallthrough test-integration run crds.clean
+.PHONY: cobertura manifests submodules fallthrough test-integration run crds.clean
 
 # NOTE(muvaf): ACK Code Generator is a separate Go module, hence we need to
 # be in its root directory to call "go run" properly.
@@ -144,7 +134,6 @@ services.all:
 define CROSSPLANE_MAKE_HELP
 Crossplane Targets:
     cobertura             Generate a coverage report for cobertura applying exclusions on generated files.
-    reviewable            Ensure a PR is ready for review.
     submodules            Update the submodules, such as the common build scripts.
     run                   Run crossplane locally, out-of-cluster. Useful for development.
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PROJECT_REPO := github.com/crossplane/$(PROJECT_NAME)
 
 PLATFORMS ?= linux_amd64 linux_arm64
 
-CODE_GENERATOR_COMMIT ?= v0.2.1
+CODE_GENERATOR_COMMIT ?= c4592885b843b2f0a316718a15349ea07b3a50b1
 GENERATED_SERVICES="apigatewayv2,cloudfront,dynamodb,efs,kms,lambda,rds,secretsmanager,servicediscovery,sfn"
 
 # -include will silently skip missing files, which allows us

--- a/apis/apigatewayv2/v1alpha1/zz_api.go
+++ b/apis/apigatewayv2/v1alpha1/zz_api.go
@@ -84,7 +84,7 @@ type APIObservation struct {
 // APIStatus defines the observed state of API.
 type APIStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          APIObservation `json:"atProvider"`
+	AtProvider          APIObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -98,7 +98,7 @@ type APIStatus struct {
 type API struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              APISpec   `json:"spec,omitempty"`
+	Spec              APISpec   `json:"spec"`
 	Status            APIStatus `json:"status,omitempty"`
 }
 

--- a/apis/apigatewayv2/v1alpha1/zz_api_mapping.go
+++ b/apis/apigatewayv2/v1alpha1/zz_api_mapping.go
@@ -52,7 +52,7 @@ type APIMappingObservation struct {
 // APIMappingStatus defines the observed state of APIMapping.
 type APIMappingStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          APIMappingObservation `json:"atProvider"`
+	AtProvider          APIMappingObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -66,7 +66,7 @@ type APIMappingStatus struct {
 type APIMapping struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              APIMappingSpec   `json:"spec,omitempty"`
+	Spec              APIMappingSpec   `json:"spec"`
 	Status            APIMappingStatus `json:"status,omitempty"`
 }
 

--- a/apis/apigatewayv2/v1alpha1/zz_authorizer.go
+++ b/apis/apigatewayv2/v1alpha1/zz_authorizer.go
@@ -69,7 +69,7 @@ type AuthorizerObservation struct {
 // AuthorizerStatus defines the observed state of Authorizer.
 type AuthorizerStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          AuthorizerObservation `json:"atProvider"`
+	AtProvider          AuthorizerObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -83,7 +83,7 @@ type AuthorizerStatus struct {
 type Authorizer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              AuthorizerSpec   `json:"spec,omitempty"`
+	Spec              AuthorizerSpec   `json:"spec"`
 	Status            AuthorizerStatus `json:"status,omitempty"`
 }
 

--- a/apis/apigatewayv2/v1alpha1/zz_deployment.go
+++ b/apis/apigatewayv2/v1alpha1/zz_deployment.go
@@ -58,7 +58,7 @@ type DeploymentObservation struct {
 // DeploymentStatus defines the observed state of Deployment.
 type DeploymentStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          DeploymentObservation `json:"atProvider"`
+	AtProvider          DeploymentObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -72,7 +72,7 @@ type DeploymentStatus struct {
 type Deployment struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              DeploymentSpec   `json:"spec,omitempty"`
+	Spec              DeploymentSpec   `json:"spec"`
 	Status            DeploymentStatus `json:"status,omitempty"`
 }
 

--- a/apis/apigatewayv2/v1alpha1/zz_domain_name.go
+++ b/apis/apigatewayv2/v1alpha1/zz_domain_name.go
@@ -54,7 +54,7 @@ type DomainNameObservation struct {
 // DomainNameStatus defines the observed state of DomainName.
 type DomainNameStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          DomainNameObservation `json:"atProvider"`
+	AtProvider          DomainNameObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -68,7 +68,7 @@ type DomainNameStatus struct {
 type DomainName struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              DomainNameSpec   `json:"spec,omitempty"`
+	Spec              DomainNameSpec   `json:"spec"`
 	Status            DomainNameStatus `json:"status,omitempty"`
 }
 

--- a/apis/apigatewayv2/v1alpha1/zz_integration.go
+++ b/apis/apigatewayv2/v1alpha1/zz_integration.go
@@ -83,7 +83,7 @@ type IntegrationObservation struct {
 // IntegrationStatus defines the observed state of Integration.
 type IntegrationStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          IntegrationObservation `json:"atProvider"`
+	AtProvider          IntegrationObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -97,7 +97,7 @@ type IntegrationStatus struct {
 type Integration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              IntegrationSpec   `json:"spec,omitempty"`
+	Spec              IntegrationSpec   `json:"spec"`
 	Status            IntegrationStatus `json:"status,omitempty"`
 }
 

--- a/apis/apigatewayv2/v1alpha1/zz_integration_response.go
+++ b/apis/apigatewayv2/v1alpha1/zz_integration_response.go
@@ -57,7 +57,7 @@ type IntegrationResponseObservation struct {
 // IntegrationResponseStatus defines the observed state of IntegrationResponse.
 type IntegrationResponseStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          IntegrationResponseObservation `json:"atProvider"`
+	AtProvider          IntegrationResponseObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -71,7 +71,7 @@ type IntegrationResponseStatus struct {
 type IntegrationResponse struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              IntegrationResponseSpec   `json:"spec,omitempty"`
+	Spec              IntegrationResponseSpec   `json:"spec"`
 	Status            IntegrationResponseStatus `json:"status,omitempty"`
 }
 

--- a/apis/apigatewayv2/v1alpha1/zz_model.go
+++ b/apis/apigatewayv2/v1alpha1/zz_model.go
@@ -56,7 +56,7 @@ type ModelObservation struct {
 // ModelStatus defines the observed state of Model.
 type ModelStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          ModelObservation `json:"atProvider"`
+	AtProvider          ModelObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -70,7 +70,7 @@ type ModelStatus struct {
 type Model struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              ModelSpec   `json:"spec,omitempty"`
+	Spec              ModelSpec   `json:"spec"`
 	Status            ModelStatus `json:"status,omitempty"`
 }
 

--- a/apis/apigatewayv2/v1alpha1/zz_route.go
+++ b/apis/apigatewayv2/v1alpha1/zz_route.go
@@ -71,7 +71,7 @@ type RouteObservation struct {
 // RouteStatus defines the observed state of Route.
 type RouteStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          RouteObservation `json:"atProvider"`
+	AtProvider          RouteObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -85,7 +85,7 @@ type RouteStatus struct {
 type Route struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              RouteSpec   `json:"spec,omitempty"`
+	Spec              RouteSpec   `json:"spec"`
 	Status            RouteStatus `json:"status,omitempty"`
 }
 

--- a/apis/apigatewayv2/v1alpha1/zz_route_response.go
+++ b/apis/apigatewayv2/v1alpha1/zz_route_response.go
@@ -55,7 +55,7 @@ type RouteResponseObservation struct {
 // RouteResponseStatus defines the observed state of RouteResponse.
 type RouteResponseStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          RouteResponseObservation `json:"atProvider"`
+	AtProvider          RouteResponseObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -69,7 +69,7 @@ type RouteResponseStatus struct {
 type RouteResponse struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              RouteResponseSpec   `json:"spec,omitempty"`
+	Spec              RouteResponseSpec   `json:"spec"`
 	Status            RouteResponseStatus `json:"status,omitempty"`
 }
 

--- a/apis/apigatewayv2/v1alpha1/zz_stage.go
+++ b/apis/apigatewayv2/v1alpha1/zz_stage.go
@@ -72,7 +72,7 @@ type StageObservation struct {
 // StageStatus defines the observed state of Stage.
 type StageStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          StageObservation `json:"atProvider"`
+	AtProvider          StageObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -86,7 +86,7 @@ type StageStatus struct {
 type Stage struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              StageSpec   `json:"spec,omitempty"`
+	Spec              StageSpec   `json:"spec"`
 	Status            StageStatus `json:"status,omitempty"`
 }
 

--- a/apis/apigatewayv2/v1alpha1/zz_vpc_link.go
+++ b/apis/apigatewayv2/v1alpha1/zz_vpc_link.go
@@ -63,7 +63,7 @@ type VPCLinkObservation struct {
 // VPCLinkStatus defines the observed state of VPCLink.
 type VPCLinkStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          VPCLinkObservation `json:"atProvider"`
+	AtProvider          VPCLinkObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -77,7 +77,7 @@ type VPCLinkStatus struct {
 type VPCLink struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              VPCLinkSpec   `json:"spec,omitempty"`
+	Spec              VPCLinkSpec   `json:"spec"`
 	Status            VPCLinkStatus `json:"status,omitempty"`
 }
 

--- a/apis/cloudfront/v1alpha1/zz_distribution.go
+++ b/apis/cloudfront/v1alpha1/zz_distribution.go
@@ -54,7 +54,7 @@ type DistributionObservation struct {
 // DistributionStatus defines the observed state of Distribution.
 type DistributionStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          DistributionObservation `json:"atProvider"`
+	AtProvider          DistributionObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -68,7 +68,7 @@ type DistributionStatus struct {
 type Distribution struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              DistributionSpec   `json:"spec,omitempty"`
+	Spec              DistributionSpec   `json:"spec"`
 	Status            DistributionStatus `json:"status,omitempty"`
 }
 

--- a/apis/dynamodb/v1alpha1/zz_backup.go
+++ b/apis/dynamodb/v1alpha1/zz_backup.go
@@ -70,7 +70,7 @@ type BackupObservation struct {
 // BackupStatus defines the observed state of Backup.
 type BackupStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          BackupObservation `json:"atProvider"`
+	AtProvider          BackupObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -84,7 +84,7 @@ type BackupStatus struct {
 type Backup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              BackupSpec   `json:"spec,omitempty"`
+	Spec              BackupSpec   `json:"spec"`
 	Status            BackupStatus `json:"status,omitempty"`
 }
 

--- a/apis/dynamodb/v1alpha1/zz_global_table.go
+++ b/apis/dynamodb/v1alpha1/zz_global_table.go
@@ -64,7 +64,7 @@ type GlobalTableObservation struct {
 // GlobalTableStatus defines the observed state of GlobalTable.
 type GlobalTableStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          GlobalTableObservation `json:"atProvider"`
+	AtProvider          GlobalTableObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -78,7 +78,7 @@ type GlobalTableStatus struct {
 type GlobalTable struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              GlobalTableSpec   `json:"spec,omitempty"`
+	Spec              GlobalTableSpec   `json:"spec"`
 	Status            GlobalTableStatus `json:"status,omitempty"`
 }
 

--- a/apis/dynamodb/v1alpha1/zz_table.go
+++ b/apis/dynamodb/v1alpha1/zz_table.go
@@ -236,7 +236,7 @@ type TableObservation struct {
 // TableStatus defines the observed state of Table.
 type TableStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          TableObservation `json:"atProvider"`
+	AtProvider          TableObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -250,7 +250,7 @@ type TableStatus struct {
 type Table struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              TableSpec   `json:"spec,omitempty"`
+	Spec              TableSpec   `json:"spec"`
 	Status            TableStatus `json:"status,omitempty"`
 }
 

--- a/apis/efs/v1alpha1/zz_file_system.go
+++ b/apis/efs/v1alpha1/zz_file_system.go
@@ -121,7 +121,7 @@ type FileSystemObservation struct {
 // FileSystemStatus defines the observed state of FileSystem.
 type FileSystemStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          FileSystemObservation `json:"atProvider"`
+	AtProvider          FileSystemObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -135,7 +135,7 @@ type FileSystemStatus struct {
 type FileSystem struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              FileSystemSpec   `json:"spec,omitempty"`
+	Spec              FileSystemSpec   `json:"spec"`
 	Status            FileSystemStatus `json:"status,omitempty"`
 }
 

--- a/apis/kms/v1alpha1/zz_key.go
+++ b/apis/kms/v1alpha1/zz_key.go
@@ -242,7 +242,7 @@ type KeyObservation struct {
 // KeyStatus defines the observed state of Key.
 type KeyStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          KeyObservation `json:"atProvider"`
+	AtProvider          KeyObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -256,7 +256,7 @@ type KeyStatus struct {
 type Key struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              KeySpec   `json:"spec,omitempty"`
+	Spec              KeySpec   `json:"spec"`
 	Status            KeyStatus `json:"status,omitempty"`
 }
 

--- a/apis/lambda/v1alpha1/zz_function.go
+++ b/apis/lambda/v1alpha1/zz_function.go
@@ -144,7 +144,7 @@ type FunctionObservation struct {
 // FunctionStatus defines the observed state of Function.
 type FunctionStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          FunctionObservation `json:"atProvider"`
+	AtProvider          FunctionObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -158,7 +158,7 @@ type FunctionStatus struct {
 type Function struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              FunctionSpec   `json:"spec,omitempty"`
+	Spec              FunctionSpec   `json:"spec"`
 	Status            FunctionStatus `json:"status,omitempty"`
 }
 

--- a/apis/rds/v1alpha1/zz_db_cluster.go
+++ b/apis/rds/v1alpha1/zz_db_cluster.go
@@ -463,7 +463,7 @@ type DBClusterObservation struct {
 // DBClusterStatus defines the observed state of DBCluster.
 type DBClusterStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          DBClusterObservation `json:"atProvider"`
+	AtProvider          DBClusterObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -477,7 +477,7 @@ type DBClusterStatus struct {
 type DBCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              DBClusterSpec   `json:"spec,omitempty"`
+	Spec              DBClusterSpec   `json:"spec"`
 	Status            DBClusterStatus `json:"status,omitempty"`
 }
 

--- a/apis/rds/v1alpha1/zz_db_parameter_group.go
+++ b/apis/rds/v1alpha1/zz_db_parameter_group.go
@@ -67,7 +67,7 @@ type DBParameterGroupObservation struct {
 // DBParameterGroupStatus defines the observed state of DBParameterGroup.
 type DBParameterGroupStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          DBParameterGroupObservation `json:"atProvider"`
+	AtProvider          DBParameterGroupObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -81,7 +81,7 @@ type DBParameterGroupStatus struct {
 type DBParameterGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              DBParameterGroupSpec   `json:"spec,omitempty"`
+	Spec              DBParameterGroupSpec   `json:"spec"`
 	Status            DBParameterGroupStatus `json:"status,omitempty"`
 }
 

--- a/apis/rds/v1alpha1/zz_global_cluster.go
+++ b/apis/rds/v1alpha1/zz_global_cluster.go
@@ -75,7 +75,7 @@ type GlobalClusterObservation struct {
 // GlobalClusterStatus defines the observed state of GlobalCluster.
 type GlobalClusterStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          GlobalClusterObservation `json:"atProvider"`
+	AtProvider          GlobalClusterObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -89,7 +89,7 @@ type GlobalClusterStatus struct {
 type GlobalCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              GlobalClusterSpec   `json:"spec,omitempty"`
+	Spec              GlobalClusterSpec   `json:"spec"`
 	Status            GlobalClusterStatus `json:"status,omitempty"`
 }
 

--- a/apis/secretsmanager/v1alpha1/zz_secret.go
+++ b/apis/secretsmanager/v1alpha1/zz_secret.go
@@ -119,7 +119,7 @@ type SecretObservation struct {
 // SecretStatus defines the observed state of Secret.
 type SecretStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          SecretObservation `json:"atProvider"`
+	AtProvider          SecretObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -133,7 +133,7 @@ type SecretStatus struct {
 type Secret struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              SecretSpec   `json:"spec,omitempty"`
+	Spec              SecretSpec   `json:"spec"`
 	Status            SecretStatus `json:"status,omitempty"`
 }
 

--- a/apis/servicediscovery/v1alpha1/zz_http_namespace.go
+++ b/apis/servicediscovery/v1alpha1/zz_http_namespace.go
@@ -61,7 +61,7 @@ type HTTPNamespaceObservation struct {
 // HTTPNamespaceStatus defines the observed state of HTTPNamespace.
 type HTTPNamespaceStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          HTTPNamespaceObservation `json:"atProvider"`
+	AtProvider          HTTPNamespaceObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -75,7 +75,7 @@ type HTTPNamespaceStatus struct {
 type HTTPNamespace struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              HTTPNamespaceSpec   `json:"spec,omitempty"`
+	Spec              HTTPNamespaceSpec   `json:"spec"`
 	Status            HTTPNamespaceStatus `json:"status,omitempty"`
 }
 

--- a/apis/servicediscovery/v1alpha1/zz_private_dns_namespace.go
+++ b/apis/servicediscovery/v1alpha1/zz_private_dns_namespace.go
@@ -66,7 +66,7 @@ type PrivateDNSNamespaceObservation struct {
 // PrivateDNSNamespaceStatus defines the observed state of PrivateDNSNamespace.
 type PrivateDNSNamespaceStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          PrivateDNSNamespaceObservation `json:"atProvider"`
+	AtProvider          PrivateDNSNamespaceObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -80,7 +80,7 @@ type PrivateDNSNamespaceStatus struct {
 type PrivateDNSNamespace struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              PrivateDNSNamespaceSpec   `json:"spec,omitempty"`
+	Spec              PrivateDNSNamespaceSpec   `json:"spec"`
 	Status            PrivateDNSNamespaceStatus `json:"status,omitempty"`
 }
 

--- a/apis/servicediscovery/v1alpha1/zz_public_dns_namespace.go
+++ b/apis/servicediscovery/v1alpha1/zz_public_dns_namespace.go
@@ -61,7 +61,7 @@ type PublicDNSNamespaceObservation struct {
 // PublicDNSNamespaceStatus defines the observed state of PublicDNSNamespace.
 type PublicDNSNamespaceStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          PublicDNSNamespaceObservation `json:"atProvider"`
+	AtProvider          PublicDNSNamespaceObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -75,7 +75,7 @@ type PublicDNSNamespaceStatus struct {
 type PublicDNSNamespace struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              PublicDNSNamespaceSpec   `json:"spec,omitempty"`
+	Spec              PublicDNSNamespaceSpec   `json:"spec"`
 	Status            PublicDNSNamespaceStatus `json:"status,omitempty"`
 }
 

--- a/apis/sfn/v1alpha1/zz_activity.go
+++ b/apis/sfn/v1alpha1/zz_activity.go
@@ -80,7 +80,7 @@ type ActivityObservation struct {
 // ActivityStatus defines the observed state of Activity.
 type ActivityStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          ActivityObservation `json:"atProvider"`
+	AtProvider          ActivityObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -94,7 +94,7 @@ type ActivityStatus struct {
 type Activity struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              ActivitySpec   `json:"spec,omitempty"`
+	Spec              ActivitySpec   `json:"spec"`
 	Status            ActivityStatus `json:"status,omitempty"`
 }
 

--- a/apis/sfn/v1alpha1/zz_state_machine.go
+++ b/apis/sfn/v1alpha1/zz_state_machine.go
@@ -89,7 +89,7 @@ type StateMachineObservation struct {
 // StateMachineStatus defines the observed state of StateMachine.
 type StateMachineStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          StateMachineObservation `json:"atProvider"`
+	AtProvider          StateMachineObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -103,7 +103,7 @@ type StateMachineStatus struct {
 type StateMachine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              StateMachineSpec   `json:"spec,omitempty"`
+	Spec              StateMachineSpec   `json:"spec"`
 	Status            StateMachineStatus `json:"status,omitempty"`
 }
 

--- a/package/crds/apigatewayv2.aws.crossplane.io_apimappings.yaml
+++ b/package/crds/apigatewayv2.aws.crossplane.io_apimappings.yaml
@@ -211,9 +211,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/apigatewayv2.aws.crossplane.io_apis.yaml
+++ b/package/crds/apigatewayv2.aws.crossplane.io_apis.yaml
@@ -205,9 +205,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/apigatewayv2.aws.crossplane.io_authorizers.yaml
+++ b/package/crds/apigatewayv2.aws.crossplane.io_authorizers.yaml
@@ -191,9 +191,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/apigatewayv2.aws.crossplane.io_deployments.yaml
+++ b/package/crds/apigatewayv2.aws.crossplane.io_deployments.yaml
@@ -191,9 +191,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/apigatewayv2.aws.crossplane.io_domainnames.yaml
+++ b/package/crds/apigatewayv2.aws.crossplane.io_domainnames.yaml
@@ -177,9 +177,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/apigatewayv2.aws.crossplane.io_integrationresponses.yaml
+++ b/package/crds/apigatewayv2.aws.crossplane.io_integrationresponses.yaml
@@ -196,9 +196,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/apigatewayv2.aws.crossplane.io_integrations.yaml
+++ b/package/crds/apigatewayv2.aws.crossplane.io_integrations.yaml
@@ -237,9 +237,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/apigatewayv2.aws.crossplane.io_models.yaml
+++ b/package/crds/apigatewayv2.aws.crossplane.io_models.yaml
@@ -167,9 +167,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/apigatewayv2.aws.crossplane.io_routeresponses.yaml
+++ b/package/crds/apigatewayv2.aws.crossplane.io_routeresponses.yaml
@@ -197,9 +197,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/apigatewayv2.aws.crossplane.io_routes.yaml
+++ b/package/crds/apigatewayv2.aws.crossplane.io_routes.yaml
@@ -212,9 +212,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/apigatewayv2.aws.crossplane.io_stages.yaml
+++ b/package/crds/apigatewayv2.aws.crossplane.io_stages.yaml
@@ -224,9 +224,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/apigatewayv2.aws.crossplane.io_vpclinks.yaml
+++ b/package/crds/apigatewayv2.aws.crossplane.io_vpclinks.yaml
@@ -215,9 +215,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/cloudfront.aws.crossplane.io_distributions.yaml
+++ b/package/crds/cloudfront.aws.crossplane.io_distributions.yaml
@@ -1249,9 +1249,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/dynamodb.aws.crossplane.io_backups.yaml
+++ b/package/crds/dynamodb.aws.crossplane.io_backups.yaml
@@ -180,9 +180,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/dynamodb.aws.crossplane.io_globaltables.yaml
+++ b/package/crds/dynamodb.aws.crossplane.io_globaltables.yaml
@@ -153,9 +153,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/dynamodb.aws.crossplane.io_tables.yaml
+++ b/package/crds/dynamodb.aws.crossplane.io_tables.yaml
@@ -377,9 +377,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/efs.aws.crossplane.io_filesystems.yaml
+++ b/package/crds/efs.aws.crossplane.io_filesystems.yaml
@@ -220,9 +220,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/kms.aws.crossplane.io_keys.yaml
+++ b/package/crds/kms.aws.crossplane.io_keys.yaml
@@ -215,9 +215,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/lambda.aws.crossplane.io_functions.yaml
+++ b/package/crds/lambda.aws.crossplane.io_functions.yaml
@@ -411,9 +411,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/rds.aws.crossplane.io_dbclusters.yaml
+++ b/package/crds/rds.aws.crossplane.io_dbclusters.yaml
@@ -564,9 +564,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/rds.aws.crossplane.io_dbparametergroups.yaml
+++ b/package/crds/rds.aws.crossplane.io_dbparametergroups.yaml
@@ -185,9 +185,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/rds.aws.crossplane.io_globalclusters.yaml
+++ b/package/crds/rds.aws.crossplane.io_globalclusters.yaml
@@ -198,9 +198,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/secretsmanager.aws.crossplane.io_secrets.yaml
+++ b/package/crds/secretsmanager.aws.crossplane.io_secrets.yaml
@@ -210,9 +210,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/servicediscovery.aws.crossplane.io_httpnamespaces.yaml
+++ b/package/crds/servicediscovery.aws.crossplane.io_httpnamespaces.yaml
@@ -154,9 +154,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/servicediscovery.aws.crossplane.io_privatednsnamespaces.yaml
+++ b/package/crds/servicediscovery.aws.crossplane.io_privatednsnamespaces.yaml
@@ -158,9 +158,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/servicediscovery.aws.crossplane.io_publicdnsnamespaces.yaml
+++ b/package/crds/servicediscovery.aws.crossplane.io_publicdnsnamespaces.yaml
@@ -154,9 +154,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/sfn.aws.crossplane.io_activities.yaml
+++ b/package/crds/sfn.aws.crossplane.io_activities.yaml
@@ -152,9 +152,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/sfn.aws.crossplane.io_statemachines.yaml
+++ b/package/crds/sfn.aws.crossplane.io_statemachines.yaml
@@ -210,9 +210,9 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #697
Depends on aws-controllers-k8s/code-generator#81

In the vast majority of resources a spec is required, so I'd like to mark it as such. I believe that in the edge cases where the spec really contains only optional fields it's possible to write spec: {}. Note that technically making `spec` required is a breaking change.

We prefer not to mark status fields as required, since resources will always exist at some point without their status and we consider 'requireness' to be more of a human-facing constraint than a software-facing constraint that our managed resource controllers should be subject to.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I don't imagine the `atProvider` change will affect anyone. I'd like to assess how many (if any) of the affected resources _really_ could have had an empty spec and still functioned. If any exist, I'd like to confirm my belief that folks can write `spec: {}` to indicate that their managed resource doesn't need a spec.