### PR TITLE
Add global poll interval flag

### DIFF
--- a/CODE_GENERATION.md
+++ b/CODE_GENERATION.md
@@ -92,7 +92,7 @@ of the provider. Create a file called `pkg/controller/<serviceid>/setup.go` and
 add the setup function like the following:
 ```golang
 // SetupStage adds a controller that reconciles Stage.
-func SetupStage(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupStage(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.StageGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -103,6 +103,7 @@ func SetupStage(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) er
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(svcapitypes.StageGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient()}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }
@@ -165,7 +166,7 @@ Likely, we need to do this injection before every SDK call. The following is an
 example for hook functions injected:
 ```golang
 // SetupStage adds a controller that reconciles Stage.
-func SetupStage(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupStage(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.StageGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -185,6 +186,7 @@ func SetupStage(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) er
 			resource.ManagedKind(svcapitypes.StageGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -37,6 +37,7 @@ func main() {
 		app            = kingpin.New(filepath.Base(os.Args[0]), "AWS support for Crossplane.").DefaultEnvars()
 		debug          = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
 		syncPeriod     = app.Flag("sync", "Controller manager sync period duration such as 300ms, 1.5h or 2h45m").Short('s').Default("1h").Duration()
+		pollInterval   = app.Flag("poll-interval", "Default poll interval for all manage resource controllers.").Default("1m").Duration()
 		leaderElection = app.Flag("leader-election", "Use leader election for the conroller manager.").Short('l').Default("false").OverrideDefaultFromEnvar("LEADER_ELECTION").Bool()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
@@ -63,7 +64,7 @@ func main() {
 	kingpin.FatalIfError(err, "Cannot create controller manager")
 
 	kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add AWS APIs to scheme")
-	kingpin.FatalIfError(controller.Setup(mgr, log, ratelimiter.NewDefaultProviderRateLimiter(ratelimiter.DefaultProviderRPS)), "Cannot setup AWS controllers")
+	kingpin.FatalIfError(controller.Setup(mgr, log, ratelimiter.NewDefaultProviderRateLimiter(ratelimiter.DefaultProviderRPS), *pollInterval), "Cannot setup AWS controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 
 }

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -36,8 +36,8 @@ func main() {
 	var (
 		app            = kingpin.New(filepath.Base(os.Args[0]), "AWS support for Crossplane.").DefaultEnvars()
 		debug          = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
-		syncPeriod     = app.Flag("sync", "Controller manager sync period duration such as 300ms, 1.5h or 2h45m").Short('s').Default("1h").Duration()
-		pollInterval   = app.Flag("poll-interval", "Default poll interval for all manage resource controllers.").Default("1m").Duration()
+		syncInterval   = app.Flag("sync", "Sync interval controls how often all resources will be double checked for drift.").Short('s').Default("1h").Duration()
+		pollInterval   = app.Flag("poll", "Poll interval controls how often an individual resource should be checked for drift.").Default("1m").Duration()
 		leaderElection = app.Flag("leader-election", "Use leader election for the conroller manager.").Short('l').Default("false").OverrideDefaultFromEnvar("LEADER_ELECTION").Bool()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
@@ -51,7 +51,7 @@ func main() {
 		ctrl.SetLogger(zl)
 	}
 
-	log.Debug("Starting", "sync-period", syncPeriod.String())
+	log.Debug("Starting", "sync-period", syncInterval.String())
 
 	cfg, err := ctrl.GetConfig()
 	kingpin.FatalIfError(err, "Cannot get API server rest config")
@@ -59,7 +59,7 @@ func main() {
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:   *leaderElection,
 		LeaderElectionID: "crossplane-leader-election-provider-aws",
-		SyncPeriod:       syncPeriod,
+		SyncPeriod:       syncInterval,
 	})
 	kingpin.FatalIfError(err, "Cannot create controller manager")
 

--- a/pkg/controller/acm/controller.go
+++ b/pkg/controller/acm/controller.go
@@ -18,6 +18,7 @@ package acm
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsacm "github.com/aws/aws-sdk-go-v2/service/acm"
@@ -59,7 +60,7 @@ const (
 )
 
 // SetupCertificate adds a controller that reconciles Certificates.
-func SetupCertificate(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupCertificate(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.CertificateGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -72,6 +73,7 @@ func SetupCertificate(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimit
 			resource.ManagedKind(v1alpha1.CertificateGroupVersionKind),
 			managed.WithExternalConnecter(&connector{client: mgr.GetClient(), newClientFn: acm.NewClient}),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithLogger(l.WithValues("controller", name)),

--- a/pkg/controller/acmpca/certificateauthority/controller.go
+++ b/pkg/controller/acmpca/certificateauthority/controller.go
@@ -18,6 +18,7 @@ package certificateauthority
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsacmpca "github.com/aws/aws-sdk-go-v2/service/acmpca"
@@ -57,7 +58,7 @@ const (
 )
 
 // SetupCertificateAuthority adds a controller that reconciles ACMPCA.
-func SetupCertificateAuthority(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupCertificateAuthority(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.CertificateAuthorityGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -70,6 +71,7 @@ func SetupCertificateAuthority(mgr ctrl.Manager, l logging.Logger, rl workqueue.
 			resource.ManagedKind(v1alpha1.CertificateAuthorityGroupVersionKind),
 			managed.WithExternalConnecter(&connector{client: mgr.GetClient(), newClientFn: acmpca.NewClient}),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 
 			// TODO: implement tag initializer
 

--- a/pkg/controller/acmpca/certificateauthoritypermission/controller.go
+++ b/pkg/controller/acmpca/certificateauthoritypermission/controller.go
@@ -19,6 +19,7 @@ package certificateauthoritypermission
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsacmpca "github.com/aws/aws-sdk-go-v2/service/acmpca"
@@ -49,7 +50,7 @@ const (
 )
 
 // SetupCertificateAuthorityPermission adds a controller that reconciles ACMPCA.
-func SetupCertificateAuthorityPermission(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupCertificateAuthorityPermission(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.CertificateAuthorityPermissionGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -62,6 +63,7 @@ func SetupCertificateAuthorityPermission(mgr ctrl.Manager, l logging.Logger, rl 
 			resource.ManagedKind(v1alpha1.CertificateAuthorityPermissionGroupVersionKind),
 			managed.WithExternalConnecter(&connector{client: mgr.GetClient(), newClientFn: acmpca.NewCAPermissionClient}),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithLogger(l.WithValues("controller", name)),

--- a/pkg/controller/apigatewayv2/api/setup.go
+++ b/pkg/controller/apigatewayv2/api/setup.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
 	"k8s.io/client-go/util/workqueue"
@@ -37,7 +38,7 @@ import (
 )
 
 // SetupAPI adds a controller that reconciles API.
-func SetupAPI(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupAPI(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.APIGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -57,6 +58,7 @@ func SetupAPI(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) erro
 			resource.ManagedKind(svcapitypes.APIGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/apigatewayv2/apimapping/setup.go
+++ b/pkg/controller/apigatewayv2/apimapping/setup.go
@@ -18,6 +18,7 @@ package apimapping
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
 	"k8s.io/client-go/util/workqueue"
@@ -37,7 +38,7 @@ import (
 )
 
 // SetupAPIMapping adds a controller that reconciles APIMapping.
-func SetupAPIMapping(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupAPIMapping(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.APIMappingGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -58,6 +59,7 @@ func SetupAPIMapping(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimite
 			resource.ManagedKind(svcapitypes.APIMappingGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/apigatewayv2/authorizer/setup.go
+++ b/pkg/controller/apigatewayv2/authorizer/setup.go
@@ -18,6 +18,7 @@ package authorizer
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
 	"k8s.io/client-go/util/workqueue"
@@ -37,7 +38,7 @@ import (
 )
 
 // SetupAuthorizer adds a controller that reconciles Authorizer.
-func SetupAuthorizer(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupAuthorizer(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.AuthorizerGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -58,6 +59,7 @@ func SetupAuthorizer(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimite
 			resource.ManagedKind(svcapitypes.AuthorizerGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/apigatewayv2/deployment/setup.go
+++ b/pkg/controller/apigatewayv2/deployment/setup.go
@@ -18,6 +18,7 @@ package deployment
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
 	"k8s.io/client-go/util/workqueue"
@@ -37,7 +38,7 @@ import (
 )
 
 // SetupDeployment adds a controller that reconciles Deployment.
-func SetupDeployment(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupDeployment(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.DeploymentGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -58,6 +59,7 @@ func SetupDeployment(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimite
 			resource.ManagedKind(svcapitypes.DeploymentGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/apigatewayv2/domainname/setup.go
+++ b/pkg/controller/apigatewayv2/domainname/setup.go
@@ -18,6 +18,7 @@ package domainname
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
 	"k8s.io/client-go/util/workqueue"
@@ -37,7 +38,7 @@ import (
 )
 
 // SetupDomainName adds a controller that reconciles DomainName.
-func SetupDomainName(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupDomainName(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.DomainNameGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -56,6 +57,7 @@ func SetupDomainName(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimite
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(svcapitypes.DomainNameGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/apigatewayv2/integration/setup.go
+++ b/pkg/controller/apigatewayv2/integration/setup.go
@@ -19,6 +19,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
 	"k8s.io/client-go/util/workqueue"
@@ -38,7 +39,7 @@ import (
 )
 
 // SetupIntegration adds a controller that reconciles Integration.
-func SetupIntegration(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupIntegration(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.IntegrationGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -59,6 +60,7 @@ func SetupIntegration(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimit
 			resource.ManagedKind(svcapitypes.IntegrationGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/apigatewayv2/integrationresponse/setup.go
+++ b/pkg/controller/apigatewayv2/integrationresponse/setup.go
@@ -18,6 +18,7 @@ package integrationresponse
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
 	"k8s.io/client-go/util/workqueue"
@@ -37,7 +38,7 @@ import (
 )
 
 // SetupIntegrationResponse adds a controller that reconciles IntegrationResponse.
-func SetupIntegrationResponse(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupIntegrationResponse(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.IntegrationResponseGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -58,6 +59,7 @@ func SetupIntegrationResponse(mgr ctrl.Manager, l logging.Logger, rl workqueue.R
 			resource.ManagedKind(svcapitypes.IntegrationResponseGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/apigatewayv2/model/setup.go
+++ b/pkg/controller/apigatewayv2/model/setup.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
 	"k8s.io/client-go/util/workqueue"
@@ -37,7 +38,7 @@ import (
 )
 
 // SetupModel adds a controller that reconciles Model.
-func SetupModel(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupModel(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.ModelGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -58,6 +59,7 @@ func SetupModel(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) er
 			resource.ManagedKind(svcapitypes.ModelGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/apigatewayv2/route/setup.go
+++ b/pkg/controller/apigatewayv2/route/setup.go
@@ -18,6 +18,7 @@ package route
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
 	"k8s.io/client-go/util/workqueue"
@@ -37,7 +38,7 @@ import (
 )
 
 // SetupRoute adds a controller that reconciles Route.
-func SetupRoute(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupRoute(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.RouteGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -58,6 +59,7 @@ func SetupRoute(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) er
 			resource.ManagedKind(svcapitypes.RouteGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/apigatewayv2/routeresponse/setup.go
+++ b/pkg/controller/apigatewayv2/routeresponse/setup.go
@@ -18,6 +18,7 @@ package routeresponse
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
 	"k8s.io/client-go/util/workqueue"
@@ -37,7 +38,7 @@ import (
 )
 
 // SetupRouteResponse adds a controller that reconciles RouteResponse.
-func SetupRouteResponse(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupRouteResponse(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.RouteResponseGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -58,6 +59,7 @@ func SetupRouteResponse(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLim
 			resource.ManagedKind(svcapitypes.RouteResponseGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/apigatewayv2/stage/setup.go
+++ b/pkg/controller/apigatewayv2/stage/setup.go
@@ -18,6 +18,7 @@ package stage
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
 	"k8s.io/client-go/util/workqueue"
@@ -37,7 +38,7 @@ import (
 )
 
 // SetupStage adds a controller that reconciles Stage.
-func SetupStage(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupStage(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.StageGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -56,6 +57,7 @@ func SetupStage(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) er
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(svcapitypes.StageGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/apigatewayv2/vpclink/setup.go
+++ b/pkg/controller/apigatewayv2/vpclink/setup.go
@@ -18,6 +18,7 @@ package vpclink
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
 	"k8s.io/client-go/util/workqueue"
@@ -37,7 +38,7 @@ import (
 )
 
 // SetupVPCLink adds a controller that reconciles VPCLink.
-func SetupVPCLink(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupVPCLink(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.VPCLinkGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -58,6 +59,7 @@ func SetupVPCLink(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) 
 			resource.ManagedKind(svcapitypes.VPCLinkGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/aws.go
+++ b/pkg/controller/aws.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"time"
+
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -99,8 +101,8 @@ import (
 
 // Setup creates all AWS controllers with the supplied logger and adds them to
 // the supplied manager.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
-	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter) error{
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
+	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter, time.Duration) error{
 		config.Setup,
 		cache.SetupReplicationGroup,
 		cachesubnetgroup.SetupCacheSubnetGroup,
@@ -175,7 +177,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 		resolverrule.SetupResolverRule,
 		kafkacluster.SetupCluster,
 	} {
-		if err := setup(mgr, l, rl); err != nil {
+		if err := setup(mgr, l, rl, poll); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/cache/cachesubnetgroup/controller.go
+++ b/pkg/controller/cache/cachesubnetgroup/controller.go
@@ -18,6 +18,7 @@ package cachesubnetgroup
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awscache "github.com/aws/aws-sdk-go-v2/service/elasticache"
@@ -50,7 +51,7 @@ const (
 )
 
 // SetupCacheSubnetGroup adds a controller that reconciles SubnetGroups.
-func SetupCacheSubnetGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupCacheSubnetGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.CacheSubnetGroupGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -63,6 +64,7 @@ func SetupCacheSubnetGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.Rate
 			resource.ManagedKind(v1alpha1.CacheSubnetGroupGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: elasticache.NewClient}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		))

--- a/pkg/controller/cache/cluster/controller.go
+++ b/pkg/controller/cache/cluster/controller.go
@@ -18,6 +18,7 @@ package cluster
 
 import (
 	"context"
+	"time"
 
 	"reflect"
 
@@ -53,7 +54,7 @@ const (
 )
 
 // SetupCacheCluster adds a controller that reconciles CacheCluster.
-func SetupCacheCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupCacheCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.CacheClusterGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -66,6 +67,7 @@ func SetupCacheCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimi
 			resource.ManagedKind(v1alpha1.CacheClusterGroupVersionKind),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: elasticache.NewClient}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		))

--- a/pkg/controller/cache/managed.go
+++ b/pkg/controller/cache/managed.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"reflect"
 	"sort"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	elasticacheservice "github.com/aws/aws-sdk-go-v2/service/elasticache"
@@ -56,7 +57,7 @@ const (
 )
 
 // SetupReplicationGroup adds a controller that reconciles ReplicationGroups.
-func SetupReplicationGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupReplicationGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.ReplicationGroupGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -70,6 +71,7 @@ func SetupReplicationGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.Rate
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: elasticache.NewClient}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient()), managed.NewNameAsExternalName(mgr.GetClient()), &tagger{kube: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		))

--- a/pkg/controller/cloudfront/distribution/setup.go
+++ b/pkg/controller/cloudfront/distribution/setup.go
@@ -19,6 +19,7 @@ package distribution
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -44,7 +45,7 @@ import (
 const stateDeployed = "Deployed"
 
 // SetupDistribution adds a controller that reconciles Distribution.
-func SetupDistribution(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupDistribution(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.DistributionGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -72,6 +73,7 @@ func SetupDistribution(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimi
 					},
 				},
 			}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"time"
+
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -33,7 +35,7 @@ import (
 
 // Setup adds a controller that reconciles ProviderConfigs by accounting for
 // their current usage.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := providerconfig.ControllerName(v1beta1.ProviderConfigGroupKind)
 
 	of := resource.ProviderConfigKinds{

--- a/pkg/controller/database/dbsubnetgroup/controller.go
+++ b/pkg/controller/database/dbsubnetgroup/controller.go
@@ -18,6 +18,7 @@ package dbsubnetgroup
 
 import (
 	"context"
+	"time"
 
 	"reflect"
 	"strings"
@@ -56,7 +57,7 @@ const (
 )
 
 // SetupDBSubnetGroup adds a controller that reconciles DBSubnetGroups.
-func SetupDBSubnetGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupDBSubnetGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.DBSubnetGroupGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -70,6 +71,7 @@ func SetupDBSubnetGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLim
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: dbsg.NewClient}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/database/rdsinstance.go
+++ b/pkg/controller/database/rdsinstance.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"reflect"
 	"sort"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
@@ -57,7 +58,7 @@ const (
 )
 
 // SetupRDSInstance adds a controller that reconciles RDSInstances.
-func SetupRDSInstance(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupRDSInstance(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.RDSInstanceGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -71,6 +72,7 @@ func SetupRDSInstance(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimit
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: rds.NewClient}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient()), managed.NewNameAsExternalName(mgr.GetClient()), &tagger{kube: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/dynamodb/backup/hooks.go
+++ b/pkg/controller/dynamodb/backup/hooks.go
@@ -18,6 +18,7 @@ package backup
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/dynamodb"
 	"k8s.io/client-go/util/workqueue"
@@ -37,7 +38,7 @@ import (
 )
 
 // SetupBackup adds a controller that reconciles Backup.
-func SetupBackup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupBackup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.BackupGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -58,6 +59,7 @@ func SetupBackup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) e
 			resource.ManagedKind(svcapitypes.BackupGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/dynamodb/globaltable/hooks.go
+++ b/pkg/controller/dynamodb/globaltable/hooks.go
@@ -19,6 +19,7 @@ package globaltable
 import (
 	"context"
 	"sort"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/dynamodb"
 	svcsdkapi "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
@@ -41,7 +42,7 @@ import (
 )
 
 // SetupGlobalTable adds a controller that reconciles GlobalTable.
-func SetupGlobalTable(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupGlobalTable(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.GlobalTableGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -64,6 +65,7 @@ func SetupGlobalTable(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimit
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(svcapitypes.GlobalTableGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/dynamodb/table/hooks.go
+++ b/pkg/controller/dynamodb/table/hooks.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"sort"
+	"time"
 
 	awsgo "github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/dynamodb"
@@ -45,7 +46,7 @@ import (
 )
 
 // SetupTable adds a controller that reconciles Table.
-func SetupTable(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupTable(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.TableGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -72,6 +73,7 @@ func SetupTable(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) er
 				managed.NewNameAsExternalName(mgr.GetClient()),
 				managed.NewDefaultProviderConfig(mgr.GetClient()),
 				&tagger{kube: mgr.GetClient()}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/ec2/address/controller.go
+++ b/pkg/controller/ec2/address/controller.go
@@ -19,6 +19,7 @@ package address
 import (
 	"context"
 	"sort"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -55,7 +56,7 @@ const (
 )
 
 // SetupAddress adds a controller that reconciles Address.
-func SetupAddress(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupAddress(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.AddressGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -69,6 +70,7 @@ func SetupAddress(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) 
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient()), &tagger{kube: mgr.GetClient()}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/ec2/internetgateway/controller.go
+++ b/pkg/controller/ec2/internetgateway/controller.go
@@ -18,6 +18,7 @@ package internetgateway
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -55,7 +56,7 @@ const (
 )
 
 // SetupInternetGateway adds a controller that reconciles InternetGateways.
-func SetupInternetGateway(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupInternetGateway(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.InternetGatewayGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -70,6 +71,7 @@ func SetupInternetGateway(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateL
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/ec2/natgateway/controller.go
+++ b/pkg/controller/ec2/natgateway/controller.go
@@ -2,6 +2,7 @@ package natgateway
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -35,7 +36,7 @@ const (
 )
 
 // SetupNatGateway adds a controller that reconciles NatGateways.
-func SetupNatGateway(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupNatGateway(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.NATGatewayGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -50,6 +51,7 @@ func SetupNatGateway(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimite
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/ec2/routetable/controller.go
+++ b/pkg/controller/ec2/routetable/controller.go
@@ -18,6 +18,7 @@ package routetable
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -59,7 +60,7 @@ const (
 )
 
 // SetupRouteTable adds a controller that reconciles RouteTables.
-func SetupRouteTable(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupRouteTable(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.RouteTableGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -74,6 +75,7 @@ func SetupRouteTable(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimite
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/ec2/securitygroup/controller.go
+++ b/pkg/controller/ec2/securitygroup/controller.go
@@ -18,6 +18,7 @@ package securitygroup
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -61,7 +62,7 @@ const (
 )
 
 // SetupSecurityGroup adds a controller that reconciles SecurityGroups.
-func SetupSecurityGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupSecurityGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.SecurityGroupGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -76,6 +77,7 @@ func SetupSecurityGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLim
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/ec2/subnet/controller.go
+++ b/pkg/controller/ec2/subnet/controller.go
@@ -18,6 +18,7 @@ package subnet
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -53,7 +54,7 @@ const (
 )
 
 // SetupSubnet adds a controller that reconciles Subnets.
-func SetupSubnet(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupSubnet(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.SubnetGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -67,6 +68,7 @@ func SetupSubnet(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) e
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/ec2/vpc/controller.go
+++ b/pkg/controller/ec2/vpc/controller.go
@@ -19,6 +19,7 @@ package vpc
 import (
 	"context"
 	"sort"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -56,7 +57,7 @@ const (
 )
 
 // SetupVPC adds a controller that reconciles VPCs.
-func SetupVPC(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupVPC(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.VPCGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -70,6 +71,7 @@ func SetupVPC(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) erro
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient()), &tagger{kube: mgr.GetClient()}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/ec2/vpccidrblock/controller.go
+++ b/pkg/controller/ec2/vpccidrblock/controller.go
@@ -18,6 +18,7 @@ package vpccidrblock
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -49,7 +50,7 @@ const (
 )
 
 // SetupVPCCIDRBlock adds a controller that reconciles VPCCIDRBlocks.
-func SetupVPCCIDRBlock(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupVPCCIDRBlock(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.VPCCIDRBlockGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -63,6 +64,7 @@ func SetupVPCCIDRBlock(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimi
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/ecr/repository/controller.go
+++ b/pkg/controller/ecr/repository/controller.go
@@ -19,6 +19,7 @@ package repository
 import (
 	"context"
 	"sort"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsecr "github.com/aws/aws-sdk-go-v2/service/ecr"
@@ -61,7 +62,7 @@ const (
 )
 
 // SetupRepository adds a controller that reconciles ECR.
-func SetupRepository(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupRepository(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.RepositoryGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -75,6 +76,7 @@ func SetupRepository(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimite
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient()), managed.NewNameAsExternalName(mgr.GetClient()), &tagger{kube: mgr.GetClient()}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/ecr/repositorypolicy/controller.go
+++ b/pkg/controller/ecr/repositorypolicy/controller.go
@@ -18,6 +18,7 @@ package repositorypolicy
 
 import (
 	"context"
+	"time"
 
 	awsecr "github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/google/go-cmp/cmp"
@@ -49,7 +50,7 @@ const (
 )
 
 // SetupRepositoryPolicy adds a controller that reconciles ECR.
-func SetupRepositoryPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupRepositoryPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.RepositoryPolicyGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -61,6 +62,7 @@ func SetupRepositoryPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.Rate
 			resource.ManagedKind(v1alpha1.RepositoryPolicyGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/eks/cluster.go
+++ b/pkg/controller/eks/cluster.go
@@ -19,6 +19,7 @@ package eks
 import (
 	"context"
 	"reflect"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
@@ -56,7 +57,7 @@ const (
 )
 
 // SetupCluster adds a controller that reconciles Clusters.
-func SetupCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.ClusterGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -70,6 +71,7 @@ func SetupCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) 
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: eks.NewEKSClient, newSTSClientFn: eks.NewSTSClient}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient()), managed.NewNameAsExternalName(mgr.GetClient()), &tagger{kube: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/eks/fargateprofile/controller.go
+++ b/pkg/controller/eks/fargateprofile/controller.go
@@ -18,6 +18,7 @@ package fargateprofile
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
@@ -51,7 +52,7 @@ const (
 )
 
 // SetupFargateProfile adds a controller that reconciles FargateProfiles.
-func SetupFargateProfile(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupFargateProfile(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.FargateProfileKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -65,6 +66,7 @@ func SetupFargateProfile(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLi
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newEKSClientFn: eks.NewEKSClient}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient()), managed.NewNameAsExternalName(mgr.GetClient()), &tagger{kube: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/eks/nodegroup/controller.go
+++ b/pkg/controller/eks/nodegroup/controller.go
@@ -19,6 +19,7 @@ package nodegroup
 import (
 	"context"
 	"reflect"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
@@ -54,7 +55,7 @@ const (
 )
 
 // SetupNodeGroup adds a controller that reconciles NodeGroups.
-func SetupNodeGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupNodeGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.NodeGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -68,6 +69,7 @@ func SetupNodeGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newEKSClientFn: eks.NewEKSClient}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient()), managed.NewNameAsExternalName(mgr.GetClient()), &tagger{kube: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/elasticloadbalancing/elb/controller.go
+++ b/pkg/controller/elasticloadbalancing/elb/controller.go
@@ -18,6 +18,7 @@ package elb
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awselb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing"
@@ -55,7 +56,7 @@ const (
 )
 
 // SetupELB adds a controller that reconciles ELBs.
-func SetupELB(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupELB(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.ELBGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -68,6 +69,7 @@ func SetupELB(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) erro
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: elb.NewClient}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/elasticloadbalancing/elbattachment/controller.go
+++ b/pkg/controller/elasticloadbalancing/elbattachment/controller.go
@@ -18,6 +18,7 @@ package elbattachment
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awselb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing"
@@ -50,7 +51,7 @@ const (
 )
 
 // SetupELBAttachment adds a controller that reconciles ELBAttachmets.
-func SetupELBAttachment(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupELBAttachment(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.ELBAttachmentGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -63,6 +64,7 @@ func SetupELBAttachment(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLim
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: elb.NewClient}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/identity/iamaccesskey/controller.go
+++ b/pkg/controller/identity/iamaccesskey/controller.go
@@ -18,6 +18,7 @@ package iamaccesskey
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
@@ -49,7 +50,7 @@ const (
 )
 
 // SetupIAMAccessKey adds a controller that reconciles IAMAccessKeys.
-func SetupIAMAccessKey(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupIAMAccessKey(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.IAMAccessKeyGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -62,6 +63,7 @@ func SetupIAMAccessKey(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimi
 			resource.ManagedKind(v1alpha1.IAMAccessKeyGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: iam.NewAccessClient}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/identity/iamgroup/controller.go
+++ b/pkg/controller/identity/iamgroup/controller.go
@@ -18,6 +18,7 @@ package iamgroup
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
@@ -52,7 +53,7 @@ const (
 )
 
 // SetupIAMGroup adds a controller that reconciles Groups.
-func SetupIAMGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupIAMGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.IAMGroupGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -65,6 +66,7 @@ func SetupIAMGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter)
 			resource.ManagedKind(v1alpha1.IAMGroupGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: iam.NewGroupClient}),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/identity/iamgrouppolicyattachment/controller.go
+++ b/pkg/controller/identity/iamgrouppolicyattachment/controller.go
@@ -19,6 +19,7 @@ package iamgrouppolicyattachment
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
@@ -51,7 +52,7 @@ const (
 
 // SetupIAMGroupPolicyAttachment adds a controller that reconciles
 // IAMGroupPolicyAttachments.
-func SetupIAMGroupPolicyAttachment(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupIAMGroupPolicyAttachment(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.IAMGroupPolicyAttachmentGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -66,6 +67,7 @@ func SetupIAMGroupPolicyAttachment(mgr ctrl.Manager, l logging.Logger, rl workqu
 			managed.WithConnectionPublishers(),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/identity/iamgroupusermembership/controller.go
+++ b/pkg/controller/identity/iamgroupusermembership/controller.go
@@ -19,6 +19,7 @@ package iamgroupusermembership
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
@@ -51,7 +52,7 @@ const (
 
 // SetupIAMGroupUserMembership adds a controller that reconciles
 // IAMGroupUserMemberships.
-func SetupIAMGroupUserMembership(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupIAMGroupUserMembership(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.IAMGroupUserMembershipGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -66,6 +67,7 @@ func SetupIAMGroupUserMembership(mgr ctrl.Manager, l logging.Logger, rl workqueu
 			managed.WithConnectionPublishers(),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/identity/iampolicy/controller.go
+++ b/pkg/controller/identity/iampolicy/controller.go
@@ -18,6 +18,7 @@ package iampolicy
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
@@ -53,7 +54,7 @@ const (
 )
 
 // SetupIAMPolicy adds a controller that reconciles IAM Policy.
-func SetupIAMPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupIAMPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.IAMPolicyGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -67,6 +68,7 @@ func SetupIAMPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: iam.NewPolicyClient}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/identity/iamrole/controller.go
+++ b/pkg/controller/identity/iamrole/controller.go
@@ -18,6 +18,7 @@ package iamrole
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
@@ -55,7 +56,7 @@ const (
 )
 
 // SetupIAMRole adds a controller that reconciles IAMRoles.
-func SetupIAMRole(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupIAMRole(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.IAMRoleGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -69,6 +70,7 @@ func SetupIAMRole(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) 
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: iam.NewRoleClient}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/identity/iamrolepolicyattachment/controller.go
+++ b/pkg/controller/identity/iamrolepolicyattachment/controller.go
@@ -18,6 +18,7 @@ package iamrolepolicyattachment
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
@@ -51,7 +52,7 @@ const (
 
 // SetupIAMRolePolicyAttachment adds a controller that reconciles
 // IAMRolePolicyAttachments.
-func SetupIAMRolePolicyAttachment(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupIAMRolePolicyAttachment(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.IAMRolePolicyAttachmentGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -65,6 +66,7 @@ func SetupIAMRolePolicyAttachment(mgr ctrl.Manager, l logging.Logger, rl workque
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: iam.NewRolePolicyAttachmentClient}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/identity/iamuser/controller.go
+++ b/pkg/controller/identity/iamuser/controller.go
@@ -18,6 +18,7 @@ package iamuser
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
@@ -54,7 +55,7 @@ const (
 )
 
 // SetupIAMUser adds a controller that reconciles Users.
-func SetupIAMUser(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupIAMUser(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.IAMUserGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -67,6 +68,7 @@ func SetupIAMUser(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) 
 			resource.ManagedKind(v1alpha1.IAMUserGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: iam.NewUserClient}),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/identity/iamuserpolicyattachment/controller.go
+++ b/pkg/controller/identity/iamuserpolicyattachment/controller.go
@@ -18,6 +18,7 @@ package iamuserpolicyattachment
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
@@ -52,7 +53,7 @@ const (
 
 // SetupIAMUserPolicyAttachment adds a controller that reconciles
 // IAMUserPolicyAttachments.
-func SetupIAMUserPolicyAttachment(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupIAMUserPolicyAttachment(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.IAMUserPolicyAttachmentGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -66,6 +67,7 @@ func SetupIAMUserPolicyAttachment(mgr ctrl.Manager, l logging.Logger, rl workque
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: iam.NewUserPolicyAttachmentClient}),
 			managed.WithConnectionPublishers(),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/identity/openidconnectprovider/controller.go
+++ b/pkg/controller/identity/openidconnectprovider/controller.go
@@ -18,6 +18,7 @@ package openidconnectprovider
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
@@ -56,7 +57,7 @@ const (
 )
 
 // SetupOpenIDConnectProvider adds a controller that reconciles OpenIDConnectProvider.
-func SetupOpenIDConnectProvider(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupOpenIDConnectProvider(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.OpenIDConnectProviderGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -68,6 +69,7 @@ func SetupOpenIDConnectProvider(mgr ctrl.Manager, l logging.Logger, rl workqueue
 			resource.ManagedKind(svcapitypes.OpenIDConnectProviderGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: iam.NewOpenIDConnectProviderClient}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/kafka/cluster/setup.go
+++ b/pkg/controller/kafka/cluster/setup.go
@@ -16,6 +16,7 @@ package cluster
 import (
 	"context"
 	"strings"
+	"time"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"k8s.io/client-go/util/workqueue"
@@ -35,7 +36,7 @@ import (
 )
 
 // SetupCluster adds a controller that reconciles Cluster.
-func SetupCluster(mgr ctrl.Manager, l logging.Logger, limiter workqueue.RateLimiter) error {
+func SetupCluster(mgr ctrl.Manager, l logging.Logger, limiter workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.ClusterGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -57,6 +58,7 @@ func SetupCluster(mgr ctrl.Manager, l logging.Logger, limiter workqueue.RateLimi
 			resource.ManagedKind(svcapitypes.ClusterGroupVersionKind),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/kms/key/setup.go
+++ b/pkg/controller/kms/key/setup.go
@@ -2,6 +2,7 @@ package key
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/kms"
 	svcsdkapi "github.com/aws/aws-sdk-go/service/kms/kmsiface"
@@ -23,7 +24,7 @@ import (
 )
 
 // SetupKey adds a controller that reconciles Key.
-func SetupKey(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupKey(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.KeyGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -48,6 +49,7 @@ func SetupKey(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) erro
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(svcapitypes.KeyGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/lambda/function/setup.go
+++ b/pkg/controller/lambda/function/setup.go
@@ -2,6 +2,7 @@ package function
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/lambda"
 	svcsdkapi "github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
@@ -26,7 +27,7 @@ import (
 )
 
 // SetupFunction adds a controller that reconciles Function.
-func SetupFunction(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupFunction(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.FunctionGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -49,6 +50,7 @@ func SetupFunction(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter)
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.FunctionGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/notification/snssubscription/controller.go
+++ b/pkg/controller/notification/snssubscription/controller.go
@@ -19,6 +19,7 @@ package snssubscription
 import (
 	"context"
 	"reflect"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
@@ -51,7 +52,7 @@ const (
 )
 
 // SetupSubscription adds a controller than reconciles SNSSubscription
-func SetupSubscription(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupSubscription(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.SNSSubscriptionGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -66,6 +67,7 @@ func SetupSubscription(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimi
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/notification/snstopic/controller.go
+++ b/pkg/controller/notification/snstopic/controller.go
@@ -19,6 +19,7 @@ package snstopic
 import (
 	"context"
 	"reflect"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
@@ -51,7 +52,7 @@ const (
 )
 
 // SetupSNSTopic adds a controller that reconciles SNSTopic.
-func SetupSNSTopic(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupSNSTopic(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.SNSTopicGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -66,6 +67,7 @@ func SetupSNSTopic(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter)
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/rds/dbcluster/setup.go
+++ b/pkg/controller/rds/dbcluster/setup.go
@@ -2,6 +2,7 @@ package dbcluster
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/rds"
 	svcsdkapi "github.com/aws/aws-sdk-go/service/rds/rdsiface"
@@ -25,7 +26,7 @@ import (
 )
 
 // SetupDBCluster adds a controller that reconciles DbCluster.
-func SetupDBCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupDBCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.DBClusterGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -47,6 +48,7 @@ func SetupDBCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(svcapitypes.DBClusterGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/rds/dbparametergroup/setup.go
+++ b/pkg/controller/rds/dbparametergroup/setup.go
@@ -2,6 +2,7 @@ package dbparametergroup
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/rds"
 	svcsdkapi "github.com/aws/aws-sdk-go/service/rds/rdsiface"
@@ -24,7 +25,7 @@ import (
 )
 
 // SetupDBParameterGroup adds a controller that reconciles DBParametergroup.
-func SetupDBParameterGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupDBParameterGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.DBParameterGroupGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -46,6 +47,7 @@ func SetupDBParameterGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.Rate
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(svcapitypes.DBParameterGroupGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/rds/globalcluster/setup.go
+++ b/pkg/controller/rds/globalcluster/setup.go
@@ -2,6 +2,7 @@ package globalcluster
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/rds"
 	"k8s.io/client-go/util/workqueue"
@@ -21,7 +22,7 @@ import (
 )
 
 // SetupGlobalCluster adds a controller that reconciles GlobalCluster.
-func SetupGlobalCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupGlobalCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.GlobalClusterGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -41,6 +42,7 @@ func SetupGlobalCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLim
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(svcapitypes.GlobalClusterGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/redshift/controller.go
+++ b/pkg/controller/redshift/controller.go
@@ -19,6 +19,7 @@ package redshift
 import (
 	"context"
 	"reflect"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsredshift "github.com/aws/aws-sdk-go-v2/service/redshift"
@@ -54,7 +55,7 @@ const (
 )
 
 // SetupCluster adds a controller that reconciles Redshift clusters.
-func SetupCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.ClusterGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -66,6 +67,7 @@ func SetupCluster(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) 
 			mgr, resource.ManagedKind(v1alpha1.ClusterGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: redshift.NewClient}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/route53/hostedzone/controller.go
+++ b/pkg/controller/route53/hostedzone/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
@@ -53,7 +54,7 @@ const (
 )
 
 // SetupHostedZone adds a controller that reconciles Hosted Zones.
-func SetupHostedZone(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupHostedZone(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.HostedZoneGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -67,6 +68,7 @@ func SetupHostedZone(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimite
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))),
 		)

--- a/pkg/controller/route53/resourcerecordset/controller.go
+++ b/pkg/controller/route53/resourcerecordset/controller.go
@@ -18,6 +18,7 @@ package resourcerecordset
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
@@ -52,7 +53,7 @@ const (
 )
 
 // SetupResourceRecordSet adds a controller that reconciles ResourceRecordSets.
-func SetupResourceRecordSet(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupResourceRecordSet(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.ResourceRecordSetGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -65,6 +66,7 @@ func SetupResourceRecordSet(mgr ctrl.Manager, l logging.Logger, rl workqueue.Rat
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: resourcerecordset.NewClient}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/route53resolver/resolverendpoint/hooks.go
+++ b/pkg/controller/route53resolver/resolverendpoint/hooks.go
@@ -2,6 +2,7 @@ package resolverendpoint
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/route53resolver"
@@ -22,7 +23,7 @@ import (
 )
 
 // SetupResolverEndpoint adds a controller that reconciles ResolverEndpoints
-func SetupResolverEndpoint(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupResolverEndpoint(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.ResolverEndpointGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -43,6 +44,7 @@ func SetupResolverEndpoint(mgr ctrl.Manager, l logging.Logger, rl workqueue.Rate
 			cpresource.ManagedKind(v1alpha1.ResolverEndpointGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/route53resolver/resolverrule/hooks.go
+++ b/pkg/controller/route53resolver/resolverrule/hooks.go
@@ -2,6 +2,7 @@ package resolverrule
 
 import (
 	"context"
+	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -22,7 +23,7 @@ import (
 )
 
 // SetupResolverRule adds a controller that reconciles ResolverRule
-func SetupResolverRule(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupResolverRule(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha1.ResolverRuleGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -43,6 +44,7 @@ func SetupResolverRule(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimi
 			cpresource.ManagedKind(v1alpha1.ResolverRuleGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/s3/bucket.go
+++ b/pkg/controller/s3/bucket.go
@@ -18,6 +18,7 @@ package s3
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
@@ -53,7 +54,7 @@ const (
 )
 
 // SetupBucket adds a controller that reconciles Buckets.
-func SetupBucket(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupBucket(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.BucketGroupKind)
 	logger := l.WithValues("controller", name)
 	return ctrl.NewControllerManagedBy(mgr).
@@ -66,6 +67,7 @@ func SetupBucket(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) e
 			resource.ManagedKind(v1beta1.BucketGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: s3.NewClient, logger: logger}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(logger),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/s3/bucketpolicy/bucketpolicy.go
+++ b/pkg/controller/s3/bucketpolicy/bucketpolicy.go
@@ -19,6 +19,7 @@ package bucketpolicy
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
@@ -52,7 +53,7 @@ const (
 
 // SetupBucketPolicy adds a controller that reconciles
 // BucketPolicies.
-func SetupBucketPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupBucketPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1alpha3.BucketPolicyGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -66,6 +67,7 @@ func SetupBucketPolicy(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimi
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(),
 				newClientFn: s3.NewBucketPolicyClient}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/secretsmanager/secret/setup.go
+++ b/pkg/controller/secretsmanager/secret/setup.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
@@ -53,7 +54,7 @@ const (
 )
 
 // SetupSecret adds a controller that reconciles a Secret.
-func SetupSecret(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupSecret(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.SecretGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -78,6 +79,7 @@ func SetupSecret(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) e
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient()), managed.NewNameAsExternalName(mgr.GetClient()), &tagger{kube: mgr.GetClient()}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/servicediscovery/httpnamespace/setup.go
+++ b/pkg/controller/servicediscovery/httpnamespace/setup.go
@@ -18,6 +18,7 @@ package httpnamespace
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/servicediscovery"
 	"k8s.io/client-go/util/workqueue"
@@ -36,7 +37,7 @@ import (
 )
 
 // SetupHTTPNamespace adds a controller that reconciles HTTPNamespace.
-func SetupHTTPNamespace(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupHTTPNamespace(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.HTTPNamespaceGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -56,6 +57,7 @@ func SetupHTTPNamespace(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLim
 			resource.ManagedKind(svcapitypes.HTTPNamespaceGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/servicediscovery/privatednsnamespace/setup.go
+++ b/pkg/controller/servicediscovery/privatednsnamespace/setup.go
@@ -18,6 +18,7 @@ package privatednsnamespace
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/servicediscovery"
 	"k8s.io/client-go/util/workqueue"
@@ -36,7 +37,7 @@ import (
 )
 
 // SetupPrivateDNSNamespace adds a controller that reconciles PrivateDNSNamespaces.
-func SetupPrivateDNSNamespace(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupPrivateDNSNamespace(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.PrivateDNSNamespaceGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -57,6 +58,7 @@ func SetupPrivateDNSNamespace(mgr ctrl.Manager, l logging.Logger, rl workqueue.R
 			resource.ManagedKind(svcapitypes.PrivateDNSNamespaceGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/servicediscovery/publicdnsnamespace/setup.go
+++ b/pkg/controller/servicediscovery/publicdnsnamespace/setup.go
@@ -18,6 +18,7 @@ package publicdnsnamespace
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/servicediscovery"
 	"k8s.io/client-go/util/workqueue"
@@ -36,7 +37,7 @@ import (
 )
 
 // SetupPublicDNSNamespace adds a controller that reconciles PublicDNSNamespaces.
-func SetupPublicDNSNamespace(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupPublicDNSNamespace(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.PublicDNSNamespaceGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -56,6 +57,7 @@ func SetupPublicDNSNamespace(mgr ctrl.Manager, l logging.Logger, rl workqueue.Ra
 			resource.ManagedKind(svcapitypes.PublicDNSNamespaceGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/sfn/activity/hooks.go
+++ b/pkg/controller/sfn/activity/hooks.go
@@ -18,6 +18,7 @@ package activity
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/sfn"
 	"k8s.io/client-go/util/workqueue"
@@ -37,7 +38,7 @@ import (
 )
 
 // SetupActivity adds a controller that reconciles Activity.
-func SetupActivity(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupActivity(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.ActivityGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -57,6 +58,7 @@ func SetupActivity(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter)
 			resource.ManagedKind(svcapitypes.ActivityGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/sfn/statemachine/hooks.go
+++ b/pkg/controller/sfn/statemachine/hooks.go
@@ -18,6 +18,7 @@ package statemachine
 
 import (
 	"context"
+	"time"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/sfn"
 	"k8s.io/client-go/util/workqueue"
@@ -37,7 +38,7 @@ import (
 )
 
 // SetupStateMachine adds a controller that reconciles StateMachine.
-func SetupStateMachine(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupStateMachine(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(svcapitypes.StateMachineGroupKind)
 	opts := []option{
 		func(e *external) {
@@ -58,6 +59,7 @@ func SetupStateMachine(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimi
 			resource.ManagedKind(svcapitypes.StateMachineGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/pkg/controller/sqs/queue/controller.go
+++ b/pkg/controller/sqs/queue/controller.go
@@ -18,6 +18,7 @@ package queue
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/google/go-cmp/cmp"
@@ -54,7 +55,7 @@ const (
 )
 
 // SetupQueue adds a controller that reconciles Queue.
-func SetupQueue(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
+func SetupQueue(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
 	name := managed.ControllerName(v1beta1.QueueGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -66,6 +67,7 @@ func SetupQueue(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) er
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.QueueGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: sqs.NewClient}),
+			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds a `--poll-interval` flag to provider, which is passed to all controllers to set their polling interval in the reconciliation happy path.

*Note to reviewers: these changes are almost entirely find and replace.*

xref https://github.com/crossplane/crossplane-runtime/issues/253

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I ran this build of `provider-aws` with `-d` and `--poll-interval 10m` and observed the following logs and metrics using the process described in https://danielmangum.com/posts/controller-runtime-scrape-prometheus-local/.

![buckets2](https://user-images.githubusercontent.com/31777345/123339213-26187300-d518-11eb-96ef-c7abc92c04d4.png)


```
2021-06-24T17:44:04.420-0400	DEBUG	provider-aws	Reconciling	{"controller": "managed/bucket.s3.aws.crossplane.io", "request": "/test-bucket"}
2021-06-24T17:44:05.519-0400	DEBUG	provider-aws	External resource is up to date	{"controller": "managed/bucket.s3.aws.crossplane.io", "request": "/test-bucket", "uid": "d2f1e730-41e2-4627-bd84-5f23130f8de5", "version": "1167", "external-name": "blah-crossplane-example-bucket", "requeue-after": "2021-06-24T17:54:05.519-0400"}
2021-06-24T17:44:05.524-0400	DEBUG	provider-aws	Reconciling	{"controller": "managed/bucket.s3.aws.crossplane.io", "request": "/test-bucket"}
2021-06-24T17:44:06.747-0400	DEBUG	provider-aws	External resource is up to date	{"controller": "managed/bucket.s3.aws.crossplane.io", "request": "/test-bucket", "uid": "d2f1e730-41e2-4627-bd84-5f23130f8de5", "version": "1167", "external-name": "blah-crossplane-example-bucket", "requeue-after": "2021-06-24T17:54:06.747-0400"}
2021-06-24T17:54:05.525-0400	DEBUG	provider-aws	Reconciling	{"controller": "managed/bucket.s3.aws.crossplane.io", "request": "/test-bucket"}
2021-06-24T17:54:06.566-0400	DEBUG	provider-aws	External resource is up to date	{"controller": "managed/bucket.s3.aws.crossplane.io", "request": "/test-bucket", "uid": "d2f1e730-41e2-4627-bd84-5f23130f8de5", "version": "1167", "external-name": "blah-crossplane-example-bucket", "requeue-after": "2021-06-24T18:04:06.566-0400"}
2021-06-24T18:04:06.583-0400	DEBUG	provider-aws	Reconciling	{"controller": "managed/bucket.s3.aws.crossplane.io", "request": "/test-bucket"}
2021-06-24T18:04:07.589-0400	DEBUG	provider-aws	External resource is up to date	{"controller": "managed/bucket.s3.aws.crossplane.io", "request": "/test-bucket", "uid": "d2f1e730-41e2-4627-bd84-5f23130f8de5", "version": "1167", "external-name": "blah-crossplane-example-bucket", "requeue-after": "2021-06-24T18:14:07.589-0400"}
```

[contribution process]: https://git.io/fj2m9
