### PR TITLE
chore: breaking GENERATED_SERVICES var into multiline 861

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,22 @@ PROJECT_REPO := github.com/crossplane/$(PROJECT_NAME)
 PLATFORMS ?= linux_amd64 linux_arm64
 
 CODE_GENERATOR_COMMIT ?= cac5654b7bb64c8f754ad9af01799ef70d9541b6
-GENERATED_SERVICES="apigatewayv2,cloudfront,dynamodb,efs,glue,kafka,kms,lambda,rds,secretsmanager,servicediscovery,sfn,transfer"
+define SERVICES
+apigatewayv2,
+cloudfront,
+dynamodb,
+efs,
+glue,
+kafka,
+kms,
+lambda,
+rds,
+secretsmanager,
+servicediscovery,
+sfn,
+transfer
+endef
+GENERATED_SERVICES := $(shell echo $(SERVICES) | tr '\n' ' ')
 
 # kind-related versions
 KIND_VERSION ?= v0.11.1


### PR DESCRIPTION
### Description of your changes
Broke up the generated_services variable into multiple lines using the second suggested solution. 

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
created an `all` block and verified the output of the changes to be the same are the original static variable

[contribution process]: https://git.io/fj2m9
