### PR TITLE
rds.rdsinstance: Add storage autoscaling (MaxAllocatedStorage)

### DIFF
--- a/apis/database/v1beta1/rdsinstance_types.go
+++ b/apis/database/v1beta1/rdsinstance_types.go
@@ -522,6 +522,16 @@ type RDSInstanceParameters struct {
 	// +immutable
 	MasterPasswordSecretRef *xpv1.SecretKeySelector `json:"masterPasswordSecretRef,omitempty"`
 
+	// The upper limit to which Amazon RDS can automatically scale the storage of
+	// the DB instance.
+	//
+	// For more information about this setting, including limitations that apply
+	// to it, see Managing capacity automatically with Amazon RDS storage autoscaling
+	// (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PIOPS.StorageTypes.html#USER_PIOPS.Autoscaling)
+	// in the Amazon RDS User Guide.
+	// +optional
+	MaxAllocatedStorage *int `json:"maxAllocatedStorage,omitempty"`
+
 	// MonitoringInterval is the interval, in seconds, between points when Enhanced Monitoring metrics
 	// are collected for the DB instance. To disable collecting Enhanced Monitoring
 	// metrics, specify 0. The default is 0.
@@ -855,6 +865,8 @@ const (
 	RDSInstanceStateBackingUp = "backing-up"
 	// The instance is being backed up, but is available
 	RDSInstanceStateConfiguringEnhancedMonitoring = "configuring-enhanced-monitoring"
+	// After you modify the storage size for a DB instance, the status of the DB instance is storage-optimization.
+	RDSInstanceStateStorageOptimization = "storage-optimization"
 	// The instance has failed and Amazon RDS can't recover it. Perform a point-in-time restore to the latest restorable time of the instance to recover the data.
 	RDSInstanceStateFailed = "failed"
 )
@@ -1109,6 +1121,9 @@ type RDSInstanceObservation struct {
 	// is found in AWS CloudTrail log entries whenever the AWS KMS key for the DB
 	// instance is accessed.
 	DBResourceID string `json:"dbResourceId,omitempty"`
+
+	// AllocatedStorage is the allocated storage size in gibibytes.
+	AllocatedStorage int `json:"allocatedStorage,omitempty"`
 
 	// DomainMemberships is the Active Directory Domain membership records associated with the DB instance.
 	DomainMemberships []DomainMembership `json:"domainMemberships,omitempty"`

--- a/apis/database/v1beta1/zz_generated.deepcopy.go
+++ b/apis/database/v1beta1/zz_generated.deepcopy.go
@@ -643,6 +643,11 @@ func (in *RDSInstanceParameters) DeepCopyInto(out *RDSInstanceParameters) {
 		*out = new(v1.SecretKeySelector)
 		**out = **in
 	}
+	if in.MaxAllocatedStorage != nil {
+		in, out := &in.MaxAllocatedStorage, &out.MaxAllocatedStorage
+		*out = new(int)
+		**out = **in
+	}
 	if in.MonitoringInterval != nil {
 		in, out := &in.MonitoringInterval, &out.MonitoringInterval
 		*out = new(int)

--- a/package/crds/database.aws.crossplane.io_rdsinstances.yaml
+++ b/package/crds/database.aws.crossplane.io_rdsinstances.yaml
@@ -451,6 +451,14 @@ spec:
                       First character must be a letter.    * Cannot be a reserved
                       word for the chosen database engine.'
                     type: string
+                  maxAllocatedStorage:
+                    description: "The upper limit to which Amazon RDS can automatically
+                      scale the storage of the DB instance. \n For more information
+                      about this setting, including limitations that apply to it,
+                      see Managing capacity automatically with Amazon RDS storage
+                      autoscaling (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PIOPS.StorageTypes.html#USER_PIOPS.Autoscaling)
+                      in the Amazon RDS User Guide."
+                    type: integer
                   monitoringInterval:
                     description: 'MonitoringInterval is the interval, in seconds,
                       between points when Enhanced Monitoring metrics are collected
@@ -901,6 +909,10 @@ spec:
                 description: RDSInstanceObservation is the representation of the current
                   state that is observed.
                 properties:
+                  allocatedStorage:
+                    description: AllocatedStorage is the allocated storage size in
+                      gibibytes.
+                    type: integer
                   dbInstanceArn:
                     description: DBInstanceArn is the Amazon Resource Name (ARN) for
                       the DB instance.

--- a/pkg/controller/database/rdsinstance.go
+++ b/pkg/controller/database/rdsinstance.go
@@ -126,7 +126,7 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	cr.Status.AtProvider = rds.GenerateObservation(instance)
 
 	switch cr.Status.AtProvider.DBInstanceStatus {
-	case v1beta1.RDSInstanceStateAvailable, v1beta1.RDSInstanceStateModifying, v1beta1.RDSInstanceStateBackingUp, v1beta1.RDSInstanceStateConfiguringEnhancedMonitoring:
+	case v1beta1.RDSInstanceStateAvailable, v1beta1.RDSInstanceStateModifying, v1beta1.RDSInstanceStateBackingUp, v1beta1.RDSInstanceStateConfiguringEnhancedMonitoring, v1beta1.RDSInstanceStateStorageOptimization:
 		cr.Status.SetConditions(xpv1.Available())
 	case v1beta1.RDSInstanceStateCreating:
 		cr.Status.SetConditions(xpv1.Creating())


### PR DESCRIPTION
### Description of your changes

Add storage autoscaling parameter MaxAllocatedStorage.
This parameter defines the upper limit to which Amazon RDS can automatically
scale the storage of the DB instance.

For more information about this setting, including limitations that apply
to it, see Managing capacity automatically with Amazon RDS storage autoscaling
(https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PIOPS.StorageTypes.html#USER_PIOPS.Autoscaling)
in the Amazon RDS User Guide.

Make rds.CreatePatch exclude AllocatedStorage if autoscaling is enabled,
and the requested AllocatedStorage is lower than was is currently
allocated.

This allows a user to manually scale *up* storage even if autoscaling is
enabled, and prevents crossplane from attempting to scale *down* if
AWS has performed autoscaling.

One problem is that this change silently ignores any attempts to manually
downscale when autoscaling is enabled. Since downscaling is not
supported and it is not possible to distinguish this from autoscaling, I
don't see any other solutions.

I have added tests to verify the logic for omitting StorageSize and the
up to date-test:

    --- FAIL: TestObserve (0.00s)
        --- FAIL: TestObserve/AutoscaledStorageIsUpToDate (0.00s)
            rdsinstance_test.go:354: r: -want, +got:
                  managed.ExternalObservation{
                  	ResourceExists:          true,
                - 	ResourceUpToDate:        true,
                + 	ResourceUpToDate:        false,
                  	ResourceLateInitialized: false,
                  	ConnectionDetails:       nil,
                  	Diff:                    "",
                  }
    --- FAIL: TestUpdate (0.00s)
        --- FAIL: TestUpdate/AutoscaleExcludeStorage (0.00s)
            rdsinstance_test.go:674: r: -want, +got:
                  interface{}(
                + 	e"cannot modify RDS instance: AllocatedStorage must not be set when on a modify request when AWS has autoscaled the storage",
                  )

Fixes #661

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
* Add unit test for IsUpToDate and Modify
* Test scaling up by filling disk,  verified that we don't hang on forever trying to scale down (thanks @petteja)
* Test scaling up manually in the console, verified that we don't hang on forever trying to scale down
* Tested manually scaling up by bumping the allocated storage in the CR - still works

[contribution process]: https://git.io/fj2m9
