### PR TITLE
s3: replication configuration - allow user to drop Filter similar AWS documentation

### DIFF
--- a/pkg/controller/s3/bucket/replicationConfig.go
+++ b/pkg/controller/s3/bucket/replicationConfig.go
@@ -293,6 +293,8 @@ func createRule(input v1beta1.ReplicationRule) awss3.ReplicationRule {
 		if Rule.Filter.Tag != nil {
 			newRule.Filter.Tag = &awss3.Tag{Key: awsclient.String(Rule.Filter.Tag.Key), Value: awsclient.String(Rule.Filter.Tag.Value)}
 		}
+	} else {
+		newRule.Filter = &awss3.ReplicationRuleFilter{}
 	}
 	if Rule.SourceSelectionCriteria != nil {
 		newRule.SourceSelectionCriteria = &awss3.SourceSelectionCriteria{


### PR DESCRIPTION
### Description of your changes
The filter part of a replication rule is as far as I can tell optional in the documentation. However, it was not possible to create a filter-less replication rule similar to the XML examples.

Using cloud trail and the console noticed that if you create a rule in the s3 console, cloud trail says `filter: ""`. With `aws s3api get-bucket-replicaton` I see `"Filter": {},`. However, in the XML examples, there is no filter:

https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-add-config.html#replication-config-min-rule-config

It turns out that if you don't want a filter, you still have to include the filter element to the Go SDK.

Question: I'm not sure if this is an issue with the Go SDK, or if the documentation is simply wrong, that you need a filter XML tag? If we can dump the XML perhaps we can know if this is a good idea or not.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Created replication rule and check the console.

[contribution process]: https://git.io/fj2m9
