### PR TITLE
Give some EC2 networking APIs a creation grace time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/crossplane/provider-aws
 
 go 1.16
 
+replace github.com/crossplane/crossplane-runtime => github.com/negz/crossplane-runtime v0.0.0-20210816051713-7a3539db4ad5
+
 require (
 	github.com/aws/aws-sdk-go v1.37.4
 	github.com/aws/aws-sdk-go-v2 v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane-runtime v0.14.1-0.20210722005935-0b469fcc77cd h1:2ZdR/HyjXFIo6KxmM08jBLeiJs7GRdGmb6qPKQANGvI=
-github.com/crossplane/crossplane-runtime v0.14.1-0.20210722005935-0b469fcc77cd/go.mod h1:0sB8XOV2zy1GdZvSMY0/5QzKQJUiNSek08wbAYHJbws=
 github.com/crossplane/crossplane-tools v0.0.0-20210320162312-1baca298c527 h1:9M6hMLKqjxtL9d9nwfcaAt59Ey0CPfSXQ3iIdYRUNaE=
 github.com/crossplane/crossplane-tools v0.0.0-20210320162312-1baca298c527/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
 github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=
@@ -411,6 +409,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/negz/crossplane-runtime v0.0.0-20210816051713-7a3539db4ad5 h1:AV8PD8PX+oawzdLmJLlE/6lDEe8RztTEzPgKZK6s6/c=
+github.com/negz/crossplane-runtime v0.0.0-20210816051713-7a3539db4ad5/go.mod h1:XvktCTRFTkdP2jR2PecrvhsxzSO8XT3jHxTOk/k+NL8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/pkg/controller/ec2/internetgateway/controller_test.go
+++ b/pkg/controller/ec2/internetgateway/controller_test.go
@@ -58,6 +58,10 @@ func withExternalName(name string) igModifier {
 	return func(r *v1beta1.InternetGateway) { meta.SetExternalName(r, name) }
 }
 
+func withExternameCreateTime() igModifier {
+	return func(r *v1beta1.InternetGateway) { meta.SetExternalCreateTime(r) }
+}
+
 func withConditions(c ...xpv1.Condition) igModifier {
 	return func(r *v1beta1.InternetGateway) { r.Status.ConditionedStatus.Conditions = c }
 }
@@ -257,12 +261,16 @@ func TestCreate(t *testing.T) {
 				})),
 			},
 			want: want{
-				cr: ig(withSpec(v1beta1.InternetGatewayParameters{
-					VPCID: aws.String(vpcID),
-				}),
+				cr: ig(
+					withSpec(v1beta1.InternetGatewayParameters{VPCID: aws.String(vpcID)}),
 					withExternalName(igID),
-					withConditions(xpv1.Creating())),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+					withExternameCreateTime(),
+					withConditions(xpv1.Creating()),
+				),
+				result: managed.ExternalCreation{
+					ExternalNameAssigned:  true,
+					ExternalCreateTimeSet: true,
+				},
 			},
 		},
 		"FailedRequest": {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes at least one variant of https://github.com/crossplane/provider-aws/issues/802.
Closes https://github.com/crossplane/provider-aws/pull/803. 

Per https://github.com/crossplane/provider-aws/issues/802 there seems to be some lag between when some EC2 networking resources (RouteTables, InternetGateways) are created and when they actually show up in queries. This PR leverages https://github.com/crossplane/crossplane-runtime/pull/280 to allow for this.

I'm leaving this in draft for now because I want to manually test it a little more (and update the relevant unit tests).

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

See https://github.com/crossplane/crossplane-runtime/pull/280.