### PR TITLE
s3: replication storage class STANDARD was missing

### DIFF
--- a/apis/s3/v1beta1/replicationConfiguration_types.go
+++ b/apis/s3/v1beta1/replicationConfiguration_types.go
@@ -183,7 +183,7 @@ type Destination struct {
 	// For valid values, see the StorageClass element of the PUT Bucket replication
 	// (https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTreplication.html)
 	// action in the Amazon Simple Storage Service API Reference.
-	// +kubebuilder:validation:Enum=GLACIER;STANDARD_IA;ONEZONE_IA;INTELLIGENT_TIERING;DEEP_ARCHIVE
+	// +kubebuilder:validation:Enum=STANDARD;GLACIER;STANDARD_IA;ONEZONE_IA;INTELLIGENT_TIERING;DEEP_ARCHIVE
 	// +optional
 	StorageClass *string `json:"storageClass"`
 }

--- a/package/crds/s3.aws.crossplane.io_buckets.yaml
+++ b/package/crds/s3.aws.crossplane.io_buckets.yaml
@@ -701,6 +701,7 @@ spec:
                                 storageClass:
                                   description: The storage class to use when replicating objects, such as S3 Standard or reduced redundancy. By default, Amazon S3 uses the storage class of the source object to create the object replica. For valid values, see the StorageClass element of the PUT Bucket replication (https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTreplication.html) action in the Amazon Simple Storage Service API Reference.
                                   enum:
+                                  - STANDARD
                                   - GLACIER
                                   - STANDARD_IA
                                   - ONEZONE_IA


### PR DESCRIPTION
### Description of your changes
Add storage class STANDARD as an option.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Created replication rule and check the console.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
