### PR TITLE
Further fixes to get provider-aws to pass conformance tests

### DIFF
--- a/apis/acm/v1alpha1/certificate_types.go
+++ b/apis/acm/v1alpha1/certificate_types.go
@@ -138,7 +138,7 @@ type Certificate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   CertificateSpec   `json:"spec,omitempty"`
+	Spec   CertificateSpec   `json:"spec"`
 	Status CertificateStatus `json:"status,omitempty"`
 }
 

--- a/apis/acm/v1alpha1/certificate_types.go
+++ b/apis/acm/v1alpha1/certificate_types.go
@@ -70,7 +70,7 @@ type CertificateExternalStatus struct {
 // An CertificateStatus represents the observed state of an Certificate manager.
 type CertificateStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          CertificateExternalStatus `json:"atProvider"`
+	AtProvider          CertificateExternalStatus `json:"atProvider,omitempty"`
 }
 
 // CertificateParameters defines the desired state of an AWS Certificate.

--- a/apis/acmpca/v1alpha1/certificateauthority_types.go
+++ b/apis/acmpca/v1alpha1/certificateauthority_types.go
@@ -203,7 +203,7 @@ type CertificateAuthority struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   CertificateAuthoritySpec   `json:"spec,omitempty"`
+	Spec   CertificateAuthoritySpec   `json:"spec"`
 	Status CertificateAuthorityStatus `json:"status,omitempty"`
 }
 

--- a/apis/acmpca/v1alpha1/certificateauthoritypermission_types.go
+++ b/apis/acmpca/v1alpha1/certificateauthoritypermission_types.go
@@ -80,7 +80,7 @@ type CertificateAuthorityPermission struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   CertificateAuthorityPermissionSpec   `json:"spec,omitempty"`
+	Spec   CertificateAuthorityPermissionSpec   `json:"spec"`
 	Status CertificateAuthorityPermissionStatus `json:"status,omitempty"`
 }
 

