### PR TITLE
Fix ECR Repo policy eternally updating

### DIFF
--- a/pkg/clients/ecr/repository_policy.go
+++ b/pkg/clients/ecr/repository_policy.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/awserr"
@@ -151,9 +151,10 @@ func SerializeAWSPrincipal(p v1alpha1.AWSPrincipal) *string {
 		// Note: AWS Docs say you can specify the account ID either
 		// raw or as an ARN, but AWS actually converts internally to
 		// the ARN format, which is problematic for checking if we're
-		// up to date. So here we just do the conversion ourselves to
-		// avoid unintended behaviour if user specifies raw account ID.
-		if !strings.HasPrefix(*p.AWSAccountID, "arn:aws:iam::") {
+		// up to date. So here we just do the conversion ourselves if
+		// we were given a string containing a number that looks like an
+		// AWS account ID (looks like a 12-digit integer).
+		if _, err := strconv.ParseInt(*p.AWSAccountID, 10, 64); err == nil {
 			s := fmt.Sprintf("arn:aws:iam::%s:root", *p.AWSAccountID)
 			return &s
 		}

--- a/pkg/clients/ecr/repository_policy.go
+++ b/pkg/clients/ecr/repository_policy.go
@@ -221,7 +221,16 @@ func IsRepositoryPolicyUpToDate(local, remote *string) bool {
 	}
 
 	sortSlicesOpt := cmpopts.SortSlices(func(x, y interface{}) bool {
-		return x.(string) < y.(string)
+		if a, ok := x.(string); ok {
+			if b, ok := y.(string); ok {
+				return a < b
+			}
+		}
+		// Note: Unknown types in slices will not cause a panic, but
+		// may not be sorted correctly. Depending on how AWS handles
+		// these, it may cause constant updates - but better this than
+		// panicing.
+		return false
 	})
 	return cmp.Equal(localUnmarshalled, remoteUnmarshalled, cmpopts.EquateEmpty(), sortSlicesOpt)
 }

--- a/pkg/clients/ecr/repository_policy_test.go
+++ b/pkg/clients/ecr/repository_policy_test.go
@@ -20,7 +20,10 @@ var (
 	boolCheck   = true
 	testID      = "id"
 	policy      = `{"Statement":[{"Action":"ecr:ListImages","Effect":"Allow","Principal":"*"}],"Version":"2012-10-17"}`
-	params      = v1alpha1.RepositoryPolicyParameters{
+	cpxPolicy   = `{"Statement":[{"Action":"ecr:ListImages","Effect":"Allow","Principal":{"AWS":["arn:aws:iam::111122223333:userARN","111122223334","arn:aws:iam::111122223333:roleARN"]}}],"Version":"2012-10-17"}`
+	// Note: different sort order of principals than input above
+	cpxRemPolicy = `{"Statement":[{"Action":"ecr:ListImages","Effect":"Allow","Principal":{"AWS":["111122223334","arn:aws:iam::111122223333:userARN","arn:aws:iam::111122223333:roleARN"]}}],"Version":"2012-10-17"}`
+	params       = v1alpha1.RepositoryPolicyParameters{
 		Policy: &v1alpha1.RepositoryPolicyBody{
 			Version: "2012-10-17",
 			Statements: []v1alpha1.RepositoryPolicyStatement{
@@ -117,7 +120,9 @@ func TestSerializeRepositoryPolicyStatement(t *testing.T) {
 							IAMUserARN: aws.String("arn:aws:iam::111122223333:userARN"),
 						},
 						{
-							AWSAccountID: aws.String("111122223333"),
+							// Note: should be converted to full ARN when serialized
+							// to avoid needless updates.
+							AWSAccountID: aws.String("111122223334"),
 						},
 						{
 							IAMRoleARN: aws.String("arn:aws:iam::111122223333:roleARN"),
@@ -141,7 +146,7 @@ func TestSerializeRepositoryPolicyStatement(t *testing.T) {
 					},
 				}),
 			),
-			out: `{"Condition":{"test":{"test":"testKey","test2":"testKey2"}},"Action":"ecr:DescribeRepositories","Effect":"Allow","Principal":{"AWS":["arn:aws:iam::111122223333:userARN","111122223333","arn:aws:iam::111122223333:roleARN"]},"Sid":"1"}`,
+			out: `{"Condition":{"test":{"test":"testKey","test2":"testKey2"}},"Action":"ecr:DescribeRepositories","Effect":"Allow","Principal":{"AWS":["arn:aws:iam::111122223333:userARN","arn:aws:iam::111122223334:root","arn:aws:iam::111122223333:roleARN"]},"Sid":"1"}`,
 		},
 	}
 
@@ -227,6 +232,13 @@ func TestIsRepositoryPolicyUpToDate(t *testing.T) {
 				remote: "{\"testthree\": \"three\", \"testone\": \"one\"}",
 			},
 			want: false,
+		},
+		"SameFieldsPrincipalPolicy": {
+			args: args{
+				local:  cpxPolicy,
+				remote: cpxRemPolicy,
+			},
+			want: true,
 		},
 	}
 

--- a/pkg/clients/ecr/repository_policy_test.go
+++ b/pkg/clients/ecr/repository_policy_test.go
@@ -240,6 +240,15 @@ func TestIsRepositoryPolicyUpToDate(t *testing.T) {
 			},
 			want: true,
 		},
+		"SameFieldsNumericPrincipals": {
+			args: args{
+				// This is to test that our slice sorting does not
+				// panic with unexpected value types.
+				local:  `{"Statement":[{"Effect":"Allow","Action":"ecr:ListImages","Principal":[2,1,"foo","bar"]}],"Version":"2012-10-17"}`,
+				remote: `{"Statement":[{"Effect":"Allow","Action":"ecr:ListImages","Principal":[2,1,"bar","foo"]}],"Version":"2012-10-17"}`,
+			},
+			want: true,
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
### Description of your changes
Resolves a couple of issues around detecting changes on the ECR
`RepositoryPolicy` type:
  1. Converts `awsAccountId` principals that were not specified as an
     ARN into the ARN format, as AWS always returns in this format from
     the API.
  2. Makes sure to sort string slices within the policy document during
     comparison, to avoid issues where AWS returns values in a different
     order.

Fixes #700

Signed-off-by: Ben Agricola <bagricola@squiz.co.uk>
I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Additional test added to compare policies with defined principals as a string slice, that tests both of these cases.
That test fails without the fixes applied.

[contribution process]: https://git.io/fj2m9
