### PR TITLE
[release-0.19] Bump crossplane-runtime to v0.14.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ PLATFORMS ?= linux_amd64 linux_arm64
 CODE_GENERATOR_COMMIT ?= cac5654b7bb64c8f754ad9af01799ef70d9541b6
 GENERATED_SERVICES="apigatewayv2,cloudfront,dynamodb,efs,kms,lambda,rds,secretsmanager,servicediscovery,sfn"
 
+# kind-related versions
+KIND_VERSION ?= v0.11.1
+KIND_NODE_IMAGE_TAG ?= v1.19.11
+
 # -include will silently skip missing files, which allows us
 # to load those files with a target in the Makefile. If only
 # "include" was used, the make command would fail and refuse
@@ -89,7 +93,7 @@ e2e.run: test-integration
 # Run integration tests.
 test-integration: $(KIND) $(KUBECTL) $(HELM3)
 	@$(INFO) running integration tests using kind $(KIND_VERSION)
-	@$(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
+	@KIND_NODE_IMAGE_TAG=${KIND_NODE_IMAGE_TAG} $(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
 	@$(OK) integration tests passed
 
 # Update the submodules, such as the common build scripts.

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -71,7 +71,8 @@ echo "created cache dir at ${CACHE_PATH}"
 docker save "${BUILD_IMAGE}" -o "${CACHE_PATH}/${PACKAGE_NAME}.xpkg" && chmod 644 "${CACHE_PATH}/${PACKAGE_NAME}.xpkg"
 
 # create kind cluster with extra mounts
-echo_step "creating k8s cluster using kind"
+KIND_NODE_IMAGE="kindest/node:${KIND_NODE_IMAGE_TAG}"
+echo_step "creating k8s cluster using kind ${KIND_VERSION} and node image ${KIND_NODE_IMAGE}"
 KIND_CONFIG="$( cat <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
@@ -82,7 +83,7 @@ nodes:
     containerPath: /cache
 EOF
 )"
-echo "${KIND_CONFIG}" | "${KIND}" create cluster --name="${K8S_CLUSTER}" --wait=5m --config=-
+echo "${KIND_CONFIG}" | "${KIND}" create cluster --name="${K8S_CLUSTER}" --wait=5m --image="${KIND_NODE_IMAGE}" --config=-
 
 # tag controller image and load it into kind cluster
 docker tag "${CONTROLLER_IMAGE}" "${PACKAGE_CONTROLLER_IMAGE}"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/aws/aws-sdk-go v1.37.4
 	github.com/aws/aws-sdk-go-v2 v0.23.0
-	github.com/crossplane/crossplane-runtime v0.14.0
+	github.com/crossplane/crossplane-runtime v0.14.1
 	github.com/crossplane/crossplane-tools v0.0.0-20210320162312-1baca298c527
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/go-ini/ini v1.46.0

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane-runtime v0.14.0 h1:alBvQAwg9wJ88wEBnzyzmlN0N/v1W3Jx4OvBX3Fmrkg=
-github.com/crossplane/crossplane-runtime v0.14.0/go.mod h1:Bc54/KBvV9ld/tvervcnhcSzk13FYguTqmYt72Mybps=
+github.com/crossplane/crossplane-runtime v0.14.1 h1:bCPC7vKHWuhHTX22f/zfkxMcIjKd4/gZ5MjFAnLQzAI=
+github.com/crossplane/crossplane-runtime v0.14.1/go.mod h1:Bc54/KBvV9ld/tvervcnhcSzk13FYguTqmYt72Mybps=
 github.com/crossplane/crossplane-tools v0.0.0-20210320162312-1baca298c527 h1:9M6hMLKqjxtL9d9nwfcaAt59Ey0CPfSXQ3iIdYRUNaE=
 github.com/crossplane/crossplane-tools v0.0.0-20210320162312-1baca298c527/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
 github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=

--- a/pkg/controller/acm/controller.go
+++ b/pkg/controller/acm/controller.go
@@ -163,7 +163,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		return managed.ExternalCreation{}, awsclient.Wrap(err, errCreate)
 	}
 	meta.SetExternalName(cr, aws.StringValue(response.RequestCertificateOutput.CertificateArn))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 
 }
 

