### PR TITLE
observe iampolicy which already exists

### DIFF
--- a/examples/iam/policy.yaml
+++ b/examples/iam/policy.yaml
@@ -24,6 +24,29 @@ spec:
 apiVersion: identity.aws.crossplane.io/v1alpha1
 kind: IAMPolicy
 metadata:
+  name: somepolicywithpath
+spec:
+  forProvider:
+    name: external-name
+    path: "/some-org-unit/"
+    document: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+              "Sid": "VisualEditor0",
+              "Effect": "Allow",
+              "Action": "elastic-inference:Connect",
+              "Resource": "*"
+          }
+        ]
+      }
+  providerConfigRef:
+    name: example
+---
+apiVersion: identity.aws.crossplane.io/v1alpha1
+kind: IAMPolicy
+metadata:
   name: glue-policy
 spec:
   forProvider:

--- a/pkg/clients/iam/fake/iampolicy.go
+++ b/pkg/clients/iam/fake/iampolicy.go
@@ -32,6 +32,7 @@ type MockPolicyClient struct {
 	MockGetPolicy           func(ctx context.Context, input *iam.GetPolicyInput, opts []func(*iam.Options)) (*iam.GetPolicyOutput, error)
 	MockCreatePolicy        func(ctx context.Context, input *iam.CreatePolicyInput, opts []func(*iam.Options)) (*iam.CreatePolicyOutput, error)
 	MockDeletePolicy        func(ctx context.Context, input *iam.DeletePolicyInput, opts []func(*iam.Options)) (*iam.DeletePolicyOutput, error)
+	MockListPolicies        func(ctx context.Context, input *iam.ListPoliciesInput, opts []func(*iam.Options)) (*iam.ListPoliciesOutput, error)
 	MockGetPolicyVersion    func(ctx context.Context, input *iam.GetPolicyVersionInput, opts []func(*iam.Options)) (*iam.GetPolicyVersionOutput, error)
 	MockCreatePolicyVersion func(ctx context.Context, input *iam.CreatePolicyVersionInput, opts []func(*iam.Options)) (*iam.CreatePolicyVersionOutput, error)
 	MockListPolicyVersions  func(ctx context.Context, input *iam.ListPolicyVersionsInput, opts []func(*iam.Options)) (*iam.ListPolicyVersionsOutput, error)
@@ -51,6 +52,11 @@ func (m *MockPolicyClient) CreatePolicy(ctx context.Context, input *iam.CreatePo
 // DeletePolicy mocks DeletePolicy method
 func (m *MockPolicyClient) DeletePolicy(ctx context.Context, input *iam.DeletePolicyInput, opts ...func(*iam.Options)) (*iam.DeletePolicyOutput, error) {
 	return m.MockDeletePolicy(ctx, input, opts)
+}
+
+// ListPolicies mocks ListPolicies method
+func (m *MockPolicyClient) ListPolicies(ctx context.Context, input *iam.ListPoliciesInput, opts ...func(*iam.Options)) (*iam.ListPoliciesOutput, error) {
+	return m.MockListPolicies(ctx, input, opts)
 }
 
 // GetPolicyVersion mocks GetPolicyVersion method

--- a/pkg/clients/iam/fake/iampolicy.go
+++ b/pkg/clients/iam/fake/iampolicy.go
@@ -20,23 +20,34 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 
 	clientset "github.com/crossplane/provider-aws/pkg/clients/iam"
 )
 
 // this ensures that the mock implements the client interface
 var _ clientset.PolicyClient = (*MockPolicyClient)(nil)
+var _ clientset.STSClient = (*MockSTSClient)(nil)
 
 // MockPolicyClient is a type that implements all the methods for PolicyClient interface
 type MockPolicyClient struct {
 	MockGetPolicy           func(ctx context.Context, input *iam.GetPolicyInput, opts []func(*iam.Options)) (*iam.GetPolicyOutput, error)
 	MockCreatePolicy        func(ctx context.Context, input *iam.CreatePolicyInput, opts []func(*iam.Options)) (*iam.CreatePolicyOutput, error)
 	MockDeletePolicy        func(ctx context.Context, input *iam.DeletePolicyInput, opts []func(*iam.Options)) (*iam.DeletePolicyOutput, error)
-	MockListPolicies        func(ctx context.Context, input *iam.ListPoliciesInput, opts []func(*iam.Options)) (*iam.ListPoliciesOutput, error)
 	MockGetPolicyVersion    func(ctx context.Context, input *iam.GetPolicyVersionInput, opts []func(*iam.Options)) (*iam.GetPolicyVersionOutput, error)
 	MockCreatePolicyVersion func(ctx context.Context, input *iam.CreatePolicyVersionInput, opts []func(*iam.Options)) (*iam.CreatePolicyVersionOutput, error)
 	MockListPolicyVersions  func(ctx context.Context, input *iam.ListPolicyVersionsInput, opts []func(*iam.Options)) (*iam.ListPolicyVersionsOutput, error)
 	MockDeletePolicyVersion func(ctx context.Context, input *iam.DeletePolicyVersionInput, opts []func(*iam.Options)) (*iam.DeletePolicyVersionOutput, error)
+}
+
+// MockSTSClient mock sts client
+type MockSTSClient struct {
+	MockGetCallerIdentity func(ctx context.Context, input *sts.GetCallerIdentityInput, opts []func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+}
+
+// GetCallerIdentity calls the underlying MockGetCallerIdentity method.
+func (c *MockSTSClient) GetCallerIdentity(ctx context.Context, input *sts.GetCallerIdentityInput, opts ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return c.MockGetCallerIdentity(ctx, input, opts)
 }
 
 // GetPolicy mocks GetPolicy method
@@ -52,11 +63,6 @@ func (m *MockPolicyClient) CreatePolicy(ctx context.Context, input *iam.CreatePo
 // DeletePolicy mocks DeletePolicy method
 func (m *MockPolicyClient) DeletePolicy(ctx context.Context, input *iam.DeletePolicyInput, opts ...func(*iam.Options)) (*iam.DeletePolicyOutput, error) {
 	return m.MockDeletePolicy(ctx, input, opts)
-}
-
-// ListPolicies mocks ListPolicies method
-func (m *MockPolicyClient) ListPolicies(ctx context.Context, input *iam.ListPoliciesInput, opts ...func(*iam.Options)) (*iam.ListPoliciesOutput, error) {
-	return m.MockListPolicies(ctx, input, opts)
 }
 
 // GetPolicyVersion mocks GetPolicyVersion method

--- a/pkg/clients/iam/iampolicy.go
+++ b/pkg/clients/iam/iampolicy.go
@@ -18,6 +18,7 @@ type PolicyClient interface {
 	GetPolicy(ctx context.Context, input *iam.GetPolicyInput, opts ...func(*iam.Options)) (*iam.GetPolicyOutput, error)
 	CreatePolicy(ctx context.Context, input *iam.CreatePolicyInput, opts ...func(*iam.Options)) (*iam.CreatePolicyOutput, error)
 	DeletePolicy(ctx context.Context, input *iam.DeletePolicyInput, opts ...func(*iam.Options)) (*iam.DeletePolicyOutput, error)
+	ListPolicies(ctx context.Context, input *iam.ListPoliciesInput, opts ...func(*iam.Options)) (*iam.ListPoliciesOutput, error)
 	GetPolicyVersion(ctx context.Context, input *iam.GetPolicyVersionInput, opts ...func(*iam.Options)) (*iam.GetPolicyVersionOutput, error)
 	CreatePolicyVersion(ctx context.Context, input *iam.CreatePolicyVersionInput, opts ...func(*iam.Options)) (*iam.CreatePolicyVersionOutput, error)
 	ListPolicyVersions(ctx context.Context, input *iam.ListPolicyVersionsInput, opts ...func(*iam.Options)) (*iam.ListPolicyVersionsOutput, error)

--- a/pkg/clients/iam/iampolicy.go
+++ b/pkg/clients/iam/iampolicy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/crossplane/provider-aws/apis/identity/v1alpha1"
@@ -18,16 +19,25 @@ type PolicyClient interface {
 	GetPolicy(ctx context.Context, input *iam.GetPolicyInput, opts ...func(*iam.Options)) (*iam.GetPolicyOutput, error)
 	CreatePolicy(ctx context.Context, input *iam.CreatePolicyInput, opts ...func(*iam.Options)) (*iam.CreatePolicyOutput, error)
 	DeletePolicy(ctx context.Context, input *iam.DeletePolicyInput, opts ...func(*iam.Options)) (*iam.DeletePolicyOutput, error)
-	ListPolicies(ctx context.Context, input *iam.ListPoliciesInput, opts ...func(*iam.Options)) (*iam.ListPoliciesOutput, error)
 	GetPolicyVersion(ctx context.Context, input *iam.GetPolicyVersionInput, opts ...func(*iam.Options)) (*iam.GetPolicyVersionOutput, error)
 	CreatePolicyVersion(ctx context.Context, input *iam.CreatePolicyVersionInput, opts ...func(*iam.Options)) (*iam.CreatePolicyVersionOutput, error)
 	ListPolicyVersions(ctx context.Context, input *iam.ListPolicyVersionsInput, opts ...func(*iam.Options)) (*iam.ListPolicyVersionsOutput, error)
 	DeletePolicyVersion(ctx context.Context, input *iam.DeletePolicyVersionInput, opts ...func(*iam.Options)) (*iam.DeletePolicyVersionOutput, error)
 }
 
+// STSClient is the external client used for STS
+type STSClient interface {
+	GetCallerIdentity(ctx context.Context, input *sts.GetCallerIdentityInput, opts ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+}
+
 // NewPolicyClient returns a new client using AWS credentials as JSON encoded data.
 func NewPolicyClient(cfg aws.Config) PolicyClient {
 	return iam.NewFromConfig(cfg)
+}
+
+// NewSTSClient creates a new STS Client.
+func NewSTSClient(cfg aws.Config) STSClient {
+	return sts.NewFromConfig(cfg)
 }
 
 // IsPolicyUpToDate checks whether there is a change in any of the modifiable fields in policy.


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
When `provider-aws` attempts to observe an iam policy which already exists, it fails with this error:
```
{
  "object": {
    "kind": "IAMPolicy",
    "name": "crossplane-lateinitialize-test",
    "uid": "some-uid",
    "apiVersion": "identity.aws.crossplane.io/v1alpha1",
    "resourceVersion": "49576502"
  },
  "reason": "CannotCreateExternalResource",
  "message": "failed to create the IAM Policy: EntityAlreadyExists: A policy called my-iam-test-policy already exists. Duplicate names are not allowed."
}
```
Since the external name is not set `Observe` skips lookup of the resource and it goes to `Create`.  For other types of resources (ex. iam role) even when the external name is not set crossplane is able to detect and take ownership of the resource.   The reason being - those aws API calls are based on resource _NAME_ so it can look up the existing aws resource by name without the external resource being set.  
That is not true for iam policy where the external name is an ARN.

With this PR, if the external-name is not set, `Observe` will attempt to construct the ARN from the result of https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html
If found it will update the external-name and move on.  If not found, it will continue with the existing behavior which is to try to create.

IAM Policy has been a painpoint during `provider-aws` upgrades - somehow the external-name is being reset and it takes a lot of manually editing resources to fix.   This should solve that problem.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
* Unit tests
* attempt to create a crossplane object where the policy name already exists
* remove the external-name property on a policy (and watch it get re-added)
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
