### PR TITLE
elasticache: Scale replicationgroup shards

### DIFF
--- a/pkg/clients/elasticache/fake/fake.go
+++ b/pkg/clients/elasticache/fake/fake.go
@@ -40,6 +40,8 @@ type MockClient struct {
 	MockCreateCacheCluster    func(context.Context, *elasticache.CreateCacheClusterInput, []func(*elasticache.Options)) (*elasticache.CreateCacheClusterOutput, error)
 	MockDeleteCacheCluster    func(context.Context, *elasticache.DeleteCacheClusterInput, []func(*elasticache.Options)) (*elasticache.DeleteCacheClusterOutput, error)
 	MockModifyCacheCluster    func(context.Context, *elasticache.ModifyCacheClusterInput, []func(*elasticache.Options)) (*elasticache.ModifyCacheClusterOutput, error)
+
+	MockModifyReplicationGroupShardConfiguration func(context.Context, *elasticache.ModifyReplicationGroupShardConfigurationInput, []func(*elasticache.Options)) (*elasticache.ModifyReplicationGroupShardConfigurationOutput, error)
 }
 
 // DescribeReplicationGroups calls the underlying
@@ -70,6 +72,12 @@ func (c *MockClient) DeleteReplicationGroup(ctx context.Context, i *elasticache.
 // MockDescribeCacheClusters method.
 func (c *MockClient) DescribeCacheClusters(ctx context.Context, i *elasticache.DescribeCacheClustersInput, opts ...func(*elasticache.Options)) (*elasticache.DescribeCacheClustersOutput, error) {
 	return c.MockDescribeCacheClusters(ctx, i, opts)
+}
+
+// ModifyReplicationGroupShardConfiguration calls the underlying
+// MockModifyReplicationGroupShardConfiguration method.
+func (c *MockClient) ModifyReplicationGroupShardConfiguration(ctx context.Context, i *elasticache.ModifyReplicationGroupShardConfigurationInput, opts ...func(*elasticache.Options)) (*elasticache.ModifyReplicationGroupShardConfigurationOutput, error) {
+	return c.MockModifyReplicationGroupShardConfiguration(ctx, i, opts)
 }
 
 // DescribeCacheSubnetGroups calls the underlying


### PR DESCRIPTION
### Description of your changes
Scale up and down replication groups as requested by the user.

On scale down, the AWS API requires us to pick the nodes to remove. I have not considered what the best option is, I picked the first node in the list.

Co-authored-by: sb1-oscar <sb1-oscar@users.noreply.github.com>

Fixes #531

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested changing the CR to scale up/down. I will have to retest since this PR has been rebased and it's a while since I wrote it.

[contribution process]: https://git.io/fj2m9