--- a/pkg/controller/acm/controller_test.go
+++ b/pkg/controller/acm/controller_test.go
@@ -248,7 +248,7 @@ func TestCreate(t *testing.T) {
 			want: want{
 				cr: certificate(
 					withDomainName()),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"InValidInput": {

--- a/pkg/controller/acmpca/certificateauthority/controller.go
+++ b/pkg/controller/acmpca/certificateauthority/controller.go
@@ -165,7 +165,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		return managed.ExternalCreation{}, awsclient.Wrap(err, errCreate)
 	}
 	meta.SetExternalName(cr, aws.StringValue(response.CreateCertificateAuthorityOutput.CertificateAuthorityArn))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 
 }
 

--- a/pkg/controller/acmpca/certificateauthority/controller_test.go
+++ b/pkg/controller/acmpca/certificateauthority/controller_test.go
@@ -263,7 +263,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:     certificateAuthority(withCertificateAuthorityArn()),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"InValidInput": {

--- a/pkg/controller/acmpca/certificateauthoritypermission/controller.go
+++ b/pkg/controller/acmpca/certificateauthoritypermission/controller.go
@@ -155,7 +155,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 	// identity of the CA it applies to, and the principal it applies.
 	meta.SetExternalName(cr, cr.Spec.ForProvider.Principal+"/"+awsclient.StringValue(cr.Spec.ForProvider.CertificateAuthorityARN))
 
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 
 }
 

--- a/pkg/controller/acmpca/certificateauthoritypermission/controller_test.go
+++ b/pkg/controller/acmpca/certificateauthoritypermission/controller_test.go
@@ -210,7 +210,7 @@ func TestCreate(t *testing.T) {
 					withPrincipal(principal),
 					withCertificateAuthorityARN(arn),
 					withExternalName(principal+"/"+arn)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"InValidInput": {

--- a/pkg/controller/apigatewayv2/api/setup.go
+++ b/pkg/controller/apigatewayv2/api/setup.go
@@ -79,7 +79,6 @@ func postCreate(_ context.Context, cr *svcapitypes.API, resp *svcsdk.CreateApiOu
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.ApiId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/apigatewayv2/apimapping/setup.go
+++ b/pkg/controller/apigatewayv2/apimapping/setup.go
@@ -88,7 +88,6 @@ func postCreate(_ context.Context, cr *svcapitypes.APIMapping, resp *svcsdk.Crea
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.ApiMappingId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/apigatewayv2/authorizer/setup.go
+++ b/pkg/controller/apigatewayv2/authorizer/setup.go
@@ -86,7 +86,6 @@ func postCreate(_ context.Context, cr *svcapitypes.Authorizer, resp *svcsdk.Crea
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.AuthorizerId))
-	cre.ExternalNameAssigned = true
 	return cre, err
 }
 

--- a/pkg/controller/apigatewayv2/deployment/setup.go
+++ b/pkg/controller/apigatewayv2/deployment/setup.go
@@ -86,7 +86,6 @@ func postCreate(_ context.Context, cr *svcapitypes.Deployment, resp *svcsdk.Crea
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.DeploymentId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/apigatewayv2/integration/setup.go
+++ b/pkg/controller/apigatewayv2/integration/setup.go
@@ -98,7 +98,6 @@ func postCreate(_ context.Context, cr *svcapitypes.Integration, resp *svcsdk.Cre
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.IntegrationId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/apigatewayv2/integrationresponse/setup.go
+++ b/pkg/controller/apigatewayv2/integrationresponse/setup.go
@@ -86,7 +86,6 @@ func postCreate(_ context.Context, cr *svcapitypes.IntegrationResponse, resp *sv
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.IntegrationResponseId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/apigatewayv2/model/setup.go
+++ b/pkg/controller/apigatewayv2/model/setup.go
@@ -86,7 +86,6 @@ func postCreate(_ context.Context, cr *svcapitypes.Model, resp *svcsdk.CreateMod
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.ModelId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/apigatewayv2/route/setup.go
+++ b/pkg/controller/apigatewayv2/route/setup.go
@@ -88,7 +88,6 @@ func postCreate(_ context.Context, cr *svcapitypes.Route, res *svcsdk.CreateRout
 	// NOTE(muvaf): Route ID is chosen as external name since it's the only unique
 	// identifier.
 	meta.SetExternalName(cr, aws.StringValue(res.RouteId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/apigatewayv2/routeresponse/setup.go
+++ b/pkg/controller/apigatewayv2/routeresponse/setup.go
@@ -88,7 +88,6 @@ func postCreate(_ context.Context, cr *svcapitypes.RouteResponse, resp *svcsdk.C
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.RouteResponseId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/apigatewayv2/vpclink/setup.go
+++ b/pkg/controller/apigatewayv2/vpclink/setup.go
@@ -92,7 +92,6 @@ func postCreate(_ context.Context, cr *svcapitypes.VPCLink, resp *svcsdk.CreateV
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.VpcLinkId))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/cloudfront/distribution/setup.go
+++ b/pkg/controller/cloudfront/distribution/setup.go
@@ -93,7 +93,6 @@ func postCreate(_ context.Context, cr *svcapitypes.Distribution, cdo *svcsdk.Cre
 	}
 
 	meta.SetExternalName(cr, awsclients.StringValue(cdo.Distribution.Id))
-	ec.ExternalNameAssigned = true
 	return ec, nil
 }
 

--- a/pkg/controller/dynamodb/backup/hooks.go
+++ b/pkg/controller/dynamodb/backup/hooks.go
@@ -92,7 +92,6 @@ func postCreate(_ context.Context, cr *svcapitypes.Backup, resp *svcsdk.CreateBa
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.BackupDetails.BackupArn))
-	cre.ExternalNameAssigned = true
 	return cre, err
 }
 

--- a/pkg/controller/ec2/address/controller.go
+++ b/pkg/controller/ec2/address/controller.go
@@ -174,7 +174,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 	} else {
 		meta.SetExternalName(cr, aws.StringValue(result.AllocateAddressOutput.AllocationId))
 	}
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/ec2/address/controller.go
+++ b/pkg/controller/ec2/address/controller.go
@@ -19,6 +19,7 @@ package address
 import (
 	"context"
 	"sort"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -66,6 +67,7 @@ func SetupAddress(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) 
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.AddressGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient()}),
+			managed.WithCreationGracePeriod(3*time.Minute),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient()), &tagger{kube: mgr.GetClient()}),

--- a/pkg/controller/ec2/address/controller_test.go
+++ b/pkg/controller/ec2/address/controller_test.go
@@ -237,7 +237,7 @@ func TestCreate(t *testing.T) {
 			want: want{
 				cr: address(withExternalName(allocationID),
 					withConditions(xpv1.Creating())),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"SuccessfulStandard": {
@@ -265,7 +265,7 @@ func TestCreate(t *testing.T) {
 					withSpec(v1beta1.AddressParameters{
 						Domain: &domainStandard,
 					})),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"CreateFail": {

--- a/pkg/controller/ec2/internetgateway/controller.go
+++ b/pkg/controller/ec2/internetgateway/controller.go
@@ -18,6 +18,7 @@ package internetgateway
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -67,6 +68,7 @@ func SetupInternetGateway(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateL
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.InternetGatewayGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: ec2.NewInternetGatewayClient}),
+			managed.WithCreationGracePeriod(3*time.Minute),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),

--- a/pkg/controller/ec2/internetgateway/controller.go
+++ b/pkg/controller/ec2/internetgateway/controller.go
@@ -154,7 +154,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 
 	meta.SetExternalName(cr, aws.StringValue(ig.InternetGateway.InternetGatewayId))
 
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/ec2/internetgateway/controller_test.go
+++ b/pkg/controller/ec2/internetgateway/controller_test.go
@@ -262,7 +262,7 @@ func TestCreate(t *testing.T) {
 				}),
 					withExternalName(igID),
 					withConditions(xpv1.Creating())),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"FailedRequest": {

--- a/pkg/controller/ec2/natgateway/controller.go
+++ b/pkg/controller/ec2/natgateway/controller.go
@@ -2,6 +2,7 @@ package natgateway
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -47,6 +48,7 @@ func SetupNatGateway(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimite
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.NATGatewayGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: ec2.NewNatGatewayClient}),
+			managed.WithCreationGracePeriod(3*time.Minute),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),

--- a/pkg/controller/ec2/natgateway/controller.go
+++ b/pkg/controller/ec2/natgateway/controller.go
@@ -145,7 +145,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		return managed.ExternalCreation{}, awsclient.Wrap(err, errCreate)
 	}
 	meta.SetExternalName(cr, aws.StringValue(nat.NatGateway.NatGatewayId))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/ec2/natgateway/controller_test.go
+++ b/pkg/controller/ec2/natgateway/controller_test.go
@@ -469,7 +469,7 @@ func TestCreate(t *testing.T) {
 				cr: nat(withExternalName(natGatewayID),
 					withSpec(specNatSpec()),
 				),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"FailedRequest": {

--- a/pkg/controller/ec2/routetable/controller.go
+++ b/pkg/controller/ec2/routetable/controller.go
@@ -18,6 +18,7 @@ package routetable
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -71,6 +72,7 @@ func SetupRouteTable(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimite
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.RouteTableGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: ec2.NewRouteTableClient}),
+			managed.WithCreationGracePeriod(3*time.Minute),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),

--- a/pkg/controller/ec2/routetable/controller.go
+++ b/pkg/controller/ec2/routetable/controller.go
@@ -169,7 +169,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		return managed.ExternalCreation{}, awsclient.Wrap(err, errCreate)
 	}
 	meta.SetExternalName(cr, aws.StringValue(result.RouteTable.RouteTableId))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) { // nolint:gocyclo

--- a/pkg/controller/ec2/routetable/controller_test.go
+++ b/pkg/controller/ec2/routetable/controller_test.go
@@ -214,7 +214,7 @@ func TestCreate(t *testing.T) {
 				cr: rt(withSpec(v1beta1.RouteTableParameters{
 					VPCID: aws.String(vpcID),
 				}), withExternalName(rtID)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"CreateFailed": {

--- a/pkg/controller/ec2/securitygroup/controller.go
+++ b/pkg/controller/ec2/securitygroup/controller.go
@@ -18,6 +18,7 @@ package securitygroup
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -73,6 +74,7 @@ func SetupSecurityGroup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLim
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.SecurityGroupGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: ec2.NewSecurityGroupClient}),
+			managed.WithCreationGracePeriod(3*time.Minute),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),

--- a/pkg/controller/ec2/subnet/controller.go
+++ b/pkg/controller/ec2/subnet/controller.go
@@ -18,6 +18,7 @@ package subnet
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -64,6 +65,7 @@ func SetupSubnet(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) e
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.SubnetGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: ec2.NewSubnetClient}),
+			managed.WithCreationGracePeriod(3*time.Minute),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithConnectionPublishers(),

