### PR TITLE
Fixes #738: servicediscovery (common)namespace READY=FALSE

### DIFF
--- a/examples/servicediscovery/httpnamespace.yaml
+++ b/examples/servicediscovery/httpnamespace.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   forProvider:
     region: us-east-1
-    description: "test"
     name: crossplane-http-namespace-test
     tags:
       - key: cluster

--- a/examples/servicediscovery/privatednsnamespace.yaml
+++ b/examples/servicediscovery/privatednsnamespace.yaml
@@ -3,14 +3,13 @@ kind: PrivateDNSNamespace
 metadata:
   name: example-privatednsnamespace
 spec:
-  providerConfigRef:
-    name: example
   forProvider:
     region: us-east-1
-    description: "test"
     name: crossplane-private-dns-namespace-test
     vpcRef:
       name: sample-vpc
     tags:
       - key: cluster
         value: "my-cluster"
+  providerConfigRef:
+    name: example

--- a/examples/servicediscovery/publicdnsnamespace.yaml
+++ b/examples/servicediscovery/publicdnsnamespace.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   forProvider:
     region: us-east-1
-    description: "test"
     name: crossplane.example.org
     tags:
       - key: cluster


### PR DESCRIPTION

### Description of your changes

Fixes #738 
if description is empty the status is READY=FALSE because of lateInited = true,
also removed description in examples because it's not required

before the fix:
```
NAME                                                                                      READY   SYNCED   EXTERNAL-NAME
privatednsnamespace.servicediscovery.aws.crossplane.io/example-privatednsnamespace        True    True     ns-ngfbsrd3zfnp3qnj
privatednsnamespace.servicediscovery.aws.crossplane.io/testnamespace.svc.cluster.local    False   True     ns-oslzgdargwixvklp
privatednsnamespace.servicediscovery.aws.crossplane.io/testnamespace2-svc-cluster-local   False   True     ns-vbcc5n6l5wel5vfr
```

after the fix:
```
NAME                                                                                      READY   SYNCED   EXTERNAL-NAME
privatednsnamespace.servicediscovery.aws.crossplane.io/example-privatednsnamespace        True    True     ns-ngfbsrd3zfnp3qnj
privatednsnamespace.servicediscovery.aws.crossplane.io/testnamespace.svc.cluster.local    True    True     ns-oslzgdargwixvklp
privatednsnamespace.servicediscovery.aws.crossplane.io/testnamespace2-svc-cluster-local   True    True     ns-vbcc5n6l5wel5vfr
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
make reviewable
18:29:28 [ OK ] go test unit-tests
```
create & delete multiple (common)namespaces :)


[contribution process]: https://git.io/fj2m9
