### PR TITLE
feat(bottlerocket): added informations for eks-bottlerocket-nodegroup

### DIFF
--- a/apis/eks/manualv1alpha1/nodegroup_types.go
+++ b/apis/eks/manualv1alpha1/nodegroup_types.go
@@ -42,10 +42,18 @@ type NodeGroupParameters struct {
 	// Region is the region you'd like  the NodeGroup to be created in.
 	Region string `json:"region"`
 
-	// The AMI type for your node group. GPU instance types should use the AL2_x86_64_GPU
-	// AMI type, which uses the Amazon EKS-optimized Linux AMI with GPU support.
-	// Non-GPU instances should use the AL2_x86_64 AMI type, which uses the Amazon
-	// EKS-optimized Linux AMI.
+	// The AMI type for your node group.
+	// GPU instance can use
+	// AL2_x86_64_GPU AMI type,
+	// which uses the Amazon EKS-optimized Linux AMI with GPU support.
+	// Non-GPU instances can use
+	// AL2_x86_64 (default) AMI type,
+	// which uses the Amazon EKS-optimized Linux AMI or,
+	// BOTTLEROCKET_ARM_64 AMI type,
+	// which uses the Amazon Bottlerocket AMI for ARM instances, or
+	// BOTTLEROCKET_x86_64 AMI type,
+	// which uses the Amazon Bottlerocket AMI fir x86_64 instances.
+	//
 	// +immutable
 	// +optional
 	AMIType *string `json:"amiType,omitempty"`

--- a/package/crds/eks.aws.crossplane.io_nodegroups.yaml
+++ b/package/crds/eks.aws.crossplane.io_nodegroups.yaml
@@ -66,11 +66,13 @@ spec:
                   Elastic Kubernetes Service NodeGroup.
                 properties:
                   amiType:
-                    description: The AMI type for your node group. GPU instance types
-                      should use the AL2_x86_64_GPU AMI type, which uses the Amazon
-                      EKS-optimized Linux AMI with GPU support. Non-GPU instances
-                      should use the AL2_x86_64 AMI type, which uses the Amazon EKS-optimized
-                      Linux AMI.
+                    description: The AMI type for your node group. GPU instance can
+                      use AL2_x86_64_GPU AMI type, which uses the Amazon EKS-optimized
+                      Linux AMI with GPU support. Non-GPU instances can use AL2_x86_64
+                      (default) AMI type, which uses the Amazon EKS-optimized Linux
+                      AMI or, BOTTLEROCKET_ARM_64 AMI type, which uses the Amazon
+                      Bottlerocket AMI for ARM instances, or BOTTLEROCKET_x86_64 AMI
+                      type, which uses the Amazon Bottlerocket AMI fir x86_64 instances.
                     type: string
                   capacityType:
                     description: CapacityType for your node group.


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

aws shipped: https://aws.amazon.com/de/about-aws/whats-new/2021/10/amazon-eks-nodes-groups-bottlerocket/
https://github.com/aws/containers-roadmap/issues/950

### Description of your changes

* added in crd information for bottlerocket ami-id

for setting up custom options in bottlerocket nodes we need launch-template support in crossplane https://github.com/crossplane/provider-aws/issues/338

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
kubectl describe nodegroup.eks.aws.crossplane.io/my-bottlerocket-group
Name:         my-bottlerocket-group
Namespace:    
Labels:       example=true
Annotations:  crossplane.io/external-create-pending: 2021-10-30T15:13:53+02:00
              crossplane.io/external-create-succeeded: 2021-10-30T15:13:55+02:00
              crossplane.io/external-name: my-bottlerocket-group
API Version:  eks.aws.crossplane.io/v1alpha1
Kind:         NodeGroup
Metadata:
  Creation Timestamp:  2021-10-30T13:13:52Z
  Finalizers:
    finalizer.managedresource.crossplane.io
  Generation:        3
  Resource Version:  7809772
  Self Link:         /apis/eks.aws.crossplane.io/v1alpha1/nodegroups/my-bottlerocket-group
  UID:               302c121b-9d55-442d-8140-fb5982ca4b21
Spec:
  Deletion Policy:  Delete
  For Provider:
    Ami Type:       BOTTLEROCKET_x86_64
    Capacity Type:  ON_DEMAND
    Cluster Name:   platform-ref-aws-cluster
    Disk Size:      20
    Instance Types:
      t3.medium
    Node Role:        arn:aws:iam::255932642927:role/platform-ref-aws-cluster-g2klb-68g6b
    Region:           us-west-2
    Release Version:  1.3.0-395b459c
    Scaling Config:
      Desired Size:  1
      Max Size:      1
      Min Size:      1
    Subnets:
      subnet-02e349b322b5a03ad
      subnet-01afe12fba1e7616f
    Tags:
      Crossplane - Kind:            nodegroup.eks.aws.crossplane.io
      Crossplane - Name:            my-bottlerocket-group
      Crossplane - Providerconfig:  default
    Version:                        1.21
  Provider Config Ref:
    Name:  default
Status:
  At Provider:
    Created At:      2021-10-30T13:13:55Z
    Modified At:     2021-10-30T13:43:58Z
    Node Group Arn:  arn:aws:eks:us-west-2:255932642927:nodegroup/platform-ref-aws-cluster/my-bottlerocket-group/2abe68aa-e649-5906-9bbe-6c2bc13f2c40
    Node Group Health:
    Resources:
      Auto Scaling Group:
        Name:  eks-my-bottlerocket-group-2abe68aa-e649-5906-9bbe-6c2bc13f2c40
    Scaling Config:
      Desired Size:  1
    Status:          ACTIVE
  Conditions:
    Last Transition Time:  2021-10-30T13:18:00Z
    Reason:                Available
    Status:                True
    Type:                  Ready
    Last Transition Time:  2021-10-30T13:13:55Z
    Reason:                ReconcileSuccess
    Status:                True
    Type:                  Synced
Events:
```