--- a/pkg/controller/ec2/subnet/controller.go
+++ b/pkg/controller/ec2/subnet/controller.go
@@ -160,7 +160,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 
 	meta.SetExternalName(cr, aws.StringValue(result.Subnet.SubnetId))
 
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/ec2/subnet/controller_test.go
+++ b/pkg/controller/ec2/subnet/controller_test.go
@@ -234,7 +234,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:     subnet(withExternalName(subnetID)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"CreateFailed": {

--- a/pkg/controller/ec2/vpc/controller.go
+++ b/pkg/controller/ec2/vpc/controller.go
@@ -183,7 +183,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 
 	meta.SetExternalName(cr, aws.StringValue(result.Vpc.VpcId))
 
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/ec2/vpc/controller.go
+++ b/pkg/controller/ec2/vpc/controller.go
@@ -19,6 +19,7 @@ package vpc
 import (
 	"context"
 	"sort"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -67,6 +68,7 @@ func SetupVPC(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) erro
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.VPCGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: ec2.NewVPCClient}),
+			managed.WithCreationGracePeriod(3*time.Minute),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient()), &tagger{kube: mgr.GetClient()}),

--- a/pkg/controller/ec2/vpc/controller_test.go
+++ b/pkg/controller/ec2/vpc/controller_test.go
@@ -251,7 +251,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:     vpc(withExternalName(vpcID)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"SuccessfulWithAttributes": {
@@ -282,7 +282,7 @@ func TestCreate(t *testing.T) {
 					withSpec(v1beta1.VPCParameters{
 						EnableDNSSupport: &enableDNS,
 					})),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"CreateFail": {

--- a/pkg/controller/ec2/vpccidrblock/controller.go
+++ b/pkg/controller/ec2/vpccidrblock/controller.go
@@ -171,7 +171,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		}
 	}
 
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(_ context.Context, _ resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/ec2/vpccidrblock/controller.go
+++ b/pkg/controller/ec2/vpccidrblock/controller.go
@@ -18,6 +18,7 @@ package vpccidrblock
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -60,6 +61,7 @@ func SetupVPCCIDRBlock(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimi
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.VPCCIDRBlockGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: ec2.NewVPCCIDRBlockClient}),
+			managed.WithCreationGracePeriod(3*time.Minute),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithConnectionPublishers(),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),

