### PR TITLE
Implements private nat-gateway

### DIFF
--- a/apis/ec2/v1beta1/natgateway_types.go
+++ b/apis/ec2/v1beta1/natgateway_types.go
@@ -56,6 +56,12 @@ type NATGatewayParameters struct {
 	// +optional
 	SubnetIDSelector *xpv1.Selector `json:"subnetIdSelector,omitempty"`
 
+	// Indicates whether the NAT gateway supports public or private connectivity. The
+	// default is public connectivity.
+	// +optional
+	// +kubebuilder:validation:Enum=public;private
+	ConnectivityType string `json:"connectivityType,omitempty"`
+
 	// Tags represents to current ec2 tags.
 	// +optional
 	Tags []Tag `json:"tags,omitempty"`

--- a/examples/ec2/private-natgateway.yaml
+++ b/examples/ec2/private-natgateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: ec2.aws.crossplane.io/v1beta1
+kind: NATGateway
+metadata:
+  name: private-natgateway
+spec:
+  forProvider:
+    region: us-east-1
+    connectivityType: private
+    subnetIdRef:
+      name: sample-subnet1
+    tags:
+      - key: Name
+        value: private-natgateway
+  providerConfigRef:
+    name: example

--- a/package/crds/ec2.aws.crossplane.io_natgateways.yaml
+++ b/package/crds/ec2.aws.crossplane.io_natgateways.yaml
@@ -102,6 +102,13 @@ spec:
                           is selected.
                         type: object
                     type: object
+                  connectivityType:
+                    description: Indicates whether the NAT gateway supports public
+                      or private connectivity. The default is public connectivity.
+                    enum:
+                    - public
+                    - private
+                    type: string
                   region:
                     description: Region is the region you'd like your NATGateway to
                       be created in.

--- a/pkg/controller/ec2/natgateway/controller.go
+++ b/pkg/controller/ec2/natgateway/controller.go
@@ -136,8 +136,9 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 	}
 
 	nat, err := e.client.CreateNatGateway(ctx, &awsec2.CreateNatGatewayInput{
-		AllocationId: cr.Spec.ForProvider.AllocationID,
-		SubnetId:     cr.Spec.ForProvider.SubnetID,
+		ConnectivityType: awsec2types.ConnectivityType(cr.Spec.ForProvider.ConnectivityType),
+		AllocationId:     cr.Spec.ForProvider.AllocationID,
+		SubnetId:         cr.Spec.ForProvider.SubnetID,
 		TagSpecifications: []awsec2types.TagSpecification{
 			{
 				ResourceType: "natgateway",


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

### Description of your changes

added option to create private-natgateway - to use the natgateway for transit-gateway without internet-gateway

https://aws.amazon.com/de/about-aws/whats-new/2021/06/aws-removes-nat-gateways-dependence-on-internet-gateway-for-private-communications/

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
kubectl apply -f examples/ec2/private-natgateway.yaml  
kubectl apply -f examples/ec2/natgateway.yaml 
```

```
kubectl delete -f examples/ec2/private-natgateway.yaml  
kubectl delete -f examples/ec2/natgateway.yaml 
```

```
 kubectl describe natgateway.ec2.aws.crossplane.io/private-natgateway
Name:         private-natgateway
Namespace:    
Labels:       <none>
Annotations:  crossplane.io/external-create-pending: 2021-10-20T22:12:00+02:00
              crossplane.io/external-create-succeeded: 2021-10-20T22:12:01+02:00
              crossplane.io/external-name: nat-02e64185616ea2e65
API Version:  ec2.aws.crossplane.io/v1beta1
Kind:         NATGateway
Metadata:
  Creation Timestamp:  2021-10-20T20:12:00Z
  Finalizers:
    finalizer.managedresource.crossplane.io
  Generation:        2
  Resource Version:  6916716
  Self Link:         /apis/ec2.aws.crossplane.io/v1beta1/natgateways/private-natgateway
  UID:               471d3148-34bf-4e24-947a-aa93bf55442d
Spec:
  Deletion Policy:  Delete
  For Provider:
    Connectivity Type: private
    Region:     eu-central-1
    Subnet Id:  subnet-f2ccb898
    Subnet Id Ref:
      Name:  sample-subnet1
    Tags:
      Key:    Name
      Value:  private-natgateway
  Provider Config Ref:
    Name:  default
Status:
  At Provider:
    Create Time:  2021-10-20T20:12:01Z
    Nat Gateway Addresses:
      Network Interface Id:  eni-0acfb3cef703bda43
      Private Ip:            172.31.17.51
    Nat Gateway Id:          nat-02e64185616ea2e65
    State:                   available
    Vpc Id:                  vpc-aab73bc0
  Conditions:
    Last Transition Time:  2021-10-20T20:14:02Z
    Reason:                Available
    Status:                True
    Type:                  Ready
    Last Transition Time:  2021-10-20T20:12:01Z
    Reason:                ReconcileSuccess
    Status:                True
    Type:                  Synced
```

```
NAME                                                  READY   SYNCED   ID                      VPC            SUBNET            ALLOCATION ID       AGE
natgateway.ec2.aws.crossplane.io/private-natgateway   True    True     nat-02e64185616ea2e65   vpc-aab73bc0   subnet-f2ccb898                       37m
natgateway.ec2.aws.crossplane.io/sample-natgateway    True    True     nat-0202f960550150def   vpc-aab73bc0   subnet-f2ccb898   eipalloc-39dc1c38   36m
```

![image](https://user-images.githubusercontent.com/21083497/138170099-24b8e3d7-fb59-4f10-9ec2-4c4a88454401.png)


[contribution process]: https://git.io/fj2m9
