### PR TITLE
dynamodb.table: implement update for global secondary indexes

### DIFF
--- a/examples/dynamodb/table.yaml
+++ b/examples/dynamodb/table.yaml
@@ -69,16 +69,31 @@ spec:
 apiVersion: dynamodb.aws.crossplane.io/v1alpha1
 kind: Table
 metadata:
-  name: sample-table-ppr
+  name: sample-table-global-secondary-indexes
 spec:
   forProvider:
     region: us-east-1
+    globalSecondaryIndexes:
+      - indexName: IndexKey
+        keySchema:
+          - keyType: HASH
+            attributeName: IndexKey
+          - keyType: RANGE
+            attributeName: SomeKey
+        projection:
+          projectionType: INCLUDE
+          nonKeyAttributes:
+            - SomeId
     attributeDefinitions:
-      - attributeName: attribute1
+      - attributeName: IndexKey
+        attributeType: S
+      - attributeName: SomeKey
         attributeType: S
     keySchema:
-      - attributeName: attribute1
+      - attributeName: IndexKey
         keyType: HASH
+      - attributeName: SomeKey
+        keyType: RANGE
     billingMode: PAY_PER_REQUEST
   providerConfigRef:
     name: example


### PR DESCRIPTION
### Description of your changes

The diff and update methods aren't generated for that field since its name and type is different in `UpdateTableInput` from `CreateTableInput`. So, we had to manually implement the whole mechanism.

Fixes a few small things like getting rid of cmpopts for `isUpToDate` and making sure we strip off the request ID from v1 SDK errors.

Fixes https://github.com/crossplane/provider-aws/issues/927

Note that it turned out `ReplicaUpdates` is only for `GlobalTable` resource and it's already implemented.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually with the example YAML by;
* Create a normal table without Global Secondary Index (GSI).
* Add a new GSI.
* Delete the GSI by making that array zero-length.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
