### PR TITLE
Remove ECR policyText observation

### DIFF
--- a/apis/ecr/v1alpha1/policy_types.go
+++ b/apis/ecr/v1alpha1/policy_types.go
@@ -235,10 +235,7 @@ type RepositoryPolicySpec struct {
 }
 
 // RepositoryPolicyObservation keeps the state for the external resource
-type RepositoryPolicyObservation struct {
-	// The JSON repository policy text associated with the repository.
-	PolicyText string `json:"policyText,omitempty"`
-}
+type RepositoryPolicyObservation struct{}
 
 // A RepositoryPolicyStatus represents the observed state of a repository policy
 type RepositoryPolicyStatus struct {

--- a/package/crds/ecr.aws.crossplane.io_repositorypolicies.yaml
+++ b/package/crds/ecr.aws.crossplane.io_repositorypolicies.yaml
@@ -485,11 +485,6 @@ spec:
               atProvider:
                 description: RepositoryPolicyObservation keeps the state for the external
                   resource
-                properties:
-                  policyText:
-                    description: The JSON repository policy text associated with the
-                      repository.
-                    type: string
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/pkg/controller/ecr/repositorypolicy/controller.go
+++ b/pkg/controller/ecr/repositorypolicy/controller.go
@@ -109,10 +109,6 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 		return managed.ExternalObservation{}, errors.Wrap(err, errGet)
 	}
 
-	if response.PolicyText != nil {
-		cr.Status.AtProvider.PolicyText = *response.PolicyText
-	}
-
 	current := cr.Spec.ForProvider.DeepCopy()
 	ecr.LateInitializeRepositoryPolicy(&cr.Spec.ForProvider, response)
 
@@ -120,7 +116,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 
 	return managed.ExternalObservation{
 		ResourceExists:          true,
-		ResourceUpToDate:        ecr.IsRepositoryPolicyUpToDate(&policyData, &cr.Status.AtProvider.PolicyText),
+		ResourceUpToDate:        ecr.IsRepositoryPolicyUpToDate(&policyData, response.PolicyText),
 		ResourceLateInitialized: !cmp.Equal(current, &cr.Spec.ForProvider),
 	}, nil
 }


### PR DESCRIPTION
### Description of your changes

Amazon ECR's `GetRepositoryPolicyRequest` API appears to return policy
statement entries in any order it feels like - this is properly handled
by Crossplane when identifying if a policy needs an update, but we fall
foul of Kubernetes' handling of resource watches, where the changing
`policyText` contents of the resource trigger a new reconcile straight
after the previous one.

This causes constant API observations, and with enough ECR policies and
a short enough poll interval, blows out the connection pool of the AWS
SDK.

Removing the `policyText` observation field and using the data available
from the API response call to detect updates avoids this situation from 
occurring.

Signed-off-by: Ben Agricola <bagricola@squiz.co.uk>

Fixes #780 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Extra test added to make sure the resource correctly returns up- and not-up-to-date on appropriate policies. Have tested on a real cluster that was experiencing the issue in question to confirm that it resolves the original problem.

[contribution process]: https://git.io/fj2m9
