### PR TITLE
assumeRoleARN for ProviderConfig

### DIFF
--- a/apis/v1beta1/providerconfig_types.go
+++ b/apis/v1beta1/providerconfig_types.go
@@ -27,6 +27,10 @@ type ProviderConfigSpec struct {
 	// Credentials required to authenticate to this provider.
 	Credentials ProviderCredentials `json:"credentials"`
 
+	// AssumeRoleARN to assume with provider credentials
+	// +optional
+	AssumeRoleARN *string `json:"assumeRoleARN,omitempty"`
+
 	// Endpoint is where you can override the default endpoint configuration
 	// of AWS calls made by the provider.
 	// +optional

--- a/apis/v1beta1/zz_generated.deepcopy.go
+++ b/apis/v1beta1/zz_generated.deepcopy.go
@@ -148,6 +148,11 @@ func (in *ProviderConfigList) DeepCopyObject() runtime.Object {
 func (in *ProviderConfigSpec) DeepCopyInto(out *ProviderConfigSpec) {
 	*out = *in
 	in.Credentials.DeepCopyInto(&out.Credentials)
+	if in.AssumeRoleARN != nil {
+		in, out := &in.AssumeRoleARN, &out.AssumeRoleARN
+		*out = new(string)
+		**out = **in
+	}
 	if in.Endpoint != nil {
 		in, out := &in.Endpoint, &out.Endpoint
 		*out = new(EndpointConfig)

--- a/package/crds/aws.crossplane.io_providerconfigs.yaml
+++ b/package/crds/aws.crossplane.io_providerconfigs.yaml
@@ -47,6 +47,9 @@ spec:
           spec:
             description: A ProviderConfigSpec defines the desired state of a ProviderConfig.
             properties:
+              assumeRoleARN:
+                description: AssumeRoleARN to assume with provider credentials
+                type: string
               credentials:
                 description: Credentials required to authenticate to this provider.
                 properties:


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

### Description of your changes
added option assumeRoleARN for ProviderConfig #912

1.) In the absence of `assumeRoleARN`, we simply call `config.LoadDefaultConfig(ctx)`, as this will automatically grant us access to the `current` AWS account / configured `WebIdentity` / `Credentials`

2.) `assumeRoleARN` allows us to assume a role via `sts:AssumeRole` via our configured `WebIdentity` / `Credentials`
- default role is assumed by `config.LoadDefaultConfig(ctx)` - `WebIdentity` /  `Credentials`
- `sts:AssumeRole` is done by `stscreds.NewAssumeRoleProvider(assumeRoleARN)`

Fixes #606 
Implemented Parts of: #597 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

for go-sdk-v1 ressources (code-generator)
for go-sdk-v2 ressources (manual implemented ressources)

create providers:
local:
```
apiVersion: aws.crossplane.io/v1beta1
kind: ProviderConfig
metadata:
  name: aws-provider
spec:
  credentials:
    source: InjectedIdentity
```

or

```
apiVersion: aws.crossplane.io/v1beta1
kind: ProviderConfig
metadata:
  name: aws-provider
spec:
  credentials:
    source: Secret
    secretRef:
      namespace: crossplane-system
      name: aws-creds
      key: creds
```

remote:
```
apiVersion: aws.crossplane.io/v1beta1
kind: ProviderConfig
metadata:
  name: aws-provider-999999999999
spec:
  assumeRoleARN: "arn:aws:iam::999999999999:role/crossplane_deploy"
  credentials:
    source: InjectedIdentity
```

or

```
apiVersion: aws.crossplane.io/v1beta1
kind: ProviderConfig
metadata:
  name: aws-provider-999999999999
spec:
  assumeRoleARN: "arn:aws:iam::999999999999:role/crossplane_deploy"
  credentials:
    source: Secret
    secretRef:
      namespace: crossplane-system
      name: aws-creds
      key: creds
```

efs:
local:
```
# aws go-sdk v1
apiVersion: efs.aws.crossplane.io/v1alpha1
kind: FileSystem
metadata:
  name: local-efs
spec:
  forProvider:
    region: eu-central-1
  providerConfigRef:
    name: aws-provider
```

remote:
```
# aws go-sdk v1
apiVersion: efs.aws.crossplane.io/v1alpha1
kind: FileSystem
metadata:
  name: remote-efs
spec:
  forProvider:
    region: eu-central-1
  providerConfigRef:
    name: aws-provider-999999999999
```

iam-role:
local:
```
# aws go-sdk v2
apiVersion: identity.aws.crossplane.io/v1beta1
kind: IAMRole
metadata:
  name: test-local-role
spec:
  forProvider:
    assumeRolePolicyDocument: |
      {
        "Version": "2012-10-17",
        "Statement": [
            {
                "Effect": "Allow",
                "Principal": {
                    "Service": [
                        "ec2.amazonaws.com",
                        "eks.amazonaws.com",
                        "eks-fargate-pods.amazonaws.com",
                        "lambda.amazonaws.com"
                    ]
                },
                "Action": [
                    "sts:AssumeRole"
                ]
            }
        ]
      }
    tags:
      - key: k1
        value: v1
  providerConfigRef:
    name: aws-provider
```

remote:
```
# aws go-sdk v2
apiVersion: identity.aws.crossplane.io/v1beta1
kind: IAMRole
metadata:
  name: test-remote-role
spec:
  forProvider:
    assumeRolePolicyDocument: |
      {
        "Version": "2012-10-17",
        "Statement": [
            {
                "Effect": "Allow",
                "Principal": {
                    "Service": [
                        "ec2.amazonaws.com",
                        "eks.amazonaws.com",
                        "eks-fargate-pods.amazonaws.com",
                        "lambda.amazonaws.com"
                    ]
                },
                "Action": [
                    "sts:AssumeRole"
                ]
            }
        ]
      }
    tags:
      - key: k1
        value: v1
  providerConfigRef:
    name: aws-provider-999999999999
```

[contribution process]: https://git.io/fj2m9
