### PR TITLE
fix(dynamodb-table): dynamodb-table sync & reconcile

### DIFF
--- a/examples/dynamodb/backup.yaml
+++ b/examples/dynamodb/backup.yaml
@@ -8,3 +8,5 @@ spec:
     backupName: sample-backup # backup id is used as external-name.
     tableNameRef:
       name: sample-table
+  providerConfigRef:
+    name: example

--- a/examples/dynamodb/globaltable.yaml
+++ b/examples/dynamodb/globaltable.yaml
@@ -7,3 +7,5 @@ spec:
     region: us-east-1
     replicationGroup:
       - regionName: us-east-1
+  providerConfigRef:
+    name: example

--- a/examples/dynamodb/table.yaml
+++ b/examples/dynamodb/table.yaml
@@ -17,3 +17,68 @@ spec:
     streamSpecification:
       streamEnabled: true
       streamViewType: NEW_AND_OLD_IMAGES
+  providerConfigRef:
+    name: example
+  writeConnectionSecretToRef:
+    name: sample-table
+    namespace: crossplane-system
+---
+apiVersion: dynamodb.aws.crossplane.io/v1alpha1
+kind: Table
+metadata:
+  name: sample-table-with-sse
+spec:
+  forProvider:
+    region: us-east-1
+    attributeDefinitions:
+      - attributeName: attribute1
+        attributeType: S
+    keySchema:
+      - attributeName: attribute1
+        keyType: HASH
+    provisionedThroughput:
+      readCapacityUnits: 1
+      writeCapacityUnits: 1
+    sseSpecification:
+      enabled: true
+  providerConfigRef:
+    name: example
+  writeConnectionSecretToRef:
+    name: sample-table-with-sse
+    namespace: crossplane-system
+---
+apiVersion: dynamodb.aws.crossplane.io/v1alpha1
+kind: Table
+metadata:
+  name: sample-table-without-sse
+spec:
+  forProvider:
+    region: us-east-1
+    attributeDefinitions:
+      - attributeName: attribute1
+        attributeType: S
+    keySchema:
+      - attributeName: attribute1
+        keyType: HASH
+    provisionedThroughput:
+      readCapacityUnits: 1
+      writeCapacityUnits: 1
+  providerConfigRef:
+    name: example
+---
+apiVersion: dynamodb.aws.crossplane.io/v1alpha1
+kind: Table
+metadata:
+  name: sample-table-ppr
+spec:
+  forProvider:
+    region: us-east-1
+    attributeDefinitions:
+      - attributeName: attribute1
+        attributeType: S
+    keySchema:
+      - attributeName: attribute1
+        keyType: HASH
+    billingMode: PAY_PER_REQUEST
+  providerConfigRef:
+    name: example


### PR DESCRIPTION
Signed-off-by: Christopher Haar <chhaar30@googlemail.com>

### Description of your changes

- implemented postUpdate
- implemented connectionSecret
- implemented in preUpdate SSESpecification, BillingMode
- implemented for SSESpecification lateInit to get kms keyarn

Fixes #580 #637

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
added new examples from #580 and tested create, update & deletion

```
kubectl get tables
NAME                       READY   SYNCED   EXTERNAL-NAME
sample-table-ppr           True    True     sample-table-ppr
sample-table-with-sse      True    True     sample-table-with-sse
sample-table-with-stream   True    True     sample-table-with-stream
sample-table-without-sse   True    True     sample-table-without-sse
```

![image](https://user-images.githubusercontent.com/21083497/134140473-824621bb-15fb-47ec-a25a-4c6d60868c9b.png)


connection secret is now possible: for LatestStreamArn, LatestStreamLabel, TableArn, TableName

stream_enabled = true
```
kubectl get secret sample-table-with-stream -n crossplane-system -o yaml
apiVersion: v1
data:
  LatestStreamArn: YXJuOmF3czpkeW5hbW9kYjpldS1jZW50cmFsLTE6MjU1OTMyNjQyOTI3OnRhYmxlL3NhbXBsZS10YWJsZS13aXRoLXN0cmVhbS9zdHJlYW0vMjAyMS0wOS0yMVQwODowMjoxMy4yNjU=
  LatestStreamLabel: MjAyMS0wOS0yMVQwODowMjoxMy4yNjU=
  TableArn: YXJuOmF3czpkeW5hbW9kYjpldS1jZW50cmFsLTE6MjU1OTMyNjQyOTI3OnRhYmxlL3NhbXBsZS10YWJsZS13aXRoLXN0cmVhbQ==
  TableName: c2FtcGxlLXRhYmxlLXdpdGgtc3RyZWFt
kind: Secret
...
```

stream_enabled = false
```
kubectl get secret sample-table-with-sse -n crossplane-system -o yaml
apiVersion: v1
data:
  LatestStreamArn: ""
  LatestStreamLabel: ""
  TableArn: YXJuOmF3czpkeW5hbW9kYjpldS1jZW50cmFsLTE6MjU1OTMyNjQyOTI3OnRhYmxlL3NhbXBsZS10YWJsZS13aXRoLXNzZQ==
  TableName: c2FtcGxlLXRhYmxlLXdpdGgtc3Nl
kind: Secret
```