### PR TITLE
 fix multi-region with injected identity -  after v2 migration v0.20.0

### DIFF
--- a/pkg/clients/aws.go
+++ b/pkg/clients/aws.go
@@ -259,7 +259,10 @@ func UseProviderSecret(ctx context.Context, data []byte, profile, region string)
 // UsePodServiceAccount assumes an IAM role configured via a ServiceAccount.
 // https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
 func UsePodServiceAccount(ctx context.Context, _ []byte, _, region string) (*aws.Config, error) {
-	cfg, err := config.LoadDefaultConfig(ctx)
+	cfg, err := config.LoadDefaultConfig(
+		ctx,
+		config.WithRegion(region),
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load default AWS config")
 	}
@@ -339,7 +342,10 @@ func UseProviderSecretV1(_ context.Context, data []byte, pc *v1beta1.ProviderCon
 // UsePodServiceAccountV1 assumes an IAM role configured via a ServiceAccount.
 // https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
 func UsePodServiceAccountV1(ctx context.Context, _ []byte, pc *v1beta1.ProviderConfig, _, region string) (*awsv1.Config, error) {
-	cfg, err := config.LoadDefaultConfig(ctx)
+	cfg, err := config.LoadDefaultConfig(
+		ctx,
+		config.WithRegion(region),
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load default AWS config")
 	}


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

### Description of your changes

added region for `config.LoadDefaultConfig` since it was dropped after v2 migration

v0.19.0:
https://github.com/crossplane/provider-aws/blob/release-0.19/pkg/clients/aws.go#L343

v0.20.0:
https://github.com/crossplane/provider-aws/blob/release-0.19/pkg/clients/aws.go#L234

Fixes Community Question from Slack:

```
Kelly Ferrone: For some reason all my aws resources end up in only one region? Why would this happen? Even though I say region: us-east-1
it is always
region: us-west-2
I see on provider-aws pod it does have AWS_REGION: us-west-2
Is this because of using the injected Identity

Milan Laketic: I can now confirm that I have the same behavior. On provider v0.19.1 I can normally provision in another region, but on latest I get resources in region where I'm assuming role
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
tested with go-sdk-v1 and go-sdk-v2 ressources:

```
---
apiVersion: efs.aws.crossplane.io/v1alpha1
kind: FileSystem
metadata:
  name: eu-west-1-efs
spec:
  forProvider:
    region: eu-west-1
  providerConfigRef:
    name: aws-provider
---
apiVersion: efs.aws.crossplane.io/v1alpha1
kind: FileSystem
metadata:
  name: eu-central-1-efs
spec:
  forProvider:
    region: eu-central-1
  providerConfigRef:
    name: aws-provider
---
apiVersion: ecr.aws.crossplane.io/v1alpha1
kind: Repository
metadata:
  name: eu-central-1-ecr
spec:
  forProvider:
    region: eu-central-1
    imageScanningConfiguration:
      scanOnPush: true
    imageTagMutability: IMMUTABLE
  providerConfigRef:
    name: aws-provider
---
apiVersion: ecr.aws.crossplane.io/v1alpha1
kind: Repository
metadata:
  name: eu-west-1-ecr
spec:
  forProvider:
    region: eu-west-1
    imageScanningConfiguration:
      scanOnPush: true
    imageTagMutability: IMMUTABLE
  providerConfigRef:
    name: aws-provider
```