### PR TITLE
database.rdsinstance: show pending EngineVersion

### DIFF
--- a/pkg/clients/rds/rds.go
+++ b/pkg/clients/rds/rds.go
@@ -318,6 +318,7 @@ func GenerateObservation(db rds.DBInstance) v1beta1.RDSInstanceObservation { // 
 			CACertificateIdentifier: aws.StringValue(db.PendingModifiedValues.CACertificateIdentifier),
 			DBInstanceClass:         aws.StringValue(db.PendingModifiedValues.DBInstanceClass),
 			DBSubnetGroupName:       aws.StringValue(db.PendingModifiedValues.DBSubnetGroupName),
+			EngineVersion:           aws.StringValue(db.PendingModifiedValues.EngineVersion),
 			IOPS:                    int(aws.Int64Value(db.PendingModifiedValues.Iops)),
 			LicenseModel:            aws.StringValue(db.PendingModifiedValues.LicenseModel),
 			MultiAZ:                 aws.BoolValue(db.PendingModifiedValues.MultiAZ),


### PR DESCRIPTION
### Description of your changes
When a version upgrade is pending, this was excluded (presumably by accident) from the status of RDSInstance.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Deploy PG 13.1
Upgrade to 13.2
Verified the status during upgrade

[contribution process]: https://git.io/fj2m9
