### PR TITLE
support for s3 replicationConfiguration with delete marker enabled (and fixes)

### DIFF
--- a/apis/s3/v1beta1/replicationConfiguration_types.go
+++ b/apis/s3/v1beta1/replicationConfiguration_types.go
@@ -123,9 +123,8 @@ type ReplicationRule struct {
 // see Backward Compatibility (https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-backward-compat-considerations).
 type DeleteMarkerReplication struct {
 	// Indicates whether to replicate delete markers.
-	// In the current implementation, Amazon S3 doesn't replicate the delete markers.
-	// The status must be "Disabled".
-	// +kubebuilder:validation:Enum=Disabled
+	// Valid values are "Enabled" or "Disabled"
+	// +kubebuilder:validation:Enum=Enabled;Disabled
 	Status string `json:"status"`
 }
 

--- a/package/crds/s3.aws.crossplane.io_buckets.yaml
+++ b/package/crds/s3.aws.crossplane.io_buckets.yaml
@@ -910,10 +910,9 @@ spec:
                               properties:
                                 status:
                                   description: Indicates whether to replicate delete
-                                    markers. In the current implementation, Amazon
-                                    S3 doesn't replicate the delete markers. The status
-                                    must be "Disabled".
+                                    markers. Valid values are "Enabled" or "Disabled"
                                   enum:
+                                  - Enabled
                                   - Disabled
                                   type: string
                               required:


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
See - https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-add-config.html
Adds support for `DeleteMarkerReplication` with status of `Enabled`.  Previously only `Disabled` was supported but `Enabled` is a valid value.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #
As part of the aws sdk go v2 bucket it appears replicationConfiguration without specifying a filter no longer results in valid XML.  
Previously when a filter was defined as `filter: {}` the provider would send XML similar to 
```
<ReplicationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
	<Rule>
		<ID>1</ID>
		<Priority>0</Priority>
		<Status>Enabled</Status>
		<DeleteMarkerReplication>
			<Status>Enabled</Status>
		</DeleteMarkerReplication>
		<Filter/>
		<Destination>
			<Bucket>arn:aws:s3:::my-s3-bucket</Bucket>
		</Destination>
	</Rule>
	<Role>arn:aws:iam::0123456789:role/my-bucket-role</Role>
</ReplicationConfiguration>
```
However with the new changes the XML sent when the filter is `filter: {}` is this 
(it's missing `<Filter/>` and violates aws XML schema):
```
<ReplicationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
	<Rule>
		<ID>1</ID>
		<Priority>0</Priority>
		<Status>Enabled</Status>
		<DeleteMarkerReplication>
			<Status>Enabled</Status>
		</DeleteMarkerReplication>
		<Destination>
			<Bucket>arn:aws:s3:::my-s3-bucket</Bucket>
		</Destination>
	</Rule>
	<Role>arn:aws:iam::0123456789:role/my-bucket-role</Role>
</ReplicationConfiguration>
```
With this PR, if no filter rules are defined (ex. `filter: {}`) an empty filter and prefix will be sent:
```
<ReplicationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
	<Rule>
		<ID>1</ID>
		<Priority>0</Priority>
		<Status>Enabled</Status>
		<DeleteMarkerReplication>
			<Status>Enabled</Status>
		</DeleteMarkerReplication>
		<Destination>
			<Bucket>arn:aws:s3:::my-s3-bucket</Bucket>
		</Destination>
		<Filter>
			<Prefix/>
		</Filter>
	</Rule>
	<Role>arn:aws:iam::0123456789:role/my-bucket-role</Role>
</ReplicationConfiguration>
```

Also - added `IsUpToDate` function for ReplicationConfiguration, added unit tests, and fixed issue where out-of-order rules caused update of external resource.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
* Unit tests
* Enable aws debug logging with http requests to ensure the `ReplicationConfiguration` XML (specifically filter settings) are sent as part of the payload (above) and that a bucket without any filters defined can be created successfully.
* Create a bucket with replication disabled or enabled.  Bucket is created with the correct replication settings
* Toggle an existing bucket with replication configuration to enabled/disabled.  The change is detected during `Observe` and aws is updated accordingly
* Ensure that bucket with replicationConfiguration does not constantly reconcile with these settings.


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
