### PR TITLE
Use singular, not plural cacheSubnetGroupNameRef in ReplicaGroup

### DIFF
--- a/apis/cache/v1beta1/replication_group_types.go
+++ b/apis/cache/v1beta1/replication_group_types.go
@@ -346,14 +346,14 @@ type ReplicationGroupParameters struct {
 	// +optional
 	CacheSubnetGroupName *string `json:"cacheSubnetGroupName,omitempty"`
 
-	// CacheSubnetGroupNameRef is a reference to a Subnet Group
+	// CacheSubnetGroupNameRef is a reference to a Subnet Group used to set
 	// the CacheSubnetGroupName.
 	// +immutable
 	// +optional
 	CacheSubnetGroupNameRef *xpv1.Reference `json:"cacheSubnetGroupNameRef,omitempty"`
 
 	// DeprecatedCacheSubnetGroupNameRef is a reference to a Subnet Group
-	// the CacheSubnetGroupName.
+	// used to set the CacheSubnetGroupName.
 	//
 	// Deprecated: Use CacheSubnetGroupNameRef. This field exists because we
 	// introduced it with the JSON tag cacheSubnetGroupNameRefs (plural)

--- a/apis/cache/v1beta1/replication_group_types.go
+++ b/apis/cache/v1beta1/replication_group_types.go
@@ -350,7 +350,18 @@ type ReplicationGroupParameters struct {
 	// the CacheSubnetGroupName.
 	// +immutable
 	// +optional
-	CacheSubnetGroupNameRef *xpv1.Reference `json:"cacheSubnetGroupNameRefs,omitempty"`
+	CacheSubnetGroupNameRef *xpv1.Reference `json:"cacheSubnetGroupNameRef,omitempty"`
+
+	// DeprecatedCacheSubnetGroupNameRef is a reference to a Subnet Group
+	// the CacheSubnetGroupName.
+	//
+	// Deprecated: Use CacheSubnetGroupNameRef. This field exists because we
+	// introduced it with the JSON tag cacheSubnetGroupNameRefs (plural)
+	// when it should have been cacheSubnetGroupNameRef (singular). This is
+	// a bug that we need to avoid a breaking change to this v1beta1 API.
+	// +immutable
+	// +optional
+	DeprecatedCacheSubnetGroupNameRef *xpv1.Reference `json:"cacheSubnetGroupNameRefs,omitempty"`
 
 	// CacheSubnetGroupNameSelector selects a reference to a CacheSubnetGroup.
 	// +immutable

--- a/apis/cache/v1beta1/zz_generated.deepcopy.go
+++ b/apis/cache/v1beta1/zz_generated.deepcopy.go
@@ -253,6 +253,11 @@ func (in *ReplicationGroupParameters) DeepCopyInto(out *ReplicationGroupParamete
 		*out = new(v1.Reference)
 		**out = **in
 	}
+	if in.DeprecatedCacheSubnetGroupNameRef != nil {
+		in, out := &in.DeprecatedCacheSubnetGroupNameRef, &out.DeprecatedCacheSubnetGroupNameRef
+		*out = new(v1.Reference)
+		**out = **in
+	}
 	if in.CacheSubnetGroupNameSelector != nil {
 		in, out := &in.CacheSubnetGroupNameSelector, &out.CacheSubnetGroupNameSelector
 		*out = new(v1.Selector)

--- a/examples/cache/replicationgroup.yaml
+++ b/examples/cache/replicationgroup.yaml
@@ -13,13 +13,14 @@ spec:
     engine: "redis"
     engineVersion: "5.0.6"
     port: 6379
-    cacheSubnetGroupNameRef: sample-cache-subnet-group
+    cacheSubnetGroupNameRef:
+      name: sample-cache-subnet-group
     numCacheClusters: 3
     cacheParameterGroupName: default.redis5.0
     cacheNodeType: cache.t3.medium
     automaticFailoverEnabled: true
-  writeConnectionSecretsToRef:
-    name: replic
+  writeConnectionSecretToRef:
+    name: replicationgroup
     namespace: crossplane-system
   providerConfigRef:
     name: example

--- a/package/crds/cache.aws.crossplane.io_replicationgroups.yaml
+++ b/package/crds/cache.aws.crossplane.io_replicationgroups.yaml
@@ -111,7 +111,7 @@ spec:
                     description: CacheSubnetGroupName specifies the name of the cache subnet group to be used for the replication group. If you're going to launch your cluster in an Amazon VPC, you need to create a subnet group before you start creating a cluster. For more information, see Subnets and Subnet Groups (http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/SubnetGroups.html).
                     type: string
                   cacheSubnetGroupNameRef:
-                    description: CacheSubnetGroupNameRef is a reference to a Subnet Group the CacheSubnetGroupName.
+                    description: CacheSubnetGroupNameRef is a reference to a Subnet Group used to set the CacheSubnetGroupName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -120,7 +120,7 @@ spec:
                     - name
                     type: object
                   cacheSubnetGroupNameRefs:
-                    description: "DeprecatedCacheSubnetGroupNameRef is a reference to a Subnet Group the CacheSubnetGroupName. \n Deprecated: Use CacheSubnetGroupNameRef. This field exists because we introduced it with the JSON tag cacheSubnetGroupNameRefs (plural) when it should have been cacheSubnetGroupNameRef (singular). This is a bug that we need to avoid a breaking change to this v1beta1 API."
+                    description: "DeprecatedCacheSubnetGroupNameRef is a reference to a Subnet Group used to set the CacheSubnetGroupName. \n Deprecated: Use CacheSubnetGroupNameRef. This field exists because we introduced it with the JSON tag cacheSubnetGroupNameRefs (plural) when it should have been cacheSubnetGroupNameRef (singular). This is a bug that we need to avoid a breaking change to this v1beta1 API."
                     properties:
                       name:
                         description: Name of the referenced object.

--- a/package/crds/cache.aws.crossplane.io_replicationgroups.yaml
+++ b/package/crds/cache.aws.crossplane.io_replicationgroups.yaml
@@ -110,8 +110,17 @@ spec:
                   cacheSubnetGroupName:
                     description: CacheSubnetGroupName specifies the name of the cache subnet group to be used for the replication group. If you're going to launch your cluster in an Amazon VPC, you need to create a subnet group before you start creating a cluster. For more information, see Subnets and Subnet Groups (http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/SubnetGroups.html).
                     type: string
-                  cacheSubnetGroupNameRefs:
+                  cacheSubnetGroupNameRef:
                     description: CacheSubnetGroupNameRef is a reference to a Subnet Group the CacheSubnetGroupName.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  cacheSubnetGroupNameRefs:
+                    description: "DeprecatedCacheSubnetGroupNameRef is a reference to a Subnet Group the CacheSubnetGroupName. \n Deprecated: Use CacheSubnetGroupNameRef. This field exists because we introduced it with the JSON tag cacheSubnetGroupNameRefs (plural) when it should have been cacheSubnetGroupNameRef (singular). This is a bug that we need to avoid a breaking change to this v1beta1 API."
                     properties:
                       name:
                         description: Name of the referenced object.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds a `cacheSubnetGroupNameRef` (singular) reference. The existing (accidentally) plural `cacheSubnetGroupNameRefs` field is maintained for backward compatibility.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've created a `ReplicaGroup` using the examples under`examples/cache` and validated that that:

* If both reference fields are set we get an error.
* If the deprecated plural field is set, we use that.
* Otherwise we use the new singular field.