### PR TITLE
Add Ipv6CIDRBlock support in VPC

### DIFF
--- a/apis/ec2/v1beta1/vpc_types.go
+++ b/apis/ec2/v1beta1/vpc_types.go
@@ -81,6 +81,20 @@ type VPCParameters struct {
 	// +immutable
 	CIDRBlock string `json:"cidrBlock"`
 
+	// The IPv6 CIDR block from the IPv6 address pool. You must also specify Ipv6Pool
+	// in the request. To let Amazon choose the IPv6 CIDR block for you, omit this
+	// parameter.
+	// +optional
+	// +immutable
+	Ipv6CIDRBlock *string `json:"ipv6CIDRBlock,omitempty"`
+
+	// Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the
+	// VPC. You cannot specify the range of IP addresses, or the size of the CIDR
+	// block.
+	// +optional
+	// +immutable
+	AmazonProvidedIpv6CIDRBlock *bool `json:"amazonProvidedIpv6CIDRBlock,omitempty"`
+
 	// A boolean flag to enable/disable DNS support in the VPC
 	// +optional
 	EnableDNSSupport *bool `json:"enableDnsSupport,omitempty"`

--- a/apis/ec2/v1beta1/vpc_types.go
+++ b/apis/ec2/v1beta1/vpc_types.go
@@ -86,14 +86,14 @@ type VPCParameters struct {
 	// parameter.
 	// +optional
 	// +immutable
-	Ipv6CIDRBlock *string `json:"ipv6CIDRBlock,omitempty"`
+	Ipv6CIDRBlock *string `json:"ipv6CidrBlock,omitempty"`
 
 	// Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the
 	// VPC. You cannot specify the range of IP addresses, or the size of the CIDR
 	// block.
 	// +optional
 	// +immutable
-	AmazonProvidedIpv6CIDRBlock *bool `json:"amazonProvidedIpv6CIDRBlock,omitempty"`
+	AmazonProvidedIpv6CIDRBlock *bool `json:"amazonProvidedIpv6CidrBlock,omitempty"`
 
 	// The ID of an IPv6 address pool from which to allocate the IPv6 CIDR block.
 	// +optional
@@ -157,6 +157,7 @@ type VPCStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:printcolumn:name="CIDR",type="string",JSONPath=".spec.forProvider.cidrBlock"
+// +kubebuilder:printcolumn:name="IPV6CIDR",type="string",JSONPath=".spec.forProvider.ipv6CidrBlock"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}

--- a/apis/ec2/v1beta1/vpc_types.go
+++ b/apis/ec2/v1beta1/vpc_types.go
@@ -95,6 +95,11 @@ type VPCParameters struct {
 	// +immutable
 	AmazonProvidedIpv6CIDRBlock *bool `json:"amazonProvidedIpv6CIDRBlock,omitempty"`
 
+	// The ID of an IPv6 address pool from which to allocate the IPv6 CIDR block.
+	// +optional
+	// +immutable
+	Ipv6Pool *string `json:"ipv6Pool,omitempty"`
+
 	// A boolean flag to enable/disable DNS support in the VPC
 	// +optional
 	EnableDNSSupport *bool `json:"enableDnsSupport,omitempty"`

--- a/apis/ec2/v1beta1/zz_generated.deepcopy.go
+++ b/apis/ec2/v1beta1/zz_generated.deepcopy.go
@@ -1693,6 +1693,11 @@ func (in *VPCParameters) DeepCopyInto(out *VPCParameters) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Ipv6Pool != nil {
+		in, out := &in.Ipv6Pool, &out.Ipv6Pool
+		*out = new(string)
+		**out = **in
+	}
 	if in.EnableDNSSupport != nil {
 		in, out := &in.EnableDNSSupport, &out.EnableDNSSupport
 		*out = new(bool)

--- a/apis/ec2/v1beta1/zz_generated.deepcopy.go
+++ b/apis/ec2/v1beta1/zz_generated.deepcopy.go
@@ -1683,6 +1683,16 @@ func (in *VPCParameters) DeepCopyInto(out *VPCParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Ipv6CIDRBlock != nil {
+		in, out := &in.Ipv6CIDRBlock, &out.Ipv6CIDRBlock
+		*out = new(string)
+		**out = **in
+	}
+	if in.AmazonProvidedIpv6CIDRBlock != nil {
+		in, out := &in.AmazonProvidedIpv6CIDRBlock, &out.AmazonProvidedIpv6CIDRBlock
+		*out = new(bool)
+		**out = **in
+	}
 	if in.EnableDNSSupport != nil {
 		in, out := &in.EnableDNSSupport, &out.EnableDNSSupport
 		*out = new(bool)

--- a/package/crds/ec2.aws.crossplane.io_vpcs.yaml
+++ b/package/crds/ec2.aws.crossplane.io_vpcs.yaml
@@ -31,6 +31,9 @@ spec:
     - jsonPath: .spec.forProvider.cidrBlock
       name: CIDR
       type: string
+    - jsonPath: .spec.forProvider.ipv6CidrBlock
+      name: IPV6CIDR
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
@@ -68,7 +71,7 @@ spec:
                 description: VPCParameters define the desired state of an AWS Virtual
                   Private Cloud.
                 properties:
-                  amazonProvidedIpv6CIDRBlock:
+                  amazonProvidedIpv6CidrBlock:
                     description: Requests an Amazon-provided IPv6 CIDR block with
                       a /56 prefix length for the VPC. You cannot specify the range
                       of IP addresses, or the size of the CIDR block.
@@ -89,7 +92,7 @@ spec:
                     description: The allowed tenancy of instances launched into the
                       VPC.
                     type: string
-                  ipv6CIDRBlock:
+                  ipv6CidrBlock:
                     description: The IPv6 CIDR block from the IPv6 address pool. You
                       must also specify Ipv6Pool in the request. To let Amazon choose
                       the IPv6 CIDR block for you, omit this parameter.

--- a/package/crds/ec2.aws.crossplane.io_vpcs.yaml
+++ b/package/crds/ec2.aws.crossplane.io_vpcs.yaml
@@ -94,6 +94,10 @@ spec:
                       must also specify Ipv6Pool in the request. To let Amazon choose
                       the IPv6 CIDR block for you, omit this parameter.
                     type: string
+                  ipv6Pool:
+                    description: The ID of an IPv6 address pool from which to allocate
+                      the IPv6 CIDR block.
+                    type: string
                   region:
                     description: Region is the region you'd like your VPC to be created
                       in.

--- a/package/crds/ec2.aws.crossplane.io_vpcs.yaml
+++ b/package/crds/ec2.aws.crossplane.io_vpcs.yaml
@@ -68,6 +68,11 @@ spec:
                 description: VPCParameters define the desired state of an AWS Virtual
                   Private Cloud.
                 properties:
+                  amazonProvidedIpv6CIDRBlock:
+                    description: Requests an Amazon-provided IPv6 CIDR block with
+                      a /56 prefix length for the VPC. You cannot specify the range
+                      of IP addresses, or the size of the CIDR block.
+                    type: boolean
                   cidrBlock:
                     description: CIDRBlock is the IPv4 network range for the VPC,
                       in CIDR notation. For example, 10.0.0.0/16.
@@ -83,6 +88,11 @@ spec:
                   instanceTenancy:
                     description: The allowed tenancy of instances launched into the
                       VPC.
+                    type: string
+                  ipv6CIDRBlock:
+                    description: The IPv6 CIDR block from the IPv6 address pool. You
+                      must also specify Ipv6Pool in the request. To let Amazon choose
+                      the IPv6 CIDR block for you, omit this parameter.
                     type: string
                   region:
                     description: Region is the region you'd like your VPC to be created

--- a/pkg/clients/ec2/vpc.go
+++ b/pkg/clients/ec2/vpc.go
@@ -107,6 +107,10 @@ func LateInitializeVPC(in *v1beta1.VPCParameters, v *ec2types.Vpc, attributes *e
 
 	in.CIDRBlock = awsclients.LateInitializeString(in.CIDRBlock, v.CidrBlock)
 	in.InstanceTenancy = awsclients.LateInitializeStringPtr(in.InstanceTenancy, aws.String(string(v.InstanceTenancy)))
+	if len(v.Ipv6CidrBlockAssociationSet) != 0 {
+		ipv6Association := v.Ipv6CidrBlockAssociationSet[0]
+		in.Ipv6CIDRBlock = awsclients.LateInitializeStringPtr(in.Ipv6CIDRBlock, ipv6Association.Ipv6CidrBlock)
+	}
 	if attributes.EnableDnsHostnames != nil {
 		in.EnableDNSHostNames = awsclients.LateInitializeBoolPtr(in.EnableDNSHostNames, attributes.EnableDnsHostnames.Value)
 	}

--- a/pkg/controller/ec2/vpc/controller.go
+++ b/pkg/controller/ec2/vpc/controller.go
@@ -188,8 +188,10 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 	}
 
 	result, err := e.client.CreateVpc(ctx, &awsec2.CreateVpcInput{
-		CidrBlock:       aws.String(cr.Spec.ForProvider.CIDRBlock),
-		InstanceTenancy: awsec2types.Tenancy(aws.ToString(cr.Spec.ForProvider.InstanceTenancy)),
+		CidrBlock:                   aws.String(cr.Spec.ForProvider.CIDRBlock),
+		Ipv6CidrBlock:               cr.Spec.ForProvider.Ipv6CIDRBlock,
+		AmazonProvidedIpv6CidrBlock: cr.Spec.ForProvider.AmazonProvidedIpv6CIDRBlock,
+		InstanceTenancy:             awsec2types.Tenancy(aws.ToString(cr.Spec.ForProvider.InstanceTenancy)),
 	})
 	if err != nil {
 		return managed.ExternalCreation{}, awsclient.Wrap(err, errCreate)

--- a/pkg/controller/ec2/vpc/controller.go
+++ b/pkg/controller/ec2/vpc/controller.go
@@ -191,6 +191,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		CidrBlock:                   aws.String(cr.Spec.ForProvider.CIDRBlock),
 		Ipv6CidrBlock:               cr.Spec.ForProvider.Ipv6CIDRBlock,
 		AmazonProvidedIpv6CidrBlock: cr.Spec.ForProvider.AmazonProvidedIpv6CIDRBlock,
+		Ipv6Pool:                    cr.Spec.ForProvider.Ipv6Pool,
 		InstanceTenancy:             awsec2types.Tenancy(aws.ToString(cr.Spec.ForProvider.InstanceTenancy)),
 	})
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: vaspahomov <vas2142553@gmail.com>

### Description of your changes

Add support IpV6CIDRBlock, AmazonProvidedIpv6CIDRBlock options in VPC. Feature allows create ipv6 nets in aws. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manualy tested on my crossplane/provider-aws installation

[contribution process]: https://git.io/fj2m9
