### PR TITLE
fix sfn 404 for deletion

### DIFF
--- a/apis/sfn/v1alpha1/generator-config.yaml
+++ b/apis/sfn/v1alpha1/generator-config.yaml
@@ -5,9 +5,11 @@ ignore:
 resources:
   StateMachine:
     exceptions:
-      codes:
-        404: StateMachineDoesNotExist
+      errors:
+        404:
+          code: StateMachineDoesNotExist
   Activity:
     exceptions:
-      codes:
-        404: ActivityDoesNotExist
+      errors:
+        404:
+          code: ActivityDoesNotExist

--- a/pkg/controller/sfn/activity/zz_conversions.go
+++ b/pkg/controller/sfn/activity/zz_conversions.go
@@ -98,5 +98,5 @@ func GenerateDeleteActivityInput(cr *svcapitypes.Activity) *svcsdk.DeleteActivit
 // IsNotFound returns whether the given error is of type NotFound or not.
 func IsNotFound(err error) bool {
 	awsErr, ok := err.(awserr.Error)
-	return ok && awsErr.Code() == "UNKNOWN"
+	return ok && awsErr.Code() == "ActivityDoesNotExist"
 }

--- a/pkg/controller/sfn/statemachine/zz_conversions.go
+++ b/pkg/controller/sfn/statemachine/zz_conversions.go
@@ -179,5 +179,5 @@ func GenerateDeleteStateMachineInput(cr *svcapitypes.StateMachine) *svcsdk.Delet
 // IsNotFound returns whether the given error is of type NotFound or not.
 func IsNotFound(err error) bool {
 	awsErr, ok := err.(awserr.Error)
-	return ok && awsErr.Code() == "UNKNOWN"
+	return ok && awsErr.Code() == "StateMachineDoesNotExist"
 }


### PR DESCRIPTION
Signed-off-by: Christopher Haar <chhaar30@googlemail.com>

fixed ressources exeptions errors in generator-config.yaml for sfn

### Description of your changes

Fixes #725

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

statemachine:
```
➜  sfn git:(master) ✗ kubectl apply -f statemachine.yaml 
statemachine.sfn.aws.crossplane.io/sample-statemachine created
➜  sfn git:(master) ✗ kubectl delete -f statemachine.yaml
statemachine.sfn.aws.crossplane.io "sample-statemachine" deleted
```

activity:
```
➜  sfn git:(master) ✗ kubectl apply -f activity.yaml 
activity.sfn.aws.crossplane.io/sample-activity created
➜  sfn git:(master) ✗ kubectl delete -f activity.yaml 
activity.sfn.aws.crossplane.io "sample-activity" deleted
```

output from deletion:

statemachine:
```
2021-06-17T10:05:26.162+0200	DEBUG	controller-runtime.manager.events	Normal	{"object": {"kind":"Key","name":"kms-key-test","uid":"5033fe49-14b3-4c50-8590-b2924cac3476","apiVersion":"kms.aws.crossplane.io/v1alpha1","resourceVersion":"124666"}, "reason": "DeletedExternalResource", "message": "Successfully requested deletion of external resource"}
2021-06-17T10:05:48.934+0200	DEBUG	provider-aws	Reconciling	{"controller": "managed/statemachine.sfn.aws.crossplane.io", "request": "/sample-statemachine"}
2021-06-17T10:05:49.050+0200	DEBUG	provider-aws	Successfully deleted managed resource	{"controller": "managed/statemachine.sfn.aws.crossplane.io", "request": "/sample-statemachine", "uid": "fb0b9575-56f4-43f6-bce7-d92bbd403071", "version": "157968", "external-name": "arn:aws:states:eu-central-1:255932642927:stateMachine:sample-statemachine", "deletion-timestamp": "2021-06-17 10:04:55 +0200 CEST"}
2021-06-17T10:05:49.050+0200	DEBUG	provider-aws	Reconciling	{"controller": "managed/statemachine.sfn.aws.crossplane.io", "request": "/sample-statemachine"}
2021-06-17T10:05:49.050+0200	DEBUG	provider-aws	Cannot get managed resource	{"controller": "managed/statemachine.sfn.aws.crossplane.io", "request": "/sample-statemachine", "error": "StateMachine.sfn.aws.crossplane.io \"sample-statemachine\" not found"}
```

activity:
```
2021-06-17T10:20:53.954+0200	DEBUG	provider-aws	Reconciling	{"controller": "managed/activity.sfn.aws.crossplane.io", "request": "/sample-activity"}
2021-06-17T10:20:54.024+0200	DEBUG	provider-aws	Successfully deleted managed resource	{"controller": "managed/activity.sfn.aws.crossplane.io", "request": "/sample-activity", "uid": "9de3e722-644b-45cb-983a-5580e01d0faf", "version": "161612", "external-name": "arn:aws:states:eu-central-1:255932642927:activity:sample-activity", "deletion-timestamp": "2021-06-17 10:20:53 +0200 CEST"}
2021-06-17T10:20:54.024+0200	DEBUG	provider-aws	Reconciling	{"controller": "managed/activity.sfn.aws.crossplane.io", "request": "/sample-activity"}
2021-06-17T10:20:54.024+0200	DEBUG	provider-aws	Cannot get managed resource	{"controller": "managed/activity.sfn.aws.crossplane.io", "request": "/sample-activity", "error": "Activity.sfn.aws.crossplane.io \"sample-activity\" not found"}
2021-06-17T10:20:54.681+0200	DEBUG	provider-aws	Reconciling	{"controller": "managed/activity.sfn.aws.crossplane.io", "request": "/sample-activity"}
2021-06-17T10:20:54.682+0200	DEBUG	provider-aws	Cannot get managed resource	{"controller": "managed/activity.sfn.aws.crossplane.io", "request": "/sample-activity", "error": "Activity.sfn.aws.crossplane.io \"sample-activity\" not found"}
```


[contribution process]: https://git.io/fj2m9
