### PR TITLE
github: add issue template for new resource request

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_resource_request.md
+++ b/.github/ISSUE_TEMPLATE/new_resource_request.md
@@ -1,0 +1,32 @@
+---
+name: New Resource Request
+about: Help us know what resource you need is missing.
+labels: new-resource
+---
+<!--
+Thank you for helping to improve Crossplane!
+
+Please be sure to search for open issues before raising a new one. We use issues
+for bug reports and feature requests. Please find us at https://slack.crossplane.io
+for questions, support, and discussion.
+-->
+
+### What resource do you need?
+<!--
+Please let us know the name of the resource you need.
+-->
+
+
+### What is your use case?
+<!--
+Help us for prioritization of the resource support by giving more details about
+why you need it.
+-->
+
+### Would you be willing to contribute it using [code generator](https://github.com/crossplane/provider-aws/blob/master/CODE_GENERATION.md)?
+
+<!--
+Please take a look at code generator instructions to see whether you'd like to
+contribute the missing parts where code generator cannot automate. See
+https://github.com/crossplane/provider-aws/blob/master/CODE_GENERATION.md
+-->


### PR DESCRIPTION


### Description of your changes

Adds an issue template for new resource requests to automate labelling and ask the usual questions we ask in such issues.

cc @luebken

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

N/A

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
