### PR TITLE
readme: add release policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ guidelines to get started.
 We use AWS Go code generation pipeline to generate new controllers. See [Code Generation Guide](CODE_GENERATION.md)
 to add a new resource.
 
+## Releases
+
+AWS Provider is released every 4 weeks and we issue patch releases as necessary.
+For example, `v0.20.0` is released on October 19, 2021. The next minor
+release `v0.21.0` will be cut on November 16, 2021, and so on.
+
 ## Report a Bug
 
 For filing bugs, suggesting improvements, or requesting new features, please


### PR DESCRIPTION
### Description of your changes

Adds release policy to README. I didn't want to add a release table like in Crossplane because there is no official active verisons or support policy around provider versions yet.

Fixes https://github.com/crossplane/provider-aws/issues/878

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

N/A

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