--- a/pkg/controller/ec2/vpccidrblock/controller_test.go
+++ b/pkg/controller/ec2/vpccidrblock/controller_test.go
@@ -274,7 +274,7 @@ func TestCreate(t *testing.T) {
 					CIDRBlock: &cidr,
 					VPCID:     &vpcID,
 				}), withExternalName(matchAssociationID)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"SuccessfulIPv6": {
@@ -303,7 +303,7 @@ func TestCreate(t *testing.T) {
 					IPv6CIDRBlock: &ipv6CIDR,
 					VPCID:         &vpcID,
 				}), withExternalName(matchAssociationID)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"CreateFail": {

--- a/pkg/controller/efs/filesystem/setup.go
+++ b/pkg/controller/efs/filesystem/setup.go
@@ -106,5 +106,5 @@ func postCreate(_ context.Context, cr *svcapitypes.FileSystem, obj *svcsdk.FileS
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, awsclients.StringValue(obj.FileSystemId))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }

--- a/pkg/controller/identity/iamaccesskey/controller.go
+++ b/pkg/controller/identity/iamaccesskey/controller.go
@@ -143,7 +143,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		}
 	}
 	meta.SetExternalName(cr, aws.StringValue(response.AccessKey.AccessKeyId))
-	return managed.ExternalCreation{ExternalNameAssigned: true, ConnectionDetails: conn}, nil
+	return managed.ExternalCreation{ConnectionDetails: conn}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/identity/iamaccesskey/controller_test.go
+++ b/pkg/controller/identity/iamaccesskey/controller_test.go
@@ -263,7 +263,6 @@ func TestCreate(t *testing.T) {
 					withUsername(userName),
 					withAccessKey(accessKeyID)),
 				result: managed.ExternalCreation{
-					ExternalNameAssigned: true,
 					ConnectionDetails: map[string][]byte{
 						xpv1.ResourceCredentialsSecretPasswordKey: []byte(secretKeyID),
 						xpv1.ResourceCredentialsSecretUserKey:     []byte(accessKeyID),

--- a/pkg/controller/identity/iamgrouppolicyattachment/controller.go
+++ b/pkg/controller/identity/iamgrouppolicyattachment/controller.go
@@ -157,7 +157,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 	// names of the group and user that are bound.
 	meta.SetExternalName(cr, cr.Spec.ForProvider.GroupName+"/"+cr.Spec.ForProvider.PolicyARN)
 
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(_ context.Context, _ resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/identity/iamgrouppolicyattachment/controller_test.go
+++ b/pkg/controller/identity/iamgrouppolicyattachment/controller_test.go
@@ -214,7 +214,7 @@ func TestCreate(t *testing.T) {
 					withSpecGroupName(groupName),
 					withSpecPolicyArn(policyArn),
 					withExternalName(groupName+"/"+policyArn)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"InValidInput": {

--- a/pkg/controller/identity/iamgroupusermembership/controller.go
+++ b/pkg/controller/identity/iamgroupusermembership/controller.go
@@ -157,7 +157,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 	// names of the group and user that are bound.
 	meta.SetExternalName(cr, cr.Spec.ForProvider.GroupName+"/"+cr.Spec.ForProvider.UserName)
 
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(_ context.Context, _ resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/identity/iamgroupusermembership/controller_test.go
+++ b/pkg/controller/identity/iamgroupusermembership/controller_test.go
@@ -211,7 +211,7 @@ func TestCreate(t *testing.T) {
 					withSpecGroupName(groupName),
 					withSpecUserName(userName),
 					withExternalName(groupName+"/"+userName)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"InValidInput": {

--- a/pkg/controller/identity/iampolicy/controller.go
+++ b/pkg/controller/identity/iampolicy/controller.go
@@ -162,7 +162,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 
 	meta.SetExternalName(cr, aws.StringValue(createResp.CreatePolicyOutput.Policy.Arn))
 
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/identity/iampolicy/controller_test.go
+++ b/pkg/controller/identity/iampolicy/controller_test.go
@@ -254,7 +254,7 @@ func TestCreate(t *testing.T) {
 						Name:     name,
 					}),
 					withExterName(arn)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"InValidInput": {

--- a/pkg/controller/identity/openidconnectprovider/controller.go
+++ b/pkg/controller/identity/openidconnectprovider/controller.go
@@ -144,7 +144,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 	}
 
 	meta.SetExternalName(cr, aws.StringValue(observed.OpenIDConnectProviderArn))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/identity/openidconnectprovider/controller_test.go
+++ b/pkg/controller/identity/openidconnectprovider/controller_test.go
@@ -257,9 +257,7 @@ func TestCreate(t *testing.T) {
 				cr: oidcProvider(withURL(url), func(provider *svcapitypes.OpenIDConnectProvider) {
 					meta.SetExternalName(provider, providerArn)
 				}),
-				result: managed.ExternalCreation{
-					ExternalNameAssigned: true,
-				},
+				result: managed.ExternalCreation{},
 			},
 		},
 	}

--- a/pkg/controller/kms/key/setup.go
+++ b/pkg/controller/kms/key/setup.go
@@ -84,7 +84,7 @@ func postCreate(_ context.Context, cr *svcapitypes.Key, obj *svcsdk.CreateKeyOut
 		return creation, err
 	}
 	meta.SetExternalName(cr, awsclients.StringValue(obj.KeyMetadata.KeyId))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 type updater struct {

--- a/pkg/controller/notification/snssubscription/controller.go
+++ b/pkg/controller/notification/snssubscription/controller.go
@@ -149,7 +149,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 	}
 
 	meta.SetExternalName(cr, aws.StringValue(res.SubscribeOutput.SubscriptionArn))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/notification/snssubscription/controller_test.go
+++ b/pkg/controller/notification/snssubscription/controller_test.go
@@ -133,7 +133,7 @@ func TestCreate(t *testing.T) {
 			},
 			want: want{
 				cr:     subscription(withSubARN(&subName)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"InValidInput": {

--- a/pkg/controller/notification/snstopic/controller.go
+++ b/pkg/controller/notification/snstopic/controller.go
@@ -139,7 +139,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 	}
 
 	meta.SetExternalName(cr, aws.StringValue(resp.CreateTopicOutput.TopicArn))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/notification/snstopic/controller_test.go
+++ b/pkg/controller/notification/snstopic/controller_test.go
@@ -300,7 +300,7 @@ func TestCreate(t *testing.T) {
 				cr: topic(
 					withDisplayName(&topicDisplayName),
 					withTopicName(&topicName)),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"InValidInput": {

--- a/pkg/controller/route53/hostedzone/controller.go
+++ b/pkg/controller/route53/hostedzone/controller.go
@@ -136,7 +136,7 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalCreation{}, errors.Wrap(errors.New("returned id does not contain /hostedzone/ prefix"), errCreate)
 	}
 	meta.SetExternalName(cr, id[1])
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{}, nil
 }
 
 func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/route53/hostedzone/controller_test.go
+++ b/pkg/controller/route53/hostedzone/controller_test.go
@@ -268,7 +268,7 @@ func TestCreate(t *testing.T) {
 			want: want{
 				cr: instance(
 					withExternalName(strings.SplitAfter(id, hostedzone.IDPrefix)[1])),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{},
 			},
 		},
 		"InValidInput": {

--- a/pkg/controller/sfn/activity/hooks.go
+++ b/pkg/controller/sfn/activity/hooks.go
@@ -79,7 +79,6 @@ func postCreate(_ context.Context, cr *svcapitypes.Activity, resp *svcsdk.Create
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.ActivityArn))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 

--- a/pkg/controller/sfn/statemachine/hooks.go
+++ b/pkg/controller/sfn/statemachine/hooks.go
@@ -91,7 +91,6 @@ func postCreate(_ context.Context, cr *svcapitypes.StateMachine, resp *svcsdk.Cr
 		return managed.ExternalCreation{}, err
 	}
 	meta.SetExternalName(cr, aws.StringValue(resp.StateMachineArn))
-	cre.ExternalNameAssigned = true
 	return cre, nil
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR fixes #802 for the v0.18 release. See https://github.com/crossplane/crossplane-runtime/releases/tag/v0.14.1 and crossplane/crossplane-runtime#283 for more detail.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I tested this change extensively as part of crossplane/crossplane-runtime#283. I've run a cursory version of the same test on this specific PR (i.e. spun a composition of EC2 resources up and down once).