### PR TITLE
Add Observation Debug logs

### DIFF
--- a/pkg/clients/iam/iamrole.go
+++ b/pkg/clients/iam/iamrole.go
@@ -137,21 +137,37 @@ func CreatePatch(in *iam.Role, target *v1beta1.IAMRoleParameters) (*v1beta1.IAMR
 }
 
 // IsRoleUpToDate checks whether there is a change in any of the modifiable fields in role.
-func IsRoleUpToDate(in v1beta1.IAMRoleParameters, observed iam.Role) (bool, error) {
+func IsRoleUpToDate(in v1beta1.IAMRoleParameters, observed iam.Role) (bool, string, error) {
 	generated, err := copystructure.Copy(&observed)
 	if err != nil {
-		return true, errors.Wrap(err, errCheckUpToDate)
+		return true, "", errors.Wrap(err, errCheckUpToDate)
 	}
 	desired, ok := generated.(*iam.Role)
 	if !ok {
-		return true, errors.New(errCheckUpToDate)
+		return true, "", errors.New(errCheckUpToDate)
 	}
 
 	if err = GenerateIAMRole(in, desired); err != nil {
-		return false, err
+		return false, "", err
 	}
 
-	return cmp.Equal(desired, &observed, cmpopts.IgnoreInterfaces(struct{ resource.AttributeReferencer }{})), nil
+	isRoleUpToDate := cmp.Equal(desired, &observed, cmpopts.IgnoreInterfaces(struct{ resource.AttributeReferencer }{}))
+	observationMessage := ""
+
+	if !isRoleUpToDate {
+		observationMessage = "Found observed difference in IAM role\n"
+		observationMessage += cmp.Diff(desired, &observed, cmpopts.IgnoreInterfaces(struct{ resource.AttributeReferencer }{}))
+
+		// Add extra logging for AssumeRolePolicyDocument because cmp.Diff doesn't show the full difference
+		if *desired.AssumeRolePolicyDocument != *observed.AssumeRolePolicyDocument {
+			observationMessage += "\ndesired assume role policy: "
+			observationMessage += *desired.AssumeRolePolicyDocument
+			observationMessage += "\nobserved assume role policy: "
+			observationMessage += *observed.AssumeRolePolicyDocument
+		}
+	}
+
+	return isRoleUpToDate, observationMessage, nil
 }
 
 // DiffIAMTags returns the lists of tags that need to be removed and added according

--- a/pkg/clients/iam/iamrole.go
+++ b/pkg/clients/iam/iamrole.go
@@ -152,22 +152,22 @@ func IsRoleUpToDate(in v1beta1.IAMRoleParameters, observed iam.Role) (bool, stri
 	}
 
 	isRoleUpToDate := cmp.Equal(desired, &observed, cmpopts.IgnoreInterfaces(struct{ resource.AttributeReferencer }{}))
-	observationMessage := ""
+	diff := ""
 
 	if !isRoleUpToDate {
-		observationMessage = "Found observed difference in IAM role\n"
-		observationMessage += cmp.Diff(desired, &observed, cmpopts.IgnoreInterfaces(struct{ resource.AttributeReferencer }{}))
+		diff = "Found observed difference in IAM role\n"
+		diff += cmp.Diff(desired, &observed, cmpopts.IgnoreInterfaces(struct{ resource.AttributeReferencer }{}))
 
 		// Add extra logging for AssumeRolePolicyDocument because cmp.Diff doesn't show the full difference
 		if *desired.AssumeRolePolicyDocument != *observed.AssumeRolePolicyDocument {
-			observationMessage += "\ndesired assume role policy: "
-			observationMessage += *desired.AssumeRolePolicyDocument
-			observationMessage += "\nobserved assume role policy: "
-			observationMessage += *observed.AssumeRolePolicyDocument
+			diff += "\ndesired assume role policy: "
+			diff += *desired.AssumeRolePolicyDocument
+			diff += "\nobserved assume role policy: "
+			diff += *observed.AssumeRolePolicyDocument
 		}
 	}
 
-	return isRoleUpToDate, observationMessage, nil
+	return isRoleUpToDate, diff, nil
 }
 
 // DiffIAMTags returns the lists of tags that need to be removed and added according

