### PR TITLE
#868 Fix broken handling of errors after aws-sdk-v2 migration

### DIFF
--- a/pkg/clients/acm/certificate.go
+++ b/pkg/clients/acm/certificate.go
@@ -2,6 +2,7 @@ package acm
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -164,6 +165,6 @@ func IsCertificateUpToDate(p v1alpha1.CertificateParameters, cd types.Certificat
 
 // IsErrorNotFound returns true if the error code indicates that the item was not found
 func IsErrorNotFound(err error) bool {
-	_, ok := err.(*acmtypes.ResourceNotFoundException)
-	return ok
+	var notFoundError *acmtypes.ResourceNotFoundException
+	return errors.As(err, &notFoundError)
 }

--- a/pkg/clients/ec2/address.go
+++ b/pkg/clients/ec2/address.go
@@ -2,6 +2,7 @@ package ec2
 
 import (
 	"context"
+	"errors"
 	"sort"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -30,7 +31,8 @@ type AddressClient interface {
 
 // IsAddressNotFoundErr returns true if the error is because the address doesn't exist
 func IsAddressNotFoundErr(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == AddressAddressNotFound || awsErr.ErrorCode() == AddressAllocationNotFound {
 			return true
 		}

--- a/pkg/clients/ec2/instance.go
+++ b/pkg/clients/ec2/instance.go
@@ -15,6 +15,7 @@ package ec2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -22,7 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/smithy-go"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/crossplane/provider-aws/apis/ec2/manualv1alpha1"
@@ -51,8 +52,9 @@ func NewInstanceClient(cfg aws.Config) InstanceClient {
 
 // IsInstanceNotFoundErr returns true if the error is because the item doesn't exist
 func IsInstanceNotFoundErr(err error) bool {
-	if awsErr, ok := err.(awserr.Error); ok {
-		if awsErr.Code() == InstanceNotFound {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
+		if awsErr.ErrorCode() == InstanceNotFound {
 			return true
 		}
 	}

--- a/pkg/clients/ec2/internetgateway.go
+++ b/pkg/clients/ec2/internetgateway.go
@@ -2,6 +2,7 @@ package ec2
 
 import (
 	"context"
+	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -37,7 +38,8 @@ func NewInternetGatewayClient(cfg aws.Config) InternetGatewayClient {
 
 // IsInternetGatewayNotFoundErr returns true if the error is because the item doesn't exist
 func IsInternetGatewayNotFoundErr(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == InternetGatewayIDNotFound {
 			return true
 		}
@@ -47,7 +49,8 @@ func IsInternetGatewayNotFoundErr(err error) bool {
 
 // IsInternetGatewayAlreadyAttached returns true if the error is because the item doesn't exist
 func IsInternetGatewayAlreadyAttached(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == InternetGatewayAlreadyAttached {
 			return true
 		}

--- a/pkg/clients/ec2/natgateway.go
+++ b/pkg/clients/ec2/natgateway.go
@@ -2,6 +2,7 @@ package ec2
 
 import (
 	"context"
+	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -35,7 +36,8 @@ func NewNatGatewayClient(cfg aws.Config) NatGatewayClient {
 
 // IsNatGatewayNotFoundErr returns true if the error is because the item doesn't exist
 func IsNatGatewayNotFoundErr(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == NatGatewayNotFound {
 			return true
 		}

--- a/pkg/clients/ec2/routetable.go
+++ b/pkg/clients/ec2/routetable.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sort"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -52,7 +53,8 @@ func NewRouteTableClient(cfg aws.Config) RouteTableClient {
 
 // IsRouteTableNotFoundErr returns true if the error is because the route table doesn't exist
 func IsRouteTableNotFoundErr(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == RouteTableIDNotFound {
 			return true
 		}
@@ -62,7 +64,8 @@ func IsRouteTableNotFoundErr(err error) bool {
 
 // IsRouteNotFoundErr returns true if the error is because the route doesn't exist
 func IsRouteNotFoundErr(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == RouteNotFound {
 			return true
 		}
@@ -72,7 +75,8 @@ func IsRouteNotFoundErr(err error) bool {
 
 // IsAssociationIDNotFoundErr returns true if the error is because the association doesn't exist
 func IsAssociationIDNotFoundErr(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == AssociationIDNotFound {
 			return true
 		}

--- a/pkg/clients/ec2/securitygroup.go
+++ b/pkg/clients/ec2/securitygroup.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sort"
 	"strings"
 
@@ -47,7 +48,8 @@ func NewSecurityGroupClient(cfg awsgo.Config) SecurityGroupClient {
 
 // IsSecurityGroupNotFoundErr returns true if the error is because the item doesn't exist
 func IsSecurityGroupNotFoundErr(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == InvalidGroupNotFound {
 			return true
 		}
@@ -57,7 +59,8 @@ func IsSecurityGroupNotFoundErr(err error) bool {
 
 // IsRuleAlreadyExistsErr returns true if the error is because the rule already exists.
 func IsRuleAlreadyExistsErr(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == InvalidPermissionDuplicate {
 			return true
 		}

--- a/pkg/clients/ec2/subnet.go
+++ b/pkg/clients/ec2/subnet.go
@@ -2,6 +2,7 @@ package ec2
 
 import (
 	"context"
+	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -33,7 +34,8 @@ func NewSubnetClient(cfg aws.Config) SubnetClient {
 
 // IsSubnetNotFoundErr returns true if the error is because the item doesn't exist
 func IsSubnetNotFoundErr(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == SubnetIDNotFound {
 			return true
 		}

--- a/pkg/clients/ec2/vpc.go
+++ b/pkg/clients/ec2/vpc.go
@@ -2,6 +2,7 @@ package ec2
 
 import (
 	"context"
+	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -35,7 +36,8 @@ func NewVPCClient(cfg aws.Config) VPCClient {
 
 // IsVPCNotFoundErr returns true if the error is because the item doesn't exist
 func IsVPCNotFoundErr(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == VPCIDNotFound {
 			return true
 		}

--- a/pkg/clients/ec2/vpccidrblock.go
+++ b/pkg/clients/ec2/vpccidrblock.go
@@ -2,12 +2,12 @@ package ec2
 
 import (
 	"context"
+	"errors"
 
 	awsgo "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 
 	"github.com/crossplane/provider-aws/apis/ec2/manualv1alpha1"
 	awsclient "github.com/crossplane/provider-aws/pkg/clients"
@@ -39,16 +39,8 @@ func (r *CIDRNotFoundError) Error() string {
 
 // IsCIDRNotFound returns true if the error code indicates that the CIDR Block Association was not found
 func IsCIDRNotFound(err error) bool {
-	if _, ok := err.(*CIDRNotFoundError); ok {
-		return true
-	}
-
-	if awsErr, ok := err.(awserr.Error); ok {
-		if awsErr.Code() == errCIDRAssociationNotFound {
-			return true
-		}
-	}
-	return false
+	var notFoundError *CIDRNotFoundError
+	return errors.As(err, &notFoundError)
 }
 
 // IsVpcCidrBlockUpToDate returns true if there is no update-able difference between desired

--- a/pkg/clients/ec2/vpccidrblock.go
+++ b/pkg/clients/ec2/vpccidrblock.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/smithy-go"
 
 	"github.com/crossplane/provider-aws/apis/ec2/manualv1alpha1"
 	awsclient "github.com/crossplane/provider-aws/pkg/clients"
@@ -40,7 +41,16 @@ func (r *CIDRNotFoundError) Error() string {
 // IsCIDRNotFound returns true if the error code indicates that the CIDR Block Association was not found
 func IsCIDRNotFound(err error) bool {
 	var notFoundError *CIDRNotFoundError
-	return errors.As(err, &notFoundError)
+	if errors.As(err, &notFoundError) {
+		return true
+	}
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
+		if awsErr.ErrorCode() == errCIDRAssociationNotFound {
+			return true
+		}
+	}
+	return false
 }
 
 // IsVpcCidrBlockUpToDate returns true if there is no update-able difference between desired

--- a/pkg/clients/ecr/repository.go
+++ b/pkg/clients/ecr/repository.go
@@ -3,6 +3,7 @@ package ecr
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sort"
 	"strings"
 
@@ -105,8 +106,8 @@ func IsRepositoryUpToDate(e *v1alpha1.RepositoryParameters, tags []ecrtypes.Tag,
 
 // IsRepoNotFoundErr returns true if the error is because the item doesn't exist
 func IsRepoNotFoundErr(err error) bool {
-	_, ok := err.(*ecrtypes.RepositoryNotFoundException)
-	return ok
+	var notFoundError *ecrtypes.RepositoryNotFoundException
+	return errors.As(err, &notFoundError)
 }
 
 // GenerateCreateRepositoryInput Generates the CreateRepositoryInput from the RepositoryParameters

--- a/pkg/clients/ecr/repository_policy.go
+++ b/pkg/clients/ecr/repository_policy.go
@@ -48,8 +48,8 @@ func LateInitializeRepositoryPolicy(in *v1alpha1.RepositoryPolicyParameters, r *
 
 // IsPolicyNotFoundErr returns true if the error code indicates that the policy was not found
 func IsPolicyNotFoundErr(err error) bool {
-	_, ok := err.(*awsecrtypes.RepositoryPolicyNotFoundException)
-	return ok
+	var notFoundError *awsecrtypes.RepositoryPolicyNotFoundException
+	return errors.As(err, &notFoundError)
 }
 
 // Serialize is the custom marshaller for the RepositoryPolicyBody

--- a/pkg/clients/iam/iam.go
+++ b/pkg/clients/iam/iam.go
@@ -2,6 +2,7 @@ package iam
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -222,14 +223,14 @@ func (c *iamClient) attachPolicyToUser(policyName string, username string) error
 }
 
 func isErrorAlreadyExists(err error) bool {
-	_, ok := err.(*iamtypes.EntityAlreadyExistsException)
-	return ok
+	var notFoundError *iamtypes.EntityAlreadyExistsException
+	return errors.As(err, &notFoundError)
 }
 
 // IsErrorNotFound returns true if the error code indicates that the item was not found
 func IsErrorNotFound(err error) bool {
-	_, ok := err.(*iamtypes.NoSuchEntityException)
-	return ok
+	var notFoundError *iamtypes.NoSuchEntityException
+	return errors.As(err, &notFoundError)
 }
 
 // PolicyDocument is the structure of IAM policy document

--- a/pkg/clients/resourcerecordset/resourcerecordset.go
+++ b/pkg/clients/resourcerecordset/resourcerecordset.go
@@ -19,6 +19,7 @@ package resourcerecordset
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -56,8 +57,8 @@ func (r *NotFoundError) Error() string {
 
 // IsNotFound returns true if the error code indicates that the requested Resource Record was not found
 func IsNotFound(err error) bool {
-	_, ok := err.(*NotFoundError)
-	return ok
+	var notFoundError *NotFoundError
+	return errors.As(err, &notFoundError)
 }
 
 // NewClient creates new AWS client with provided AWS Configuration/Credentials

--- a/pkg/clients/s3/bucket.go
+++ b/pkg/clients/s3/bucket.go
@@ -125,8 +125,8 @@ func IsNotFound(err error) bool {
 
 // IsAlreadyExists helper function to test for ErrCodeBucketAlreadyOwnedByYou error
 func IsAlreadyExists(err error) bool {
-	var notFoundError *s3types.BucketAlreadyOwnedByYou
-	return errors.As(err, &notFoundError)
+	var alreadyOwnedByYou *s3types.BucketAlreadyOwnedByYou
+	return errors.As(err, &alreadyOwnedByYou)
 }
 
 // GenerateCreateBucketInput creates the input for CreateBucket S3 Client request
@@ -156,7 +156,8 @@ func GenerateBucketObservation(name string) v1beta1.BucketExternalStatus {
 
 // CORSConfigurationNotFound is parses the aws Error and validates if the cors configuration does not exist
 func CORSConfigurationNotFound(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == CORSNotFoundErrCode {
 			return true
 		}
@@ -166,7 +167,8 @@ func CORSConfigurationNotFound(err error) bool {
 
 // ReplicationConfigurationNotFound is parses the aws Error and validates if the replication configuration does not exist
 func ReplicationConfigurationNotFound(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == ReplicationNotFoundErrCode {
 			return true
 		}
@@ -176,7 +178,8 @@ func ReplicationConfigurationNotFound(err error) bool {
 
 // PublicAccessBlockConfigurationNotFound is parses the aws Error and validates if the public access block does not exist
 func PublicAccessBlockConfigurationNotFound(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == PublicAccessBlockNotFoundErrCode {
 			return true
 		}
@@ -186,7 +189,8 @@ func PublicAccessBlockConfigurationNotFound(err error) bool {
 
 // LifecycleConfigurationNotFound is parses the aws Error and validates if the lifecycle configuration does not exist
 func LifecycleConfigurationNotFound(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == LifecycleNotFoundErrCode {
 			return true
 		}
@@ -196,7 +200,8 @@ func LifecycleConfigurationNotFound(err error) bool {
 
 // SSEConfigurationNotFound is parses the aws Error and validates if the SSE configuration does not exist
 func SSEConfigurationNotFound(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == SSENotFoundErrCode {
 			return true
 		}
@@ -206,7 +211,8 @@ func SSEConfigurationNotFound(err error) bool {
 
 // TaggingNotFound is parses the aws Error and validates if the tagging configuration does not exist
 func TaggingNotFound(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == TaggingNotFoundErrCode {
 			return true
 		}
@@ -216,7 +222,8 @@ func TaggingNotFound(err error) bool {
 
 // WebsiteConfigurationNotFound is parses the aws Error and validates if the website configuration does not exist
 func WebsiteConfigurationNotFound(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == WebsiteNotFoundErrCode {
 			return true
 		}
@@ -226,7 +233,8 @@ func WebsiteConfigurationNotFound(err error) bool {
 
 // MethodNotSupported is parses the aws Error and validates if the method is allowed for a request
 func MethodNotSupported(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == MethodNotAllowed {
 			return true
 		}
@@ -236,7 +244,8 @@ func MethodNotSupported(err error) bool {
 
 // ArgumentNotSupported is parses the aws Error and validates if parameters are now allowed for a request
 func ArgumentNotSupported(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == UnsupportedArgument {
 			return true
 		}

--- a/pkg/clients/s3/bucket.go
+++ b/pkg/clients/s3/bucket.go
@@ -18,6 +18,7 @@ package s3
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -118,14 +119,14 @@ func NewClient(cfg aws.Config) BucketClient {
 
 // IsNotFound helper function to test for NotFound error
 func IsNotFound(err error) bool {
-	_, ok := err.(*s3types.NoSuchBucket)
-	return ok
+	var notFoundError *s3types.NoSuchBucket
+	return errors.As(err, &notFoundError)
 }
 
 // IsAlreadyExists helper function to test for ErrCodeBucketAlreadyOwnedByYou error
 func IsAlreadyExists(err error) bool {
-	_, ok := err.(*s3types.BucketAlreadyOwnedByYou)
-	return ok
+	var notFoundError *s3types.BucketAlreadyOwnedByYou
+	return errors.As(err, &notFoundError)
 }
 
 // GenerateCreateBucketInput creates the input for CreateBucket S3 Client request

--- a/pkg/clients/s3/bucketpolicy.go
+++ b/pkg/clients/s3/bucketpolicy.go
@@ -43,8 +43,9 @@ func NewBucketPolicyClient(cfg aws.Config) BucketPolicyClient {
 
 // IsErrorPolicyNotFound returns true if the error code indicates that the item was not found
 func IsErrorPolicyNotFound(err error) bool {
-	if s3Err, ok := err.(smithy.APIError); ok {
-		if s3Err.ErrorCode() == "NoSuchBucketPolicy" {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
+		if awsErr.ErrorCode() == "NoSuchBucketPolicy" {
 			return true
 		}
 	}

--- a/pkg/clients/sqs/queue.go
+++ b/pkg/clients/sqs/queue.go
@@ -19,6 +19,7 @@ package sqs
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strconv"
 	"strings"
 	"time"
@@ -145,7 +146,8 @@ func GenerateQueueObservation(url string, attr map[string]string) v1beta1.QueueO
 
 // IsNotFound checks if the error returned by AWS API says that the queue being probed doesn't exist
 func IsNotFound(err error) bool {
-	if awsErr, ok := err.(smithy.APIError); ok {
+	var awsErr smithy.APIError
+	if errors.As(err, &awsErr) {
 		if awsErr.ErrorCode() == QueueNotFound {
 			return true
 		}


### PR DESCRIPTION
### Description of your changes
Fixes #868

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Tested ec2.SecurityGroup, ECR.Repository, ECR.RepositoryPolicy and S3.Bucket.

Tested ok in our environment with a fork, where it previously failed.
We are not running all the affected types, so not every change has been thoroughly tested.
