### PR TITLE
Fix originssl

### DIFF
--- a/examples/cloudfront/distribution-custom-origin.yaml
+++ b/examples/cloudfront/distribution-custom-origin.yaml
@@ -1,0 +1,36 @@
+# Distribution will not be deleted unless you mark the distribution disabled via
+# spec.distributionConfig.enabled.
+apiVersion: cloudfront.aws.crossplane.io/v1alpha1
+kind: Distribution
+metadata:
+  name: example-distribution
+spec:
+  forProvider:
+    region: us-east-1
+    distributionConfig:
+      enabled: true
+      comment: Example CloudFront Distribution
+      origins:
+        items:
+          - domainName: crossplane-example.amazon.com
+            id: customOrigin
+            customOriginConfig:
+              httpPort: 80
+              originProtocolPolicy: "http-only"
+              originReadTimeout: 10
+              originKeepaliveTimeout: 5
+              httpSPort: 443
+              originSSLProtocols:
+                items:
+                  - TLSv1
+                quantity: 1
+      defaultCacheBehavior:
+        targetOriginID: customOrigin
+        viewerProtocolPolicy: allow-all
+        minTTL: 0
+        forwardedValues:
+          cookies:
+            forward: none
+          queryString: false
+  providerConfigRef:
+    name: example

--- a/pkg/controller/cloudfront/distribution/setup.go
+++ b/pkg/controller/cloudfront/distribution/setup.go
@@ -104,7 +104,8 @@ var mappingOptions = []cloudfront.LateInitOption{
 	cloudfront.Replacer("ID", "Id"),
 	cloudfront.Replacer("ARN", "Arn"),
 	cloudfront.MapReplacer(map[string]string{
-		"HTTPVersion": "HttpVersion",
+		"HTTPVersion":        "HttpVersion",
+		"OriginSSLProtocols": "OriginSslProtocols",
 	})}
 
 func lateInitialize(in *svcapitypes.DistributionParameters, gdo *svcsdk.GetDistributionOutput) error {


### PR DESCRIPTION
### Description of your changes
From #915

> Creating a distribution with a custom origin was stuck infinitely reconciling every second. After looking into this, it was due to a naming difference between provider-aws and the aws sdk where for provider-aws the variable was OriginSSLProtocols and for aws-sdk it was OriginSslProtocols.

Fixes #894. 


I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested with the following code from #894

```yaml
# Distribution will not be deleted unless you mark the distribution disabled via
# spec.distributionConfig.enabled.
apiVersion: cloudfront.aws.crossplane.io/v1alpha1
kind: Distribution
metadata:
  name: example2-distribution
spec:
  forProvider:
    region: us-east-1
    distributionConfig:
      enabled: true
      comment: Example CloudFront Distribution
      origins:
        items:
          - domainName: exampledomain.example.com
            id: example
            originPath: "/helloworld"
            customHeaders:
              items:
                - headerName: "test"
                  headerValue: "test"
              quantity: 1
            customOriginConfig:
              httpPort: 80
              originProtocolPolicy: "http-only"
              originReadTimeout: 10
              originKeepaliveTimeout: 5
              httpSPort: 443
              originSSLProtocols:
                items:
                  - TLSv1
                quantity: 1
      defaultCacheBehavior:
        targetOriginID: example
        viewerProtocolPolicy: allow-all
        minTTL: 0
        forwardedValues:
          cookies:
            forward: none
          queryString: false
  providerConfigRef:
    name: aws-provider
```

