### PR TITLE
[release-0.18] Bump crossplane-runtime to v0.13.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ PROJECT_NAME := provider-aws
 PROJECT_REPO := github.com/crossplane/$(PROJECT_NAME)
 
 PLATFORMS ?= linux_amd64 linux_arm64
+
+# kind-related versions
+KIND_VERSION ?= v0.11.1
+KIND_NODE_IMAGE_TAG ?= v1.19.11
+
 # -include will silently skip missing files, which allows us
 # to load those files with a target in the Makefile. If only
 # "include" was used, the make command would fail and refuse
@@ -94,7 +99,7 @@ e2e.run: test-integration
 # Run integration tests.
 test-integration: $(KIND) $(KUBECTL) $(HELM3)
 	@$(INFO) running integration tests using kind $(KIND_VERSION)
-	@$(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
+	@KIND_NODE_IMAGE_TAG=${KIND_NODE_IMAGE_TAG} $(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
 	@$(OK) integration tests passed
 
 # Update the submodules, such as the common build scripts.

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -71,7 +71,8 @@ echo "created cache dir at ${CACHE_PATH}"
 docker save "${BUILD_IMAGE}" -o "${CACHE_PATH}/${PACKAGE_NAME}.xpkg" && chmod 644 "${CACHE_PATH}/${PACKAGE_NAME}.xpkg"
 
 # create kind cluster with extra mounts
-echo_step "creating k8s cluster using kind"
+KIND_NODE_IMAGE="kindest/node:${KIND_NODE_IMAGE_TAG}"
+echo_step "creating k8s cluster using kind ${KIND_VERSION} and node image ${KIND_NODE_IMAGE}"
 KIND_CONFIG="$( cat <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
@@ -82,7 +83,7 @@ nodes:
     containerPath: /cache
 EOF
 )"
-echo "${KIND_CONFIG}" | "${KIND}" create cluster --name="${K8S_CLUSTER}" --wait=5m --config=-
+echo "${KIND_CONFIG}" | "${KIND}" create cluster --name="${K8S_CLUSTER}" --wait=5m --image="${KIND_NODE_IMAGE}" --config=-
 
 # tag controller image and load it into kind cluster
 docker tag "${CONTROLLER_IMAGE}" "${PACKAGE_CONTROLLER_IMAGE}"

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -32,103 +32,6 @@ echo_error(){
     exit 1
 }
 
-# k8s watchers
-
-wait_for_pods_in_namespace(){
-    local timeout=$1
-    shift
-    namespace=$1
-    shift
-    arr=("$@")
-    local counter=0
-    for i in "${arr[@]}";
-        do
-            echo -n "waiting for pod $i in namespace $namespace..." >&2
-            while ! ("${KUBECTL}" -n $namespace get pod $i) &>/dev/null; do
-                if [ "$counter" -ge "$timeout" ]; then echo "TIMEOUT"; exit -1; else (( counter+=5 )); fi
-                echo -n "." >&2
-                sleep 5
-            done
-            echo "FOUND POD!" >&2
-        done
-}
-
-check_deployments(){
-    for name in $1; do
-        echo_sub_step "inspecting deployment '${name}'"
-        local dep_stat=$("${KUBECTL}" -n "$2" get deployments/"${name}")
-
-        echo_info "check if is deployed"
-        if $(echo "$dep_stat" | grep -iq 'No resources found'); then
-            echo "is not deployed"
-            exit -1
-        else
-            echo_step_completed
-        fi
-
-        echo_info "check if is ready"
-        IFS='/' read -ra ready_status_parts <<< "$(echo "$dep_stat" | awk ' FNR > 1 {print $2}')"
-        if (("${ready_status_parts[0]}" < "${ready_status_parts[1]}")); then
-            echo "is not Ready"
-            exit -1
-        else
-            echo_step_completed
-        fi
-        echo
-    done
-}
-
-check_pods(){
-    pods=$("${KUBECTL}" -n "${CROSSPLANE_NAMESPACE}" get pods)
-    count=$(echo "$pods" | wc -l)
-    if (("${count}"-1 != "${1}")); then
-        sleep 10
-        "${KUBECTL}" get events -A
-        sleep 20
-        echo_error "unexpected number of pods"
-        exit -1
-    fi
-    echo "$pods"
-    while read -r pod_stat; do
-        name=$(echo "$pod_stat" | awk '{print $1}')
-        echo_sub_step "inspecting pod '${name}'"
-
-        if $(echo "$pod_stat" | awk '{print $3}' | grep -ivq 'Completed'); then
-            echo_info "is not completed, continuing with further checks"
-        else
-            echo_info "is completed, foregoing further checks"
-            echo_step_completed
-            continue
-        fi
-
-        echo_info "check if is ready"
-        IFS='/' read -ra ready_status_parts <<< "$(echo "$pod_stat" | awk '{print $2}')"
-        if (("${ready_status_parts[0]}" < "${ready_status_parts[1]}")); then
-            echo_error "is not ready"
-            exit -1
-        else
-            echo_step_completed
-        fi
-
-        echo_info "check if is running"
-        if $(echo "$pod_stat" | awk '{print $3}' | grep -ivq 'Running'); then
-            echo_error "is not running"
-            exit -1
-        else
-            echo_step_completed
-        fi
-
-        echo_info "check if has restarts"
-        if (( $(echo "$pod_stat" | awk '{print $4}') > 0 )); then
-            echo_error "has restarts"
-            exit -1
-        else
-            echo_step_completed
-        fi
-        echo
-    done <<< "$(echo "$pods" | awk 'FNR>1')"
-}
-
 # ------------------------------
 projectdir="$( cd "$( dirname "${BASH_SOURCE[0]}")"/../.. && pwd )"
 
@@ -179,16 +82,11 @@ nodes:
     containerPath: /cache
 EOF
 )"
