### PR TITLE
fix(nat): make tagSpecification optional to fits nat-gateway without tags

### DIFF
--- a/pkg/controller/ec2/natgateway/controller.go
+++ b/pkg/controller/ec2/natgateway/controller.go
@@ -135,17 +135,22 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		return managed.ExternalCreation{}, errors.New(errUnexpectedObject)
 	}
 
-	nat, err := e.client.CreateNatGateway(ctx, &awsec2.CreateNatGatewayInput{
+	// Create an input without tags.
+	input := &awsec2.CreateNatGatewayInput{
 		ConnectivityType: awsec2types.ConnectivityType(cr.Spec.ForProvider.ConnectivityType),
 		AllocationId:     cr.Spec.ForProvider.AllocationID,
 		SubnetId:         cr.Spec.ForProvider.SubnetID,
-		TagSpecifications: []awsec2types.TagSpecification{
-			{
-				ResourceType: "natgateway",
-				Tags:         v1beta1.GenerateEC2Tags(cr.Spec.ForProvider.Tags),
-			},
-		},
-	})
+	}
+
+	// If we specified tags, update the above input.
+	if cr.Spec.ForProvider.Tags != nil {
+		input.TagSpecifications = []awsec2types.TagSpecification{{
+			ResourceType: "natgateway",
+			Tags:         v1beta1.GenerateEC2Tags(cr.Spec.ForProvider.Tags),
+		}}
+	}
+
+	nat, err := e.client.CreateNatGateway(ctx, input)
 	if err != nil {
 		return managed.ExternalCreation{}, awsclient.Wrap(err, errCreate)
 	}


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

### Description of your changes
fixed 
` failed to create the NATGateway resource: api error InvalidParameter: Tag specification must have at least one tag`
- skip tagSpecification if tags nil - then nat-gateway is created without error message


Fixes https://github.com/crossplane/provider-aws/issues/684

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
kubectl apply -f examples/ec2/natgateway-without-tags.yaml 

```
[...]
Spec:
  Deletion Policy:  Delete
  For Provider:
    Allocation Id:  eipalloc-0386dc8235394d295
    Allocation Id Ref:
      Name:     sample-eip
    Region:     us-east-1
    Subnet Id:  subnet-0bea8bdb2151f4fbe
    Subnet Id Ref:
      Name:  sample-subnet1
  Provider Config Ref:
    Name:  example
Status:
  At Provider:
    Create Time:  2021-11-24T07:49:32Z
    Nat Gateway Addresses:
      Allocation Id:         eipalloc-0386dc8235394d295
      Network Interface Id:  eni-04b3f0dd378d5b51d
      Private Ip:            10.0.1.150
      Public Ip:             34.225.0.40
    Nat Gateway Id:          nat-0cdc37e208c2f4c36
    State:                   available
    Vpc Id:                  vpc-0557e8b3073ddddad
  Conditions:
    Last Transition Time:  2021-11-24T07:51:34Z
    Reason:                Available
    Status:                True
    Type:                  Ready
    Last Transition Time:  2021-11-24T07:49:32Z
    Reason:                ReconcileSuccess
    Status:                True
    Type:                  Synced
```


kubectl apply -f examples/ec2/natgateway.yaml 

```
[...]
Spec:
  Deletion Policy:  Delete
  For Provider:
    Allocation Id:  eipalloc-0386dc8235394d295
    Allocation Id Ref:
      Name:     sample-eip
    Region:     us-east-1
    Subnet Id:  subnet-0bea8bdb2151f4fbe
    Subnet Id Ref:
      Name:  sample-subnet1
    Tags:
      Key:    Name
      Value:  sample-natgateway
  Provider Config Ref:
    Name:  example
Status:
  At Provider:
    Create Time:  2021-11-24T09:09:38Z
    Nat Gateway Addresses:
      Allocation Id:         eipalloc-0386dc8235394d295
      Network Interface Id:  eni-07bc918765cf65ba0
      Private Ip:            10.0.1.182
      Public Ip:             34.225.0.40
    Nat Gateway Id:          nat-0194775b0544d0162
    State:                   available
    Vpc Id:                  vpc-0557e8b3073ddddad
  Conditions:
    Last Transition Time:  2021-11-24T09:11:41Z
    Reason:                Available
    Status:                True
    Type:                  Ready
    Last Transition Time:  2021-11-24T09:09:38Z
    Reason:                ReconcileSuccess
    Status:                True
    Type:                  Synced

```