--- a/pkg/clients/iam/iamrole_test.go
+++ b/pkg/clients/iam/iamrole_test.go
@@ -224,9 +224,9 @@ func TestIsRoleUpToDate(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		args                   args
-		want                   bool
-		wantObservationMessage string
+		args     args
+		want     bool
+		wantDiff string
 	}{
 		"SameFields": {
 			args: args{
@@ -251,8 +251,8 @@ func TestIsRoleUpToDate(t *testing.T) {
 					}},
 				},
 			},
-			want:                   true,
-			wantObservationMessage: "",
+			want:     true,
+			wantDiff: "",
 		},
 		"DifferentFields": {
 			args: args{
@@ -277,26 +277,26 @@ func TestIsRoleUpToDate(t *testing.T) {
 					}},
 				},
 			},
-			want:                   false,
-			wantObservationMessage: "Found observed difference in IAM role",
+			want:     false,
+			wantDiff: "Found observed difference in IAM role",
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got, testObservationMessage, _ := IsRoleUpToDate(tc.args.p, tc.args.role)
+			got, testDiff, _ := IsRoleUpToDate(tc.args.p, tc.args.role)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
 			}
-			if tc.wantObservationMessage == "" {
-				if tc.wantObservationMessage != testObservationMessage {
-					t.Errorf("r: -want, +got:\n%s", testObservationMessage)
+			if tc.wantDiff == "" {
+				if tc.wantDiff != testDiff {
+					t.Errorf("r: -want, +got:\n%s", testDiff)
 				}
 			}
 
-			if tc.wantObservationMessage == "Found observed difference in IAM role" {
-				if !strings.Contains(testObservationMessage, tc.wantObservationMessage) {
-					t.Errorf("r: -want, +got:\n%s", testObservationMessage)
+			if tc.wantDiff == "Found observed difference in IAM role" {
+				if !strings.Contains(testDiff, tc.wantDiff) {
+					t.Errorf("r: -want, +got:\n%s", testDiff)
 				}
 			}
 		})

--- a/pkg/controller/identity/iamrole/controller.go
+++ b/pkg/controller/identity/iamrole/controller.go
@@ -124,14 +124,15 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 
 	cr.Status.AtProvider = iam.GenerateRoleObservation(*observed.Role)
 
-	upToDate, err := iam.IsRoleUpToDate(cr.Spec.ForProvider, role)
+	upToDate, observationMessage, err := iam.IsRoleUpToDate(cr.Spec.ForProvider, role)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, errUpToDateFailed)
 	}
 
 	return managed.ExternalObservation{
-		ResourceExists:   true,
-		ResourceUpToDate: upToDate,
+		ResourceExists:     true,
+		ResourceUpToDate:   upToDate,
+		ObservationMessage: observationMessage,
 	}, nil
 }
 

--- a/pkg/controller/identity/iamrole/controller.go
+++ b/pkg/controller/identity/iamrole/controller.go
@@ -124,15 +124,15 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 
 	cr.Status.AtProvider = iam.GenerateRoleObservation(*observed.Role)
 
-	upToDate, observationMessage, err := iam.IsRoleUpToDate(cr.Spec.ForProvider, role)
+	upToDate, diff, err := iam.IsRoleUpToDate(cr.Spec.ForProvider, role)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, errUpToDateFailed)
 	}
 
 	return managed.ExternalObservation{
-		ResourceExists:     true,
-		ResourceUpToDate:   upToDate,
-		ObservationMessage: observationMessage,
+		ResourceExists:   true,
+		ResourceUpToDate: upToDate,
+		Diff:             diff,
 	}, nil
 }
 


### PR DESCRIPTION
### Description of your changes