-echo "${KIND_CONFIG}" | "${KIND}" create cluster --name="${K8S_CLUSTER}" --config=-
+echo "${KIND_CONFIG}" | "${KIND}" create cluster --name="${K8S_CLUSTER}" --wait=5m --config=-
 
 # tag controller image and load it into kind cluster
 docker tag "${CONTROLLER_IMAGE}" "${PACKAGE_CONTROLLER_IMAGE}"
 "${KIND}" load docker-image "${PACKAGE_CONTROLLER_IMAGE}" --name="${K8S_CLUSTER}"
-
-# wait for kind pods
-echo_step "wait for kind pods"
-kindpods=("kube-apiserver-${BUILD_REGISTRY}-inttests-control-plane" "kube-controller-manager-${BUILD_REGISTRY}-inttests-control-plane" "kube-scheduler-${BUILD_REGISTRY}-inttests-control-plane")
-wait_for_pods_in_namespace 120 "kube-system" "${kindpods[@]}"
 
 # files are not synced properly from host to kind node container on Jenkins, so
 # we must manually copy image from host to node
@@ -244,28 +142,10 @@ echo_info "using crossplane version ${chart_version}"
 echo
 # we replace empty dir with our PVC so that the /cache dir in the kind node
 # container is exposed to the crossplane pod
-"${HELM3}" install crossplane --namespace crossplane-system crossplane-master/crossplane --version ${chart_version} --devel --set packageCache.pvc=package-cache
-
-echo_step "waiting for deployment crossplane rollout to finish"
-"${KUBECTL}" -n "${CROSSPLANE_NAMESPACE}" rollout status "deploy/crossplane" --timeout=2m
-
-echo_step "wait until the pods are up and running"
-"${KUBECTL}" -n "${CROSSPLANE_NAMESPACE}" wait --for=condition=Ready pods --all --timeout=1m
+"${HELM3}" install crossplane --namespace crossplane-system crossplane-master/crossplane --version ${chart_version} --devel --wait --set packageCache.pvc=package-cache
 
 # ----------- integration tests
 echo_step "--- INTEGRATION TESTS ---"
-echo
-echo_step "check for necessary deployment statuses"
-echo
-echo -------- deployments
-"${KUBECTL}" -n "${CROSSPLANE_NAMESPACE}" get deployments
-
-check_deployments "crossplane" "${CROSSPLANE_NAMESPACE}"
-
-echo_step "check for crossplane pods statuses"
-echo
-echo "--- pods ---"
-check_pods 2
 
 # install package
 echo_step "installing ${PROJECT_NAME} into \"${CROSSPLANE_NAMESPACE}\" namespace"
