### PR TITLE
Make ec2 Instance IAMInstanceProfileSpecification fields optional

### DIFF
--- a/apis/ec2/manualv1alpha1/common.go
+++ b/apis/ec2/manualv1alpha1/common.go
@@ -304,12 +304,15 @@ type IAMInstanceProfile struct {
 }
 
 // IAMInstanceProfileSpecification describes an IAM instance profile.
+// Use one of 'arn' or 'name'.
 type IAMInstanceProfileSpecification struct {
 	// The Amazon Resource Name (ARN) of the instance profile.
-	ARN *string `json:"arn"`
+	// +optional
+	ARN *string `json:"arn,omitempty"`
 
 	// The name of the instance profile.
-	Name *string `json:"name"`
+	// +optional
+	Name *string `json:"name,omitempty"`
 }
 
 // InstanceBlockDeviceMapping describes a block device mapping.

--- a/package/crds/ec2.aws.crossplane.io_instances.yaml
+++ b/package/crds/ec2.aws.crossplane.io_instances.yaml
@@ -345,9 +345,6 @@ spec:
                       name:
                         description: The name of the instance profile.
                         type: string
-                    required:
-                    - arn
-                    - name
                     type: object
                   imageId:
                     description: The ID of the AMI. An AMI ID is required to launch


### PR DESCRIPTION
Signed-off-by: vaspahomov <vas2142553@gmail.com>

### Description of your changes

Make Name and Arn fields of IAMInstanceProfileSpecification optional.
Aws api required only one of this fields specified but not both. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually tested on my crossplane/provider-aws installation

[contribution process]: https://git.io/fj2m9
