### PR TITLE
s3: fix deleteMarkerReplication.Status -> deleteMarkerReplication.status

### DIFF
--- a/apis/s3/v1beta1/replicationConfiguration_types.go
+++ b/apis/s3/v1beta1/replicationConfiguration_types.go
@@ -126,7 +126,7 @@ type DeleteMarkerReplication struct {
 	// In the current implementation, Amazon S3 doesn't replicate the delete markers.
 	// The status must be "Disabled".
 	// +kubebuilder:validation:Enum=Disabled
-	Status string `json:"Status"`
+	Status string `json:"status"`
 }
 
 // Destination specifies information about where to publish analysis or configuration results

--- a/package/crds/s3.aws.crossplane.io_buckets.yaml
+++ b/package/crds/s3.aws.crossplane.io_buckets.yaml
@@ -596,13 +596,13 @@ spec:
                             deleteMarkerReplication:
                               description: "Specifies whether Amazon S3 replicates the delete markers. If you specify a Filter, you must specify this element. However, in the latest version of replication configuration (when Filter is specified), Amazon S3 doesn't replicate delete markers. Therefore, the DeleteMarkerReplication element can contain only <Status>Disabled</Status>. For an example configuration, see Basic Rule Configuration (https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-config-min-rule-config). \n If you don't specify the Filter element, Amazon S3 assumes that the replication configuration is the earlier version, V1. In the earlier version, Amazon S3 handled replication of delete markers differently. For more information, see Backward Compatibility (https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-backward-compat-considerations)."
                               properties:
-                                Status:
+                                status:
                                   description: Indicates whether to replicate delete markers. In the current implementation, Amazon S3 doesn't replicate the delete markers. The status must be "Disabled".
                                   enum:
                                   - Disabled
                                   type: string
                               required:
-                              - Status
+                              - status
                               type: object
                             destination:
                               description: "A container for information about the replication destination and its configurations including enabling the S3 Replication Time Control (S3 RTC). \n Destination is a required field"


### PR DESCRIPTION
### Description of your changes
fix deleteMarkerReplication.Status -> deleteMarkerReplication.status
    
The JSON/YAML field name had an upper case first letter, which is not
consistent with any other resource.

Question: Given the other issues with replication configuration, I'm not sure if anyone has used replication lately. So I wonder if this is OK or not in beta.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Created replication rule and checked the console.

[contribution process]: https://git.io/fj2m9