@@ -283,29 +163,29 @@ EOF
 
 echo "${INSTALL_YAML}" | "${KUBECTL}" apply -f -
 
-"${KUBECTL}" -n "${CROSSPLANE_NAMESPACE}" get deployments
-
-# this is to let package manager unpack pods and start the controller.
-sleep 20
-
 # printing the cache dir contents can be useful for troubleshooting failures
 echo_step "check kind node cache dir contents"
 docker exec "${K8S_CLUSTER}-control-plane" ls -la /cache
 
-echo_step "check for package pod statuses"
-echo
-echo "--- pods ---"
-check_pods 3
+echo_step "waiting for provider to be installed"
+
+kubectl wait "provider.pkg.crossplane.io/${PACKAGE_NAME}" --for=condition=healthy --timeout=60s
 
 echo_step "uninstalling ${PROJECT_NAME}"
 
 echo "${INSTALL_YAML}" | "${KUBECTL}" delete -f -
 
 # check pods deleted
-sleep 60
-echo_step "check only crossplane pods remain"
-echo "--- pods ---"
-"${KUBECTL}" -n "${CROSSPLANE_NAMESPACE}" get pods
-check_pods 2
+timeout=60
+current=0
+step=3
+while [[ $(kubectl get providerrevision.pkg.crossplane.io -o name | wc -l) != "0" ]]; do
+  echo "waiting for provider to be deleted for another $step seconds"
+  current=$current+$step
+  if ! [[ $timeout > $current ]]; then
+    echo_error "timeout of ${timeout}s has been reached"
+  fi
+  sleep $step;
+done
 
 echo_success "Integration tests succeeded!"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/aws/aws-sdk-go v1.37.4
 	github.com/aws/aws-sdk-go-v2 v0.23.0
-	github.com/crossplane/crossplane-runtime v0.13.0
+	github.com/crossplane/crossplane-runtime v0.13.1
 	github.com/crossplane/crossplane-tools v0.0.0-20210320162312-1baca298c527
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/go-ini/ini v1.46.0

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane-runtime v0.13.0 h1:TFeItxtW32/fETB9be0AsEha/ur0bbrtQRocC+Jd6RI=
-github.com/crossplane/crossplane-runtime v0.13.0/go.mod h1:Bc54/KBvV9ld/tvervcnhcSzk13FYguTqmYt72Mybps=
+github.com/crossplane/crossplane-runtime v0.13.1 h1:7KKErtwSs3hbY/6zLPV2O+iDnWByGy+1OW06jx+UuSo=
+github.com/crossplane/crossplane-runtime v0.13.1/go.mod h1:Bc54/KBvV9ld/tvervcnhcSzk13FYguTqmYt72Mybps=
 github.com/crossplane/crossplane-tools v0.0.0-20210320162312-1baca298c527 h1:9M6hMLKqjxtL9d9nwfcaAt59Ey0CPfSXQ3iIdYRUNaE=
 github.com/crossplane/crossplane-tools v0.0.0-20210320162312-1baca298c527/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
 github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=

--- a/pkg/controller/acm/controller.go
+++ b/pkg/controller/acm/controller.go
@@ -162,7 +162,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		return managed.ExternalCreation{}, awsclient.Wrap(err, errCreate)
 	}
 	meta.SetExternalName(cr, aws.StringValue(response.RequestCertificateOutput.CertificateArn))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 
 }
 

