### PR TITLE
s3: resolve bucket ARN in replication config references

### DIFF
--- a/apis/s3/v1beta1/referencers.go
+++ b/apis/s3/v1beta1/referencers.go
@@ -40,6 +40,28 @@ func SNSTopicARN() reference.ExtractValueFn {
 	}
 }
 
+// BucketARN returns a function that returns the ARN of the given S3 Bucket
+func BucketARN() reference.ExtractValueFn {
+	return func(mg resource.Managed) string {
+		r, ok := mg.(*Bucket)
+		if !ok {
+			return ""
+		}
+		return r.Status.AtProvider.ARN
+	}
+}
+
+// BucketARN2 Why not like this? :shrug:
+func BucketARN2(mg resource.Managed) string {
+	r, ok := mg.(*Bucket)
+	if !ok {
+		return ""
+	}
+	return r.Status.AtProvider.ARN
+}
+
+var _ reference.ExtractValueFn = BucketARN2
+
 // ResolveReferences of this Bucket
 func (mg *Bucket) ResolveReferences(ctx context.Context, c client.Reader) error { // nolint:gocyclo
 	r := reference.NewAPIResolver(c, mg)
@@ -103,7 +125,7 @@ func (mg *Bucket) ResolveReferences(ctx context.Context, c client.Reader) error 
 				Reference:    v.Destination.BucketRef,
 				Selector:     v.Destination.BucketSelector,
 				To:           reference.To{Managed: &Bucket{}, List: &BucketList{}},
-				Extract:      reference.ExternalName(),
+				Extract:      BucketARN2,
 			})
 			if err != nil {
 				return errors.Wrapf(err, "spec.forProvider.replicationConfiguration.rules[%d].bucket", i)

--- a/apis/s3/v1beta1/referencers.go
+++ b/apis/s3/v1beta1/referencers.go
@@ -51,17 +51,6 @@ func BucketARN() reference.ExtractValueFn {
 	}
 }
 