--- a/apis/cache/v1alpha1/cache_subnet_group_types.go
+++ b/apis/cache/v1alpha1/cache_subnet_group_types.go
@@ -58,7 +58,7 @@ type CacheSubnetGroupExternalStatus struct {
 // A CacheSubnetGroupStatus represents the observed state of a Subnet Group.
 type CacheSubnetGroupStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          CacheSubnetGroupExternalStatus `json:"atProvider"`
+	AtProvider          CacheSubnetGroupExternalStatus `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/ec2/v1alpha1/vpccidrblock_types.go
+++ b/apis/ec2/v1alpha1/vpccidrblock_types.go
@@ -118,7 +118,7 @@ type VPCCIDRBlockState struct {
 // A VPCCIDRBlockStatus represents the observed state of a ElasticIP.
 type VPCCIDRBlockStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          VPCCIDRBlockObservation `json:"atProvider"`
+	AtProvider          VPCCIDRBlockObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/ec2/v1beta1/address_types.go
+++ b/apis/ec2/v1beta1/address_types.go
@@ -126,7 +126,7 @@ type AddressObservation struct {
 // A AddressStatus represents the observed state of a Address.
 type AddressStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          AddressObservation `json:"atProvider"`
+	AtProvider          AddressObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/ec2/v1beta1/internetgateway_types.go
+++ b/apis/ec2/v1beta1/internetgateway_types.go
@@ -94,7 +94,7 @@ type InternetGatewayObservation struct {
 // An InternetGatewayStatus represents the observed state of an InternetGateway.
 type InternetGatewayStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          InternetGatewayObservation `json:"atProvider"`
+	AtProvider          InternetGatewayObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/ec2/v1beta1/natgateway_types.go
+++ b/apis/ec2/v1beta1/natgateway_types.go
@@ -90,7 +90,7 @@ type NATGatewayAddress struct {
 // NATGatewayStatus describes the observed state
 type NATGatewayStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          NATGatewayObservation `json:"atProvider"`
+	AtProvider          NATGatewayObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/ec2/v1beta1/routetable_types.go
+++ b/apis/ec2/v1beta1/routetable_types.go
@@ -213,7 +213,7 @@ type RouteTableObservation struct {
 // A RouteTableStatus represents the observed state of a RouteTable.
 type RouteTableStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          RouteTableObservation `json:"atProvider"`
+	AtProvider          RouteTableObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/ec2/v1beta1/securitygroup_types.go
+++ b/apis/ec2/v1beta1/securitygroup_types.go
@@ -232,7 +232,7 @@ type SecurityGroupObservation struct {
 // A SecurityGroupStatus represents the observed state of a SecurityGroup.
 type SecurityGroupStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          SecurityGroupObservation `json:"atProvider"`
+	AtProvider          SecurityGroupObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/ec2/v1beta1/subnet_types.go
+++ b/apis/ec2/v1beta1/subnet_types.go
@@ -109,7 +109,7 @@ type SubnetObservation struct {
 // A SubnetStatus represents the observed state of a Subnet.
 type SubnetStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          SubnetObservation `json:"atProvider"`
+	AtProvider          SubnetObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/ec2/v1beta1/vpc_types.go
+++ b/apis/ec2/v1beta1/vpc_types.go
@@ -128,7 +128,7 @@ type VPCObservation struct {
 // A VPCStatus represents the observed state of a VPC.
 type VPCStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          VPCObservation `json:"atProvider"`
+	AtProvider          VPCObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/ecr/v1alpha1/policy_types.go
+++ b/apis/ecr/v1alpha1/policy_types.go
@@ -243,7 +243,7 @@ type RepositoryPolicyObservation struct {
 // A RepositoryPolicyStatus represents the observed state of a repository policy
 type RepositoryPolicyStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          RepositoryPolicyObservation `json:"atProvider"`
+	AtProvider          RepositoryPolicyObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/ecr/v1alpha1/repository_types.go
+++ b/apis/ecr/v1alpha1/repository_types.go
@@ -98,7 +98,7 @@ type ImageScanningConfiguration struct {
 // A RepositoryStatus represents the observed state of a Elastic Container Repository.
 type RepositoryStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          RepositoryObservation `json:"atProvider"`
+	AtProvider          RepositoryObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/elasticloadbalancing/v1alpha1/elb_attachment_types.go
+++ b/apis/elasticloadbalancing/v1alpha1/elb_attachment_types.go
@@ -59,7 +59,7 @@ type ELBAttachmentObservation struct {
 // An ELBAttachmentStatus represents the observed state of an ELBAttachmentAttachment.
 type ELBAttachmentStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          ELBAttachmentObservation `json:"atProvider"`
+	AtProvider          ELBAttachmentObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/elasticloadbalancing/v1alpha1/elb_types.go
+++ b/apis/elasticloadbalancing/v1alpha1/elb_types.go
@@ -166,7 +166,7 @@ type ELBObservation struct {
 // An ELBStatus represents the observed state of an ELB.
 type ELBStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          ELBObservation `json:"atProvider"`
+	AtProvider          ELBObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/identity/v1alpha1/iamgroup_types.go
+++ b/apis/identity/v1alpha1/iamgroup_types.go
@@ -47,7 +47,7 @@ type IAMGroupObservation struct {
 // An IAMGroupStatus represents the observed state of an IAM Group.
 type IAMGroupStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          IAMGroupObservation `json:"atProvider"`
+	AtProvider          IAMGroupObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/identity/v1alpha1/iamgrouppolicyattachment_types.go
+++ b/apis/identity/v1alpha1/iamgrouppolicyattachment_types.go
@@ -70,7 +70,7 @@ type IAMGroupPolicyAttachmentObservation struct {
 // IAMGroupPolicyAttachment.
 type IAMGroupPolicyAttachmentStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          IAMGroupPolicyAttachmentObservation `json:"atProvider"`
+	AtProvider          IAMGroupPolicyAttachmentObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/identity/v1alpha1/iamgroupusermembership_types.go
+++ b/apis/identity/v1alpha1/iamgroupusermembership_types.go
@@ -71,7 +71,7 @@ type IAMGroupUserMembershipObservation struct {
 // IAMGroupUserMembership.
 type IAMGroupUserMembershipStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          IAMGroupUserMembershipObservation `json:"atProvider"`
+	AtProvider          IAMGroupUserMembershipObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/identity/v1alpha1/iampolicy_types.go
+++ b/apis/identity/v1alpha1/iampolicy_types.go
@@ -71,7 +71,7 @@ type IAMPolicyObservation struct {
 // An IAMPolicyStatus represents the observed state of an IAMPolicy.
 type IAMPolicyStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          IAMPolicyObservation `json:"atProvider"`
+	AtProvider          IAMPolicyObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/identity/v1alpha1/iamuser_types.go
+++ b/apis/identity/v1alpha1/iamuser_types.go
@@ -56,7 +56,7 @@ type IAMUserObservation struct {
 // An IAMUserStatus represents the observed state of an IAM User.
 type IAMUserStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          IAMUserObservation `json:"atProvider"`
+	AtProvider          IAMUserObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/identity/v1alpha1/iamuserpolicyattachment_types.go
+++ b/apis/identity/v1alpha1/iamuserpolicyattachment_types.go
@@ -70,7 +70,7 @@ type IAMUserPolicyAttachmentObservation struct {
 // IAMUserPolicyAttachment.
 type IAMUserPolicyAttachmentStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          IAMUserPolicyAttachmentObservation `json:"atProvider"`
+	AtProvider          IAMUserPolicyAttachmentObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/identity/v1alpha1/openidconnectprovider_types.go
+++ b/apis/identity/v1alpha1/openidconnectprovider_types.go
@@ -89,7 +89,7 @@ type OpenIDConnectProviderObservation struct {
 // OpenIDConnectProviderStatus defines the observed state of OpenIDConnectProvider.
 type OpenIDConnectProviderStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          OpenIDConnectProviderObservation `json:"atProvider"`
+	AtProvider          OpenIDConnectProviderObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/identity/v1alpha1/openidconnectprovider_types.go
+++ b/apis/identity/v1alpha1/openidconnectprovider_types.go
@@ -103,7 +103,7 @@ type OpenIDConnectProviderStatus struct {
 type OpenIDConnectProvider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              OpenIDConnectProviderSpec   `json:"spec,omitempty"`
+	Spec              OpenIDConnectProviderSpec   `json:"spec"`
 	Status            OpenIDConnectProviderStatus `json:"status,omitempty"`
 }
 

--- a/apis/identity/v1beta1/iamrole_types.go
+++ b/apis/identity/v1beta1/iamrole_types.go
@@ -104,7 +104,7 @@ type IAMRoleExternalStatus struct {
 // An IAMRoleStatus represents the observed state of an IAMRole.
 type IAMRoleStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          IAMRoleExternalStatus `json:"atProvider"`
+	AtProvider          IAMRoleExternalStatus `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/identity/v1beta1/iamrolepolicyattachment_types.go
+++ b/apis/identity/v1beta1/iamrolepolicyattachment_types.go
@@ -71,7 +71,7 @@ type IAMRolePolicyAttachmentExternalStatus struct {
 // IAMRolePolicyAttachment.
 type IAMRolePolicyAttachmentStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          IAMRolePolicyAttachmentExternalStatus `json:"atProvider"`
+	AtProvider          IAMRolePolicyAttachmentExternalStatus `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/notification/v1alpha1/snstopic_types.go
+++ b/apis/notification/v1alpha1/snstopic_types.go
@@ -116,7 +116,7 @@ type SNSTopicObservation struct {
 // SNSTopicStatus is the status of AWS SNS Topic
 type SNSTopicStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          SNSTopicObservation `json:"atProvider"`
+	AtProvider          SNSTopicObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/s3/v1beta1/bucket_types.go
+++ b/apis/s3/v1beta1/bucket_types.go
@@ -161,7 +161,7 @@ type BucketExternalStatus struct {
 // BucketStatus represents the observed state of the Bucket.
 type BucketStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          BucketExternalStatus `json:"atProvider"`
+	AtProvider          BucketExternalStatus `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/sqs/v1beta1/queue_types.go
+++ b/apis/sqs/v1beta1/queue_types.go
@@ -213,7 +213,7 @@ type QueueObservation struct {
 // QueueStatus represents the observed state of a Queue.
 type QueueStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-	AtProvider          QueueObservation `json:"atProvider"`
+	AtProvider          QueueObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/package/crds/acm.aws.crossplane.io_certificates.yaml
+++ b/package/crds/acm.aws.crossplane.io_certificates.yaml
@@ -246,6 +246,8 @@ spec:
                   type: object
                 type: array
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/acm.aws.crossplane.io_certificates.yaml
+++ b/package/crds/acm.aws.crossplane.io_certificates.yaml
@@ -245,8 +245,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         type: object
     served: true

--- a/package/crds/acmpca.aws.crossplane.io_certificateauthorities.yaml
+++ b/package/crds/acmpca.aws.crossplane.io_certificateauthorities.yaml
@@ -280,6 +280,8 @@ spec:
                   type: object
                 type: array
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/acmpca.aws.crossplane.io_certificateauthoritypermissions.yaml
+++ b/package/crds/acmpca.aws.crossplane.io_certificateauthoritypermissions.yaml
@@ -163,6 +163,8 @@ spec:
                   type: object
                 type: array
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/cache.aws.crossplane.io_cachesubnetgroups.yaml
+++ b/package/crds/cache.aws.crossplane.io_cachesubnetgroups.yaml
@@ -172,8 +172,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/ec2.aws.crossplane.io_addresses.yaml
+++ b/package/crds/ec2.aws.crossplane.io_addresses.yaml
@@ -212,8 +212,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/ec2.aws.crossplane.io_internetgateways.yaml
+++ b/package/crds/ec2.aws.crossplane.io_internetgateways.yaml
@@ -206,8 +206,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/ec2.aws.crossplane.io_natgateways.yaml
+++ b/package/crds/ec2.aws.crossplane.io_natgateways.yaml
@@ -237,8 +237,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/ec2.aws.crossplane.io_routetables.yaml
+++ b/package/crds/ec2.aws.crossplane.io_routetables.yaml
@@ -353,8 +353,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/ec2.aws.crossplane.io_securitygroups.yaml
+++ b/package/crds/ec2.aws.crossplane.io_securitygroups.yaml
@@ -415,8 +415,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/ec2.aws.crossplane.io_subnets.yaml
+++ b/package/crds/ec2.aws.crossplane.io_subnets.yaml
@@ -214,8 +214,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/ec2.aws.crossplane.io_vpccidrblocks.yaml
+++ b/package/crds/ec2.aws.crossplane.io_vpccidrblocks.yaml
@@ -214,8 +214,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/ec2.aws.crossplane.io_vpcs.yaml
+++ b/package/crds/ec2.aws.crossplane.io_vpcs.yaml
@@ -229,8 +229,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/ecr.aws.crossplane.io_repositories.yaml
+++ b/package/crds/ecr.aws.crossplane.io_repositories.yaml
@@ -183,8 +183,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/ecr.aws.crossplane.io_repositorypolicies.yaml
+++ b/package/crds/ecr.aws.crossplane.io_repositorypolicies.yaml
@@ -411,8 +411,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/elasticloadbalancing.aws.crossplane.io_elbattachments.yaml
+++ b/package/crds/elasticloadbalancing.aws.crossplane.io_elbattachments.yaml
@@ -164,8 +164,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/elasticloadbalancing.aws.crossplane.io_elbs.yaml
+++ b/package/crds/elasticloadbalancing.aws.crossplane.io_elbs.yaml
@@ -307,8 +307,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/identity.aws.crossplane.io_iamgrouppolicyattachments.yaml
+++ b/package/crds/identity.aws.crossplane.io_iamgrouppolicyattachments.yaml
@@ -185,8 +185,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/identity.aws.crossplane.io_iamgroups.yaml
+++ b/package/crds/identity.aws.crossplane.io_iamgroups.yaml
@@ -139,8 +139,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/identity.aws.crossplane.io_iamgroupusermemberships.yaml
+++ b/package/crds/identity.aws.crossplane.io_iamgroupusermemberships.yaml
@@ -185,8 +185,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/identity.aws.crossplane.io_iampolicies.yaml
+++ b/package/crds/identity.aws.crossplane.io_iampolicies.yaml
@@ -164,8 +164,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/identity.aws.crossplane.io_iamrolepolicyattachments.yaml
+++ b/package/crds/identity.aws.crossplane.io_iamrolepolicyattachments.yaml
@@ -185,8 +185,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/identity.aws.crossplane.io_iamroles.yaml
+++ b/package/crds/identity.aws.crossplane.io_iamroles.yaml
@@ -168,8 +168,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/identity.aws.crossplane.io_iamuserpolicyattachments.yaml
+++ b/package/crds/identity.aws.crossplane.io_iamuserpolicyattachments.yaml
@@ -185,8 +185,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/identity.aws.crossplane.io_iamusers.yaml
+++ b/package/crds/identity.aws.crossplane.io_iamusers.yaml
@@ -160,8 +160,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/identity.aws.crossplane.io_openidconnectproviders.yaml
+++ b/package/crds/identity.aws.crossplane.io_openidconnectproviders.yaml
@@ -151,8 +151,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         type: object
     served: true

--- a/package/crds/identity.aws.crossplane.io_openidconnectproviders.yaml
+++ b/package/crds/identity.aws.crossplane.io_openidconnectproviders.yaml
@@ -152,6 +152,8 @@ spec:
                   type: object
                 type: array
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/package/crds/notification.aws.crossplane.io_snstopics.yaml
+++ b/package/crds/notification.aws.crossplane.io_snstopics.yaml
@@ -188,8 +188,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/s3.aws.crossplane.io_buckets.yaml
+++ b/package/crds/s3.aws.crossplane.io_buckets.yaml
@@ -1021,8 +1021,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec

--- a/package/crds/sqs.aws.crossplane.io_queues.yaml
+++ b/package/crds/sqs.aws.crossplane.io_queues.yaml
@@ -235,8 +235,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - atProvider
             type: object
         required:
         - spec


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This fixes the same issue as https://github.com/crossplane/provider-aws/pull/698 (`status.atProvider` being required and `spec` not being required) for hand curated, non-generated resources.

Edit: I previously had included a commit that corrected a misnamed ReplicationGroup reference field; that is going to be a larger issue so I'll tackle it elsewhere.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've run this in combination with https://github.com/crossplane/conformance/pull/24 and verified that all CRDs are considered conformant.