--- a/pkg/controller/acm/controller_test.go
+++ b/pkg/controller/acm/controller_test.go
@@ -241,7 +241,7 @@ func TestCreate(t *testing.T) {
 			want: want{
 				cr: certificate(
 					withDomainName()),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"InValidInput": {

--- a/pkg/controller/acmpca/certificateauthority/controller.go
+++ b/pkg/controller/acmpca/certificateauthority/controller.go
@@ -163,7 +163,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		return managed.ExternalCreation{}, awsclient.Wrap(err, errCreate)
 	}
 	meta.SetExternalName(cr, aws.StringValue(response.CreateCertificateAuthorityOutput.CertificateAuthorityArn))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 
 }
 

--- a/pkg/controller/acmpca/certificateauthority/controller_test.go
+++ b/pkg/controller/acmpca/certificateauthority/controller_test.go
@@ -256,7 +256,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:     certificateAuthority(withCertificateAuthorityArn()),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"InValidInput": {

--- a/pkg/controller/apigatewayv2/api/setup.go
+++ b/pkg/controller/apigatewayv2/api/setup.go
@@ -79,7 +79,6 @@ func postCreate(_ context.Context, cr *svcapitypes.API, resp *svcsdk.CreateApiOu
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.ApiId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/apigatewayv2/apimapping/setup.go
+++ b/pkg/controller/apigatewayv2/apimapping/setup.go
@@ -88,7 +88,6 @@ func postCreate(_ context.Context, cr *svcapitypes.APIMapping, resp *svcsdk.Crea
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.ApiMappingId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/apigatewayv2/authorizer/setup.go
+++ b/pkg/controller/apigatewayv2/authorizer/setup.go
@@ -86,7 +86,6 @@ func postCreate(_ context.Context, cr *svcapitypes.Authorizer, resp *svcsdk.Crea
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.AuthorizerId))
-	cre.ExternalNameAssigned = true
 	return cre, err
 }
 

--- a/pkg/controller/apigatewayv2/deployment/setup.go
+++ b/pkg/controller/apigatewayv2/deployment/setup.go
@@ -86,7 +86,6 @@ func postCreate(_ context.Context, cr *svcapitypes.Deployment, resp *svcsdk.Crea
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.DeploymentId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/apigatewayv2/integration/setup.go
+++ b/pkg/controller/apigatewayv2/integration/setup.go
@@ -86,7 +86,6 @@ func postCreate(_ context.Context, cr *svcapitypes.Integration, resp *svcsdk.Cre
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.IntegrationId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/apigatewayv2/integrationresponse/setup.go
+++ b/pkg/controller/apigatewayv2/integrationresponse/setup.go
@@ -86,7 +86,6 @@ func postCreate(_ context.Context, cr *svcapitypes.IntegrationResponse, resp *sv
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.IntegrationResponseId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/apigatewayv2/model/setup.go
+++ b/pkg/controller/apigatewayv2/model/setup.go
@@ -86,7 +86,6 @@ func postCreate(_ context.Context, cr *svcapitypes.Model, resp *svcsdk.CreateMod
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.ModelId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/apigatewayv2/route/setup.go
+++ b/pkg/controller/apigatewayv2/route/setup.go
@@ -88,7 +88,6 @@ func postCreate(_ context.Context, cr *svcapitypes.Route, res *svcsdk.CreateRout
 	// NOTE(muvaf): Route ID is chosen as external name since it's the only unique
 	// identifier.
 	meta.SetExternalName(cr, aws.StringValue(res.RouteId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/apigatewayv2/routeresponse/setup.go
+++ b/pkg/controller/apigatewayv2/routeresponse/setup.go
@@ -88,7 +88,6 @@ func postCreate(_ context.Context, cr *svcapitypes.RouteResponse, resp *svcsdk.C
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.RouteResponseId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/apigatewayv2/vpclink/setup.go
+++ b/pkg/controller/apigatewayv2/vpclink/setup.go
@@ -92,7 +92,6 @@ func postCreate(_ context.Context, cr *svcapitypes.VPCLink, resp *svcsdk.CreateV
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.VpcLinkId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/dynamodb/backup/hooks.go
+++ b/pkg/controller/dynamodb/backup/hooks.go
@@ -92,7 +92,6 @@ func postCreate(_ context.Context, cr *svcapitypes.Backup, resp *svcsdk.CreateBa
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.BackupDetails.BackupArn))
-	cre.ExternalNameAssigned = true
 	return cre, err
 }
 

--- a/pkg/controller/ec2/address/controller.go
+++ b/pkg/controller/ec2/address/controller.go
@@ -174,7 +174,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 	} else {
 		meta.SetExternalName(cr, aws.StringValue(result.AllocateAddressOutput.AllocationId))
 	}
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/ec2/address/controller.go
+++ b/pkg/controller/ec2/address/controller.go
@@ -19,6 +19,7 @@ package address
 import (
 	"context"
 	"sort"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -66,6 +67,7 @@ func SetupAddress(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) 
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.AddressGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient()}),
+			managed.WithCreationGracePeriod(3*time.Minute),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient()), &tagger{kube: mgr.GetClient()}),

--- a/pkg/controller/ec2/address/controller_test.go
+++ b/pkg/controller/ec2/address/controller_test.go
@@ -237,7 +237,7 @@ func TestCreate(t *testing.T) {
 			want: want{
 				cr: address(withExternalName(allocationID),
 					withConditions(xpv1.Creating())),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"SuccessfulStandard": {
@@ -265,7 +265,7 @@ func TestCreate(t *testing.T) {
 					withSpec(v1beta1.AddressParameters{
 						Domain: &domainStandard,
 					})),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"CreateFail": {

--- a/pkg/controller/ec2/internetgateway/controller.go
+++ b/pkg/controller/ec2/internetgateway/controller.go
@@ -18,6 +18,7 @@ package internetgateway
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -67,6 +68,7 @@ func SetupInternetGateway(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateL
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.InternetGatewayGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: ec2.NewInternetGatewayClient}),
+			managed.WithCreationGracePeriod(3*time.Minute),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),

--- a/pkg/controller/ec2/internetgateway/controller.go
+++ b/pkg/controller/ec2/internetgateway/controller.go
@@ -154,7 +154,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 
 	meta.SetExternalName(cr, aws.StringValue(ig.InternetGateway.InternetGatewayId))
 
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/ec2/internetgateway/controller_test.go
+++ b/pkg/controller/ec2/internetgateway/controller_test.go
@@ -262,7 +262,7 @@ func TestCreate(t *testing.T) {
 				}),
 					withExternalName(igID),
 					withConditions(xpv1.Creating())),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"FailedRequest": {

--- a/pkg/controller/ec2/natgateway/controller.go
+++ b/pkg/controller/ec2/natgateway/controller.go
@@ -2,6 +2,7 @@ package natgateway
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -47,6 +48,7 @@ func SetupNatGateway(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimite
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.NATGatewayGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: ec2.NewNatGatewayClient}),
+			managed.WithCreationGracePeriod(3*time.Minute),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),

--- a/pkg/controller/ec2/natgateway/controller.go
+++ b/pkg/controller/ec2/natgateway/controller.go
@@ -145,7 +145,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		return managed.ExternalCreation{}, awsclient.Wrap(err, errCreate)
 	}
 	meta.SetExternalName(cr, aws.StringValue(nat.NatGateway.NatGatewayId))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/ec2/natgateway/controller_test.go
+++ b/pkg/controller/ec2/natgateway/controller_test.go
@@ -469,7 +469,7 @@ func TestCreate(t *testing.T) {
 				cr: nat(withExternalName(natGatewayID),
 					withSpec(specNatSpec()),
 				),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"FailedRequest": {

--- a/pkg/controller/ec2/routetable/controller.go
+++ b/pkg/controller/ec2/routetable/controller.go
@@ -18,6 +18,7 @@ package routetable
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -71,6 +72,7 @@ func SetupRouteTable(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimite
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.RouteTableGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: ec2.NewRouteTableClient}),
+			managed.WithCreationGracePeriod(3*time.Minute),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),

--- a/pkg/controller/ec2/routetable/controller.go
+++ b/pkg/controller/ec2/routetable/controller.go
@@ -169,7 +169,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		return managed.ExternalCreation{}, awsclient.Wrap(err, errCreate)
 	}
 	meta.SetExternalName(cr, aws.StringValue(result.RouteTable.RouteTableId))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) { // nolint:gocyclo

--- a/pkg/controller/ec2/routetable/controller_test.go
+++ b/pkg/controller/ec2/routetable/controller_test.go
@@ -214,7 +214,7 @@ func TestCreate(t *testing.T) {
 				cr: rt(withSpec(v1beta1.RouteTableParameters{
 					VPCID: aws.String(vpcID),
 				}), withExternalName(rtID)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"CreateFailed": {

--- a/pkg/controller/ec2/securitygroup/controller.go
+++ b/pkg/controller/ec2/securitygroup/controller.go
@@ -18,6 +18,7 @@ package securitygroup
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -73,6 +74,7 @@ func SetupSecurityGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLim
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.SecurityGroupGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: ec2.NewSecurityGroupClient}),
+			managed.WithCreationGracePeriod(3*time.Minute),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),

--- a/pkg/controller/ec2/subnet/controller.go
+++ b/pkg/controller/ec2/subnet/controller.go
@@ -18,6 +18,7 @@ package subnet
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -64,6 +65,7 @@ func SetupSubnet(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) e
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.SubnetGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: ec2.NewSubnetClient}),
+			managed.WithCreationGracePeriod(3*time.Minute),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),

