### PR TITLE
fix s3 nil paymentConfiguration preventing bucket from being ready

### DIFF
--- a/pkg/controller/s3/bucket_test.go
+++ b/pkg/controller/s3/bucket_test.go
@@ -179,11 +179,17 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr: s3Testing.Bucket(
+					s3Testing.WithConditions(xpv1.Available()),
 					s3Testing.WithArn(fmt.Sprintf("arn:aws:s3:::%s", s3Testing.BucketName)),
 				),
 				result: managed.ExternalObservation{
 					ResourceExists:   true,
-					ResourceUpToDate: false,
+					ResourceUpToDate: true,
+					ConnectionDetails: map[string][]byte{
+						xpv1.ResourceCredentialsSecretEndpointKey:  []byte(s3Testing.BucketName),
+						v1beta1.ResourceCredentialsSecretRegionKey: []byte(s3Testing.Region),
+					},
+					ResourceLateInitialized: false,
 				},
 			},
 		},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fixes https://github.com/crossplane/provider-aws/issues/784

In aws-sdk-go-v2 the `Payer` property for `GetBucketRequestPaymentOutput` has changed.
Previously it was a string:
https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#GetBucketRequestPaymentOutput
But in v2 it is a type:
https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#GetBucketRequestPaymentOutput
https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3@v1.18.0/types#Payer

Perhaps it was set via `LateInitialize` previously?   Either way, the comparison functionality is broken now.
What is currently happening is if `PayerConfiguration` is not set it will ALWAYS need an update due to this code block:
```
	case config == nil && len(external.Payer) != 0:
		return NeedsUpdate, nil
```
This fixes the comparison functionality, which should allow bucket status to be ready
 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
Fixes #

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