The issue I'm having is that I have a resource that is out-of-sync, and I am having a hard time debugging the reason it keeps getting flagged as out-of-sync. I would like to add the option of an additional debug level log that details why a resource's observed state does not match its desired state.

I have created a PR to update the crossplane-runtime library with https://github.com/crossplane/crossplane-runtime/pull/272 . This PR of provider-aws is dependent on that being merged, and provider-aws updating to use the new version of crossplane-runtime. (Unit tests in this PR will only pass once that has been done)

In that PR I added the option for an ExternalObservartion to have a debug level message. This PR takes advantage of that and adds details describing the change. It also shows the full AssumeRolePolicyDocument differences if those are found to be out-of-sync.

Fixes #749

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I've tested this by building provider-aws against this commit (with changes to the IAM controller as well), and ensure that the proper log messages are shown at the Debug level. See this output:

```
2021-07-11T19:51:27.152-0400	DEBUG	provider-aws	External resource is up to date	{"controller": "managed/iamrolepolicyattachment.identity.aws.crossplane.io", "request": "/cc-crossplane-iam-role-rolepolicyattachment", "uid": "a197b39c-19d7-4099-82f2-f1ccd5105761", "version": "109686", "external-name": "cc-crossplane-iam-role-rolepolicyattachment", "requeue-after": "2021-07-11T19:52:27.152-0400"}
2021-07-11T19:52:22.998-0400	DEBUG	provider-aws	Reconciling	{"controller": "managed/iampolicy.identity.aws.crossplane.io", "request": "/cc-crossplane-iam-role"}
2021-07-11T19:52:23.000-0400	DEBUG	provider-aws	Reconciling	{"controller": "managed/iamrole.identity.aws.crossplane.io", "request": "/cc-crossplane-iam-role"}
2021-07-11T19:52:23.281-0400	DEBUG	provider-aws	Found observed difference in IAM role
  &iam.Role{
  	Arn:                      &"arn:aws:iam::111111111111:role/cc-crossplane-iam-role",
- 	AssumeRolePolicyDocument: &"%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22AWS%22%3A%22arn%3Aaws%3Aiam%3A%3A540005025229%3Aroot%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%2C%22Condition%22%3A%7B%22StringEquals%22%"...,
+ 	AssumeRolePolicyDocument: &"%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22AWS%22%3A%22arn%3Aaws%3Aiam%3A%3A540005025229%3Aroot%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%2C%22Condition%22%3A%7B%22StringEquals%22%"...,
  	CreateDate:               &s"2021-07-11 23:51:21 +0000 UTC",
  	Description:              nil,
  	... // 7 identical fields
  }

desired assume role policy: %7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22AWS%22%3A%22arn%3Aaws%3Aiam%3A%3A540005025229%3Aroot%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22sts%3AExternalId%22%3A%22000000000000%22%7D%7D%7D%5D%7D
observed assume role policy: %7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22AWS%22%3A%22arn%3Aaws%3Aiam%3A%3A540005025229%3Aroot%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22sts%3AExternalId%22%3A%2211111%22%7D%7D%7D%5D%7D	{"controller": "managed/iamrole.identity.aws.crossplane.io", "request": "/cc-crossplane-iam-role", "uid": "67d1d6fb-a50e-4f51-b333-275bc3ebe4cf", "version": "109674", "external-name": "cc-crossplane-iam-role"}
2021-07-11T19:52:23.338-0400	DEBUG	provider-aws	External resource is up to date	{"controller": "managed/iampolicy.identity.aws.crossplane.io", "request": "/cc-crossplane-iam-role", "uid": "470f8e08-85b1-4e5d-960b-937fdbae93ff", "version": "109681", "external-name": "arn:aws:iam::111111111111:policy/cc-crossplane-iam-role", "requeue-after": "2021-07-11T19:53:23.338-0400"}
```

Also I added a unit test to check for this debug message (will only work with an updated crossplane-runtime library)