--- a/pkg/controller/ec2/subnet/controller.go
+++ b/pkg/controller/ec2/subnet/controller.go
@@ -160,7 +160,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 
 	meta.SetExternalName(cr, aws.StringValue(result.Subnet.SubnetId))
 
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/ec2/subnet/controller_test.go
+++ b/pkg/controller/ec2/subnet/controller_test.go
@@ -234,7 +234,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:     subnet(withExternalName(subnetID)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"CreateFailed": {

--- a/pkg/controller/ec2/vpc/controller.go
+++ b/pkg/controller/ec2/vpc/controller.go
@@ -183,7 +183,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 
 	meta.SetExternalName(cr, aws.StringValue(result.Vpc.VpcId))
 
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/ec2/vpc/controller_test.go
+++ b/pkg/controller/ec2/vpc/controller_test.go
@@ -251,7 +251,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:     vpc(withExternalName(vpcID)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"SuccessfulWithAttributes": {
@@ -282,7 +282,7 @@ func TestCreate(t *testing.T) {
 					withSpec(v1beta1.VPCParameters{
 						EnableDNSSupport: &enableDNS,
 					})),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"CreateFail": {

--- a/pkg/controller/ec2/vpccidrblock/controller.go
+++ b/pkg/controller/ec2/vpccidrblock/controller.go
@@ -168,7 +168,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		}
 	}
 
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(_ context.Context, _ resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/ec2/vpccidrblock/controller.go
+++ b/pkg/controller/ec2/vpccidrblock/controller.go
@@ -18,6 +18,7 @@ package vpccidrblock
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -60,6 +61,7 @@ func SetupVPCCIDRBlock(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimi
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.VPCCIDRBlockGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: ec2.NewVPCCIDRBlockClient}),
+			managed.WithCreationGracePeriod(3*time.Minute),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),

--- a/pkg/controller/ec2/vpccidrblock/controller_test.go
+++ b/pkg/controller/ec2/vpccidrblock/controller_test.go
@@ -274,7 +274,7 @@ func TestCreate(t *testing.T) {
 					CIDRBlock: &cidr,
 					VPCID:     &vpcID,
 				}), withExternalName(matchAssociationID)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"SuccessfulIPv6": {
@@ -303,7 +303,7 @@ func TestCreate(t *testing.T) {
 					IPv6CIDRBlock: &ipv6CIDR,
 					VPCID:         &vpcID,
 				}), withExternalName(matchAssociationID)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"CreateFail": {

--- a/pkg/controller/efs/filesystem/setup.go
+++ b/pkg/controller/efs/filesystem/setup.go
@@ -109,5 +109,5 @@ func postCreate(_ context.Context, cr *svcapitypes.FileSystem, obj *svcsdk.FileS
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, awsclients.StringValue(obj.FileSystemId))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }

--- a/pkg/controller/identity/iamaccesskey/controller.go
+++ b/pkg/controller/identity/iamaccesskey/controller.go
@@ -143,7 +143,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		}
 	}
 	meta.SetExternalName(cr, aws.StringValue(response.AccessKey.AccessKeyId))