-// BucketARN2 Why not like this? :shrug:
-func BucketARN2(mg resource.Managed) string {
-	r, ok := mg.(*Bucket)
-	if !ok {
-		return ""
-	}
-	return r.Status.AtProvider.ARN
-}
-
-var _ reference.ExtractValueFn = BucketARN2
-
 // ResolveReferences of this Bucket
 func (mg *Bucket) ResolveReferences(ctx context.Context, c client.Reader) error { // nolint:gocyclo
 	r := reference.NewAPIResolver(c, mg)
@@ -125,7 +114,7 @@ func (mg *Bucket) ResolveReferences(ctx context.Context, c client.Reader) error 
 				Reference:    v.Destination.BucketRef,
 				Selector:     v.Destination.BucketSelector,
 				To:           reference.To{Managed: &Bucket{}, List: &BucketList{}},
-				Extract:      BucketARN2,
+				Extract:      BucketARN(),
 			})
 			if err != nil {
 				return errors.Wrapf(err, "spec.forProvider.replicationConfiguration.rules[%d].bucket", i)

--- a/apis/s3/v1beta1/replicationConfiguration_types.go
+++ b/apis/s3/v1beta1/replicationConfiguration_types.go
@@ -126,7 +126,7 @@ type DeleteMarkerReplication struct {
 	// In the current implementation, Amazon S3 doesn't replicate the delete markers.
 	// The status must be "Disabled".
 	// +kubebuilder:validation:Enum=Disabled
-	Status string `json:"Status"`
+	Status string `json:"status"`
 }
 
 // Destination specifies information about where to publish analysis or configuration results

--- a/examples/iam/role.yaml
+++ b/examples/iam/role.yaml
@@ -16,7 +16,8 @@ spec:
                         "ec2.amazonaws.com",
                         "eks.amazonaws.com",
                         "eks-fargate-pods.amazonaws.com",
-                        "lambda.amazonaws.com"
+                        "lambda.amazonaws.com",
+                        "s3.amazonaws.com"
                     ]
                 },
                 "Action": [

--- a/examples/iam/rolepolicyattachment.yaml
+++ b/examples/iam/rolepolicyattachment.yaml
@@ -16,6 +16,19 @@ spec:
 apiVersion: identity.aws.crossplane.io/v1beta1
 kind: IAMRolePolicyAttachment
 metadata:
+  name: sample-s3-replication-policy
+spec:
+  forProvider:
+    policyArn: arn:aws:iam::aws:policy/AmazonS3FullAccess
+    roleNameRef:
+      name: somerole
+  providerConfigRef:
+    name: example
+
+---
+apiVersion: identity.aws.crossplane.io/v1beta1
+kind: IAMRolePolicyAttachment
+metadata:
   name: sample-rolemanagedpolicyattachment
 spec:
   forProvider:

--- a/examples/s3/bucket.yaml
+++ b/examples/s3/bucket.yaml
@@ -46,5 +46,44 @@ spec:
             prefix: "ola/"
           expiration:
             days: 15
+    replicationConfiguration:
+      roleRef:
+        name: somerole
+      rules:
+        - destination:
+            storageClass: STANDARD
+            bucketRef:
+              name: repl-dest
+          deleteMarkerReplication:
+            status: Disabled
+          filter:
+            prefix: ""
+          priority: 0
+          id: rule-1
+          status: Enabled
+  providerConfigRef:
+    name: example
+---
+apiVersion: s3.aws.crossplane.io/v1beta1
+kind: Bucket
+metadata:
+  name: repl-dest
+  annotations:
+    # This will be the actual bucket name. It must be globally unique, so you
+    # probably want to change it before trying to apply this example.
+    crossplane.io/external-name: crossplane-example-repl-dest
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    acl: private
+    locationConstraint: us-east-1
+    paymentConfiguration:
+      payer: BucketOwner
+    serverSideEncryptionConfiguration:
+      rules:
+        - applyServerSideEncryptionByDefault:
+            sseAlgorithm: AES256
+    versioningConfiguration:
+      status: Enabled
   providerConfigRef:
     name: example

--- a/package/crds/s3.aws.crossplane.io_buckets.yaml
+++ b/package/crds/s3.aws.crossplane.io_buckets.yaml
@@ -908,7 +908,7 @@ spec:
                                 S3 handled replication of delete markers differently.
                                 For more information, see Backward Compatibility (https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-backward-compat-considerations)."
                               properties:
-                                Status:
+                                status:
                                   description: Indicates whether to replicate delete
                                     markers. In the current implementation, Amazon
                                     S3 doesn't replicate the delete markers. The status
@@ -917,7 +917,7 @@ spec:
                                   - Disabled
                                   type: string
                               required:
-                              - Status
+                              - status
                               type: object
                             destination:
                               description: "A container for information about the


### PR DESCRIPTION

### Description of your changes

The replication destination bucket should resolve to an ARN, not a bucket name.

Fixes #745

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
With blood, sweat and tears. Fixed three other issues first.

This is a "minimal" configuration (excluding role and policy):
```yaml
---
apiVersion: s3.aws.crossplane.io/v1beta1
kind: Bucket
metadata:
  annotations:
    crossplane.io/external-name: repl-src.2021-06-07
  name: repl-src
spec:
  deletionPolicy: Delete
  forProvider:
    acl: private
    locationConstraint: eu-north-1
    paymentConfiguration:
      payer: BucketOwner
    serverSideEncryptionConfiguration:
      rules:
      - applyServerSideEncryptionByDefault:
          sseAlgorithm: AES256
    versioningConfiguration:
      status: Enabled
    replicationConfiguration:
      role: arn:aws:iam::...:role/s3-replication-test # assumable by s3 svc, I just tested with an s3 admin role
      rules:
      - destination:
          storageClass: STANDARD
          bucketRef:
            name: repl-dest
        deleteMarkerReplication:
          status: Disabled
        priority: 0
        id: rule-1
        status: Enabled
---
apiVersion: s3.aws.crossplane.io/v1beta1
kind: Bucket
metadata:
  annotations:
    crossplane.io/external-name: repl-dest.2021-06-07
  name: repl-dest
spec:
  deletionPolicy: Delete
  forProvider:
    acl: private
    locationConstraint: eu-north-1
    paymentConfiguration:
      payer: BucketOwner
    serverSideEncryptionConfiguration:
      rules:
      - applyServerSideEncryptionByDefault:
          sseAlgorithm: AES256
    versioningConfiguration:
      status: Enabled

```
Question: Do you prefer the function returning a function for BucketARN?

[contribution process]: https://git.io/fj2m9