-	return managed.ExternalCreation{ExternalNameAssigned: true, ConnectionDetails: conn}, nil
+	return managed.ExternalCreation{ConnectionDetails: conn}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/identity/iamaccesskey/controller_test.go
+++ b/pkg/controller/identity/iamaccesskey/controller_test.go
@@ -263,7 +263,6 @@ func TestCreate(t *testing.T) {
 					withUsername(userName),
 					withAccessKey(accessKeyID)),
 				result: managed.ExternalCreation{
-					ExternalNameAssigned: true,
 					ConnectionDetails: map[string][]byte{
 						xpv1.ResourceCredentialsSecretPasswordKey: []byte(secretKeyID),
 						xpv1.ResourceCredentialsSecretUserKey:     []byte(accessKeyID),

--- a/pkg/controller/identity/iampolicy/controller.go
+++ b/pkg/controller/identity/iampolicy/controller.go
@@ -162,7 +162,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 
 	meta.SetExternalName(cr, aws.StringValue(createResp.CreatePolicyOutput.Policy.Arn))
 
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/identity/iampolicy/controller_test.go
+++ b/pkg/controller/identity/iampolicy/controller_test.go
@@ -254,7 +254,7 @@ func TestCreate(t *testing.T) {
 						Name:     name,
 					}),
 					withExterName(arn)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"InValidInput": {

--- a/pkg/controller/kms/key/setup.go
+++ b/pkg/controller/kms/key/setup.go
@@ -84,7 +84,7 @@ func postCreate(_ context.Context, cr *svcapitypes.Key, obj *svcsdk.CreateKeyOut
 		return creation, err
 	}
 	meta.SetExternalName(cr, awsclients.StringValue(obj.KeyMetadata.KeyId))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 type updater struct {

--- a/pkg/controller/notification/snssubscription/controller.go
+++ b/pkg/controller/notification/snssubscription/controller.go
@@ -149,7 +149,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 	}
 
 	meta.SetExternalName(cr, aws.StringValue(res.SubscribeOutput.SubscriptionArn))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/notification/snssubscription/controller_test.go
+++ b/pkg/controller/notification/snssubscription/controller_test.go
@@ -133,7 +133,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:     subscription(withSubARN(&subName)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"InValidInput": {

--- a/pkg/controller/notification/snstopic/controller.go
+++ b/pkg/controller/notification/snstopic/controller.go
@@ -139,7 +139,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 	}
 
 	meta.SetExternalName(cr, aws.StringValue(resp.CreateTopicOutput.TopicArn))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/notification/snstopic/controller_test.go
+++ b/pkg/controller/notification/snstopic/controller_test.go
@@ -300,7 +300,7 @@ func TestCreate(t *testing.T) {
 				cr: topic(
 					withDisplayName(&topicDisplayName),
 					withTopicName(&topicName)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"InValidInput": {

--- a/pkg/controller/route53/hostedzone/controller.go
+++ b/pkg/controller/route53/hostedzone/controller.go
@@ -136,7 +136,7 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalCreation{}, errors.Wrap(errors.New("returned id does not contain /hostedzone/ prefix"), errCreate)
 	}
 	meta.SetExternalName(cr, id[1])
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/route53/hostedzone/controller_test.go
+++ b/pkg/controller/route53/hostedzone/controller_test.go
@@ -268,7 +268,7 @@ func TestCreate(t *testing.T) {
 			want: want{
 				cr: instance(
 					withExternalName(strings.SplitAfter(id, hostedzone.IDPrefix)[1])),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"InValidInput": {

--- a/pkg/controller/sfn/activity/hooks.go
+++ b/pkg/controller/sfn/activity/hooks.go
@@ -79,7 +79,6 @@ func postCreate(_ context.Context, cr *svcapitypes.Activity, resp *svcsdk.Create
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.ActivityArn))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/sfn/statemachine/hooks.go
+++ b/pkg/controller/sfn/statemachine/hooks.go
@@ -91,7 +91,6 @@ func postCreate(_ context.Context, cr *svcapitypes.StateMachine, resp *svcsdk.Cr
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.StateMachineArn))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR fixes https://github.com/crossplane/provider-aws/issues/802 for the v0.18 release. See https://github.com/crossplane/crossplane-runtime/releases/tag/v0.13.1 and https://github.com/crossplane/crossplane-runtime/pull/283 for more detail.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I tested this change extensively as part of https://github.com/crossplane/crossplane-runtime/pull/283. I've run a cursory version of the same test on this specific PR (i.e. spun a composition of EC2 resources up and down once).