### PR TITLE
Manually late-init CloudFront Distributions 

### DIFF
--- a/pkg/clients/aws.go
+++ b/pkg/clients/aws.go
@@ -633,6 +633,26 @@ func LateInitializeInt64(in int64, from int64) int64 {
 	return from
 }
 
+// LateInitializeStringPtrSlice returns in if it's non-nil or from is zero
+// length, otherwise it returns from.
+func LateInitializeStringPtrSlice(in []*string, from []*string) []*string {
+	if in != nil || len(from) == 0 {
+		return in
+	}
+
+	return from
+}
+
+// LateInitializeInt64PtrSlice returns in if it's non-nil or from is zero
+// length, otherwise it returns from.
+func LateInitializeInt64PtrSlice(in []*int64, from []*int64) []*int64 {
+	if in != nil || len(from) == 0 {
+		return in
+	}
+
+	return from
+}
+
 // Bool converts the supplied bool for use with the AWS Go SDK.
 func Bool(v bool, o ...FieldOption) *bool {
 	for _, fo := range o {

--- a/pkg/clients/aws_test.go
+++ b/pkg/clients/aws_test.go
@@ -789,3 +789,97 @@ func TestDiffTagsMapPtr(t *testing.T) {
 		})
 	}
 }
+
+func TestLateInitStringPtrSlice(t *testing.T) {
+	type args struct {
+		in   []*string
+		from []*string
+	}
+
+	cases := map[string]struct {
+		args args
+		want []*string
+	}{
+		"BothNil": {
+			args: args{},
+			want: nil,
+		},
+		"BothEmpty": {
+			args: args{
+				in:   []*string{},
+				from: []*string{},
+			},
+			want: []*string{},
+		},
+		"FromNil": {
+			args: args{
+				in:   aws.StringSlice([]string{"hi!"}),
+				from: nil,
+			},
+			want: aws.StringSlice([]string{"hi!"}),
+		},
+		"InNil": {
+			args: args{
+				in:   nil,
+				from: aws.StringSlice([]string{"hi!"}),
+			},
+			want: aws.StringSlice([]string{"hi!"}),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := LateInitializeStringPtrSlice(tc.args.in, tc.args.from)
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("\nLateInitializeStringPtrSlice(...): -got, +want:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLateInitInt64PtrSlice(t *testing.T) {
+	type args struct {
+		in   []*int64
+		from []*int64
+	}
+
+	cases := map[string]struct {
+		args args
+		want []*int64
+	}{
+		"BothNil": {
+			args: args{},
+			want: nil,
+		},
+		"BothEmpty": {
+			args: args{
+				in:   []*int64{},
+				from: []*int64{},
+			},
+			want: []*int64{},
+		},
+		"FromNil": {
+			args: args{
+				in:   aws.Int64Slice([]int64{1}),
+				from: nil,
+			},
+			want: aws.Int64Slice([]int64{1}),
+		},
+		"InNil": {
+			args: args{
+				in:   nil,
+				from: aws.Int64Slice([]int64{1}),
+			},
+			want: aws.Int64Slice([]int64{1}),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := LateInitializeInt64PtrSlice(tc.args.in, tc.args.from)
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("\nLateInitializeInt64PtrSlice(...): -got, +want:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/cloudfront/cachepolicy/lateinit.go
+++ b/pkg/controller/cloudfront/cachepolicy/lateinit.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudfront
+package cachepolicy
 
 import (
 	"encoding/json"
@@ -306,6 +306,14 @@ func handlePtr(cName string, crFieldInitialized bool, crFieldValue, responseFiel
 
 	return crKeepField, nil
 }
+
+// TODO(negz): I believe handleSlice attempts to late init slices under the
+// assumption that the actual and desired elements will be in the same order,
+// which is often not the case (e.g. for CloudFront Distributions). It also
+// appears to append actual elements to the desired slice when the actual slice
+// is longer than the desired slice, which would prevent us from removing
+// elements from the desired slice (since they'd be late-init-ed right back in
+// during Observe, resetting the desired state).
 
 // nolint:gocyclo
 func handleSlice(cName string, crFieldInitialized bool, crFieldValue, responseFieldValue reflect.Value,

--- a/pkg/controller/cloudfront/cachepolicy/lateinit_test.go
+++ b/pkg/controller/cloudfront/cachepolicy/lateinit_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloudfront
+package cachepolicy
 
 import (
 	"reflect"

--- a/pkg/controller/cloudfront/cachepolicy/setup.go
+++ b/pkg/controller/cloudfront/cachepolicy/setup.go
@@ -34,7 +34,6 @@ import (
 
 	svcapitypes "github.com/crossplane/provider-aws/apis/cloudfront/v1alpha1"
 	awsclients "github.com/crossplane/provider-aws/pkg/clients"
-	"github.com/crossplane/provider-aws/pkg/controller/cloudfront"
 )
 
 // SetupCachePolicy adds a controller that reconciles CachePolicy.
@@ -103,15 +102,15 @@ func preDelete(_ context.Context, cp *svcapitypes.CachePolicy, dpi *svcsdk.Delet
 	return false, nil
 }
 
-var mappingOptions = []cloudfront.LateInitOption{cloudfront.Replacer("ID", "Id")}
+var mappingOptions = []LateInitOption{Replacer("ID", "Id")}
 
 func lateInitialize(in *svcapitypes.CachePolicyParameters, gpo *svcsdk.GetCachePolicyOutput) error {
-	_, err := cloudfront.LateInitializeFromResponse("",
+	_, err := LateInitializeFromResponse("",
 		in.CachePolicyConfig, gpo.CachePolicy.CachePolicyConfig, mappingOptions...)
 	return err
 }
 
 func isUpToDate(cp *svcapitypes.CachePolicy, gpo *svcsdk.GetCachePolicyOutput) (bool, error) {
-	return cloudfront.IsUpToDate(gpo.CachePolicy.CachePolicyConfig, cp.Spec.ForProvider.CachePolicyConfig,
+	return IsUpToDate(gpo.CachePolicy.CachePolicyConfig, cp.Spec.ForProvider.CachePolicyConfig,
 		mappingOptions...)
 }

--- a/pkg/controller/cloudfront/distribution/lateinit.go
+++ b/pkg/controller/cloudfront/distribution/lateinit.go
@@ -284,15 +284,15 @@ func lateInitCacheBehavior(in *svcapitypes.CacheBehavior, from *svcsdk.CacheBeha
 
 		in.AllowedMethods.Items = awsclients.LateInitializeStringPtrSlice(in.AllowedMethods.Items, from.AllowedMethods.Items)
 		in.AllowedMethods.Quantity = awsclients.LateInitializeInt64Ptr(in.AllowedMethods.Quantity, from.AllowedMethods.Quantity)
-	}
 
-	if from.AllowedMethods.CachedMethods != nil {
-		if in.AllowedMethods.CachedMethods == nil {
-			in.AllowedMethods.CachedMethods = &svcapitypes.CachedMethods{}
+		if from.AllowedMethods.CachedMethods != nil {
+			if in.AllowedMethods.CachedMethods == nil {
+				in.AllowedMethods.CachedMethods = &svcapitypes.CachedMethods{}
+			}
+
+			in.AllowedMethods.CachedMethods.Items = awsclients.LateInitializeStringPtrSlice(in.AllowedMethods.CachedMethods.Items, from.AllowedMethods.CachedMethods.Items)
+			in.AllowedMethods.CachedMethods.Quantity = awsclients.LateInitializeInt64Ptr(in.AllowedMethods.CachedMethods.Quantity, from.AllowedMethods.CachedMethods.Quantity)
 		}
-
-		in.AllowedMethods.CachedMethods.Items = awsclients.LateInitializeStringPtrSlice(in.AllowedMethods.CachedMethods.Items, from.AllowedMethods.CachedMethods.Items)
-		in.AllowedMethods.CachedMethods.Quantity = awsclients.LateInitializeInt64Ptr(in.AllowedMethods.CachedMethods.Quantity, from.AllowedMethods.CachedMethods.Quantity)
 	}
 
 	in.CachePolicyID = awsclients.LateInitializeStringPtr(in.CachePolicyID, from.CachePolicyId)
@@ -428,10 +428,10 @@ func lateInitOriginGroup(in *svcapitypes.OriginGroup, from *svcsdk.OriginGroup) 
 			if in.FailoverCriteria.StatusCodes == nil {
 				in.FailoverCriteria.StatusCodes = &svcapitypes.StatusCodes{}
 			}
-		}
 
-		in.FailoverCriteria.StatusCodes.Items = awsclients.LateInitializeInt64PtrSlice(in.FailoverCriteria.StatusCodes.Items, from.FailoverCriteria.StatusCodes.Items)
-		in.FailoverCriteria.StatusCodes.Quantity = awsclients.LateInitializeInt64Ptr(in.FailoverCriteria.StatusCodes.Quantity, from.FailoverCriteria.StatusCodes.Quantity)
+			in.FailoverCriteria.StatusCodes.Items = awsclients.LateInitializeInt64PtrSlice(in.FailoverCriteria.StatusCodes.Items, from.FailoverCriteria.StatusCodes.Items)
+			in.FailoverCriteria.StatusCodes.Quantity = awsclients.LateInitializeInt64Ptr(in.FailoverCriteria.StatusCodes.Quantity, from.FailoverCriteria.StatusCodes.Quantity)
+		}
 	}
 
 	in.ID = awsclients.LateInitializeStringPtr(in.ID, from.Id)
@@ -502,7 +502,7 @@ func lateInitOrigins(in *svcapitypes.Origins, from *svcsdk.Origins) {
 	}
 
 	// If we have some origins we need to late init each one from its
-	// corresponding origin in the API API (if any).
+	// corresponding origin in the API (if any).
 	existing := make(map[string]*svcsdk.Origin)
 	for i := range from.Items {
 		o := from.Items[i]

--- a/pkg/controller/cloudfront/distribution/lateinit.go
+++ b/pkg/controller/cloudfront/distribution/lateinit.go
@@ -1,0 +1,622 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// NOTE(negz): We disable the gocyclo and staticcheck linters below because late
+// init functions are inherently branchy, and because staticheck reports a lot
+// of deprecation warnings in the CloudFront SDK that we can't address without a
+// breaking change. We also need to turn off golint so that it doesn't complain
+// about the nolint directive not being a valid package comment string. :| I
+// believe this is only turning off these linters for this file.
+
+//nolint:gocyclo,staticcheck,golint
+package distribution
+
+import (
+	svcsdk "github.com/aws/aws-sdk-go/service/cloudfront"
+
+	svcapitypes "github.com/crossplane/provider-aws/apis/cloudfront/v1alpha1"
+	awsclients "github.com/crossplane/provider-aws/pkg/clients"
+)
+
+// TODO(negz): Every field of the generated DistributionParameters is a pointer.
+// Are they really all optional and thus late-init-able? I'm pretty sure despite
+// what the AWS SDK says that some of these fields are required.
+
+// TODO(negz): We should ask the code generator to ignore all the 'quantity'
+// fields and just infer them from the length of their associated items slice.
+// Currently we only do this for Origins, for reasons that are unclear.
+// https://github.com/crossplane/provider-aws/issues/789
+
+func lateInitialize(dp *svcapitypes.DistributionParameters, gdo *svcsdk.GetDistributionOutput) error {
+	if gdo.Distribution == nil || gdo.Distribution.DistributionConfig == nil {
+		return nil
+	}
+
+	if dp.DistributionConfig == nil {
+		dp.DistributionConfig = &svcapitypes.DistributionConfig{}
+	}
+
+	// For brevity, since this is really the only thing we're working with.
+	in := dp.DistributionConfig
+	from := gdo.Distribution.DistributionConfig
+
+	if from.Aliases != nil {
+		if in.Aliases == nil {
+			in.Aliases = &svcapitypes.Aliases{}
+		}
+
+		in.Aliases.Items = awsclients.LateInitializeStringPtrSlice(in.Aliases.Items, from.Aliases.Items)
+		in.Aliases.Quantity = awsclients.LateInitializeInt64Ptr(in.Aliases.Quantity, from.Aliases.Quantity)
+	}
+
+	if from.CacheBehaviors != nil {
+		if in.CacheBehaviors == nil {
+			in.CacheBehaviors = &svcapitypes.CacheBehaviors{}
+		}
+
+		lateInitCacheBehaviors(in.CacheBehaviors, from.CacheBehaviors)
+	}
+
+	in.Comment = awsclients.LateInitializeStringPtr(in.Comment, from.Comment)
+
+	if from.CustomErrorResponses != nil {
+		if in.CustomErrorResponses == nil {
+			in.CustomErrorResponses = &svcapitypes.CustomErrorResponses{}
+		}
+
+		lateInitCustomErrorResponses(in.CustomErrorResponses, from.CustomErrorResponses)
+	}
+
+	if from.DefaultCacheBehavior != nil {
+		if in.DefaultCacheBehavior == nil {
+			in.DefaultCacheBehavior = &svcapitypes.DefaultCacheBehavior{}
+		}
+
+		lateInitDefaultCacheBehavior(in.DefaultCacheBehavior, from.DefaultCacheBehavior)
+	}
+
+	in.DefaultRootObject = awsclients.LateInitializeStringPtr(in.DefaultRootObject, from.DefaultRootObject)
+	in.Enabled = awsclients.LateInitializeBoolPtr(in.Enabled, from.Enabled)
+	in.HTTPVersion = awsclients.LateInitializeStringPtr(in.HTTPVersion, from.HttpVersion)
+	in.IsIPV6Enabled = awsclients.LateInitializeBoolPtr(in.IsIPV6Enabled, from.IsIPV6Enabled)
+
+	if from.Logging != nil {
+		if in.Logging == nil {
+			in.Logging = &svcapitypes.LoggingConfig{}
+		}
+		in.Logging.Bucket = awsclients.LateInitializeStringPtr(in.Logging.Bucket, from.Logging.Bucket)
+		in.Logging.Enabled = awsclients.LateInitializeBoolPtr(in.Logging.Enabled, from.Logging.Enabled)
+		in.Logging.IncludeCookies = awsclients.LateInitializeBoolPtr(in.Logging.IncludeCookies, from.Logging.IncludeCookies)
+		in.Logging.Prefix = awsclients.LateInitializeStringPtr(in.Logging.Prefix, from.Logging.Prefix)
+	}
+
+	if from.OriginGroups != nil {
+		if in.OriginGroups == nil {
+			in.OriginGroups = &svcapitypes.OriginGroups{}
+		}
+
+		lateInitOriginGroups(in.OriginGroups, from.OriginGroups)
+	}
+
+	if from.Origins != nil {
+		if in.Origins == nil {
+			in.Origins = &svcapitypes.Origins{}
+		}
+
+		lateInitOrigins(in.Origins, from.Origins)
+	}
+
+	in.PriceClass = awsclients.LateInitializeStringPtr(in.PriceClass, from.PriceClass)
+
+	if from.Restrictions != nil {
+		if in.Restrictions == nil {
+			in.Restrictions = &svcapitypes.Restrictions{}
+		}
+
+		if from.Restrictions.GeoRestriction != nil {
+			if in.Restrictions.GeoRestriction == nil {
+				in.Restrictions.GeoRestriction = &svcapitypes.GeoRestriction{}
+			}
+
+			in.Restrictions.GeoRestriction.Quantity = awsclients.LateInitializeInt64Ptr(in.Restrictions.GeoRestriction.Quantity, from.Restrictions.GeoRestriction.Quantity)
+			in.Restrictions.GeoRestriction.Items = awsclients.LateInitializeStringPtrSlice(in.Restrictions.GeoRestriction.Items, from.Restrictions.GeoRestriction.Items)
+			in.Restrictions.GeoRestriction.RestrictionType = awsclients.LateInitializeStringPtr(in.Restrictions.GeoRestriction.RestrictionType, from.Restrictions.GeoRestriction.RestrictionType)
+		}
+	}
+	if from.ViewerCertificate != nil {
+		if in.ViewerCertificate == nil {
+			in.ViewerCertificate = &svcapitypes.ViewerCertificate{}
+		}
+
+		in.ViewerCertificate.ACMCertificateARN = awsclients.LateInitializeStringPtr(in.ViewerCertificate.ACMCertificateARN, from.ViewerCertificate.ACMCertificateArn)
+		in.ViewerCertificate.Certificate = awsclients.LateInitializeStringPtr(in.ViewerCertificate.Certificate, from.ViewerCertificate.Certificate)
+		in.ViewerCertificate.CertificateSource = awsclients.LateInitializeStringPtr(in.ViewerCertificate.CertificateSource, from.ViewerCertificate.CertificateSource)
+		in.ViewerCertificate.CloudFrontDefaultCertificate = awsclients.LateInitializeBoolPtr(in.ViewerCertificate.CloudFrontDefaultCertificate, from.ViewerCertificate.CloudFrontDefaultCertificate)
+		in.ViewerCertificate.IAMCertificateID = awsclients.LateInitializeStringPtr(in.ViewerCertificate.IAMCertificateID, from.ViewerCertificate.IAMCertificateId)
+		in.ViewerCertificate.MinimumProtocolVersion = awsclients.LateInitializeStringPtr(in.ViewerCertificate.MinimumProtocolVersion, from.ViewerCertificate.MinimumProtocolVersion)
+		in.ViewerCertificate.SSLSupportMethod = awsclients.LateInitializeStringPtr(in.ViewerCertificate.SSLSupportMethod, from.ViewerCertificate.SSLSupportMethod)
+	}
+
+	in.WebACLID = awsclients.LateInitializeStringPtr(in.WebACLID, from.WebACLId)
+
+	return nil
+}
+
+func lateInitDefaultCacheBehavior(in *svcapitypes.DefaultCacheBehavior, from *svcsdk.DefaultCacheBehavior) {
+	if from.AllowedMethods != nil {
+		if in.AllowedMethods == nil {
+			in.AllowedMethods = &svcapitypes.AllowedMethods{}
+		}
+
+		in.AllowedMethods.Items = awsclients.LateInitializeStringPtrSlice(in.AllowedMethods.Items, from.AllowedMethods.Items)
+		in.AllowedMethods.Quantity = awsclients.LateInitializeInt64Ptr(in.AllowedMethods.Quantity, from.AllowedMethods.Quantity)
+
+		if from.AllowedMethods.CachedMethods != nil {
+			if in.AllowedMethods.CachedMethods == nil {
+				in.AllowedMethods.CachedMethods = &svcapitypes.CachedMethods{}
+			}
+
+			in.AllowedMethods.CachedMethods.Items = awsclients.LateInitializeStringPtrSlice(in.AllowedMethods.CachedMethods.Items, from.AllowedMethods.CachedMethods.Items)
+			in.AllowedMethods.CachedMethods.Quantity = awsclients.LateInitializeInt64Ptr(in.AllowedMethods.CachedMethods.Quantity, from.AllowedMethods.CachedMethods.Quantity)
+		}
+	}
+
+	in.CachePolicyID = awsclients.LateInitializeStringPtr(in.CachePolicyID, from.CachePolicyId)
+	in.Compress = awsclients.LateInitializeBoolPtr(in.Compress, from.Compress)
+	in.DefaultTTL = awsclients.LateInitializeInt64Ptr(in.DefaultTTL, from.DefaultTTL)
+	in.FieldLevelEncryptionID = awsclients.LateInitializeStringPtr(in.FieldLevelEncryptionID, from.FieldLevelEncryptionId)
+
+	if from.ForwardedValues != nil {
+		if in.ForwardedValues == nil {
+			in.ForwardedValues = &svcapitypes.ForwardedValues{}
+		}
+
+		if from.ForwardedValues.Cookies != nil {
+			if in.ForwardedValues.Cookies == nil {
+				in.ForwardedValues.Cookies = &svcapitypes.CookiePreference{}
+			}
+
+			in.ForwardedValues.Cookies.Forward = awsclients.LateInitializeStringPtr(in.ForwardedValues.Cookies.Forward, from.ForwardedValues.Cookies.Forward)
+
+			if from.ForwardedValues.Cookies.WhitelistedNames != nil {
+				if in.ForwardedValues.Cookies.WhitelistedNames == nil {
+					in.ForwardedValues.Cookies.WhitelistedNames = &svcapitypes.CookieNames{}
+				}
+
+				in.ForwardedValues.Cookies.WhitelistedNames.Items = awsclients.LateInitializeStringPtrSlice(in.ForwardedValues.Cookies.WhitelistedNames.Items, from.ForwardedValues.Cookies.WhitelistedNames.Items)
+				in.ForwardedValues.Cookies.WhitelistedNames.Quantity = awsclients.LateInitializeInt64Ptr(in.ForwardedValues.Cookies.WhitelistedNames.Quantity, from.ForwardedValues.Cookies.WhitelistedNames.Quantity)
+			}
+		}
+
+		if from.ForwardedValues.Headers != nil {
+			if in.ForwardedValues.Headers == nil {
+				in.ForwardedValues.Headers = &svcapitypes.Headers{}
+			}
+
+			in.ForwardedValues.Headers.Items = awsclients.LateInitializeStringPtrSlice(in.ForwardedValues.Headers.Items, from.ForwardedValues.Headers.Items)
+			in.ForwardedValues.Headers.Quantity = awsclients.LateInitializeInt64Ptr(in.ForwardedValues.Headers.Quantity, from.ForwardedValues.Headers.Quantity)
+
+		}
+
+		in.ForwardedValues.QueryString = awsclients.LateInitializeBoolPtr(in.ForwardedValues.QueryString, from.ForwardedValues.QueryString)
+
+		if from.ForwardedValues.QueryStringCacheKeys != nil {
+			if in.ForwardedValues.QueryStringCacheKeys == nil {
+				in.ForwardedValues.QueryStringCacheKeys = &svcapitypes.QueryStringCacheKeys{}
+			}
+
+			in.ForwardedValues.QueryStringCacheKeys.Items = awsclients.LateInitializeStringPtrSlice(in.ForwardedValues.QueryStringCacheKeys.Items, from.ForwardedValues.QueryStringCacheKeys.Items)
+			in.ForwardedValues.QueryStringCacheKeys.Quantity = awsclients.LateInitializeInt64Ptr(in.ForwardedValues.QueryStringCacheKeys.Quantity, from.ForwardedValues.QueryStringCacheKeys.Quantity)
+		}
+	}
+
+	if from.LambdaFunctionAssociations != nil {
+		if in.LambdaFunctionAssociations == nil {
+			in.LambdaFunctionAssociations = &svcapitypes.LambdaFunctionAssociations{}
+		}
+		lateInitLambdaFunctionAssociations(in.LambdaFunctionAssociations, from.LambdaFunctionAssociations)
+	}
+
+	in.MaxTTL = awsclients.LateInitializeInt64Ptr(in.MaxTTL, from.MaxTTL)
+	in.MinTTL = awsclients.LateInitializeInt64Ptr(in.MinTTL, from.MinTTL)
+	in.OriginRequestPolicyID = awsclients.LateInitializeStringPtr(in.OriginRequestPolicyID, from.OriginRequestPolicyId)
+	in.RealtimeLogConfigARN = awsclients.LateInitializeStringPtr(in.RealtimeLogConfigARN, from.RealtimeLogConfigArn)
+	in.SmoothStreaming = awsclients.LateInitializeBoolPtr(in.SmoothStreaming, from.SmoothStreaming)
+	in.TargetOriginID = awsclients.LateInitializeStringPtr(in.TargetOriginID, from.TargetOriginId)
+
+	if from.TrustedKeyGroups != nil {
+		if in.TrustedKeyGroups == nil {
+			in.TrustedKeyGroups = &svcapitypes.TrustedKeyGroups{}
+		}
+
+		in.TrustedKeyGroups.Enabled = awsclients.LateInitializeBoolPtr(in.TrustedKeyGroups.Enabled, from.TrustedKeyGroups.Enabled)
+		in.TrustedKeyGroups.Items = awsclients.LateInitializeStringPtrSlice(in.TrustedKeyGroups.Items, from.TrustedKeyGroups.Items)
+		in.TrustedKeyGroups.Quantity = awsclients.LateInitializeInt64Ptr(in.TrustedKeyGroups.Quantity, from.TrustedKeyGroups.Quantity)
+	}
+
+	if from.TrustedSigners != nil {
+		if in.TrustedSigners == nil {
+			in.TrustedSigners = &svcapitypes.TrustedSigners{}
+		}
+
+		in.TrustedSigners.Enabled = awsclients.LateInitializeBoolPtr(in.TrustedSigners.Enabled, from.TrustedSigners.Enabled)
+		in.TrustedSigners.Items = awsclients.LateInitializeStringPtrSlice(in.TrustedSigners.Items, from.TrustedSigners.Items)
+		in.TrustedSigners.Quantity = awsclients.LateInitializeInt64Ptr(in.TrustedSigners.Quantity, from.TrustedSigners.Quantity)
+	}
+
+	in.ViewerProtocolPolicy = awsclients.LateInitializeStringPtr(in.ViewerProtocolPolicy, from.ViewerProtocolPolicy)
+}
+
+func lateInitCacheBehaviors(in *svcapitypes.CacheBehaviors, from *svcsdk.CacheBehaviors) {
+	in.Quantity = awsclients.LateInitializeInt64Ptr(in.Quantity, from.Quantity)
+
+	if len(from.Items) == 0 || in.Items != nil {
+		return
+	}
+
+	in.Items = make([]*svcapitypes.CacheBehavior, len(from.Items))
+	for i := range from.Items {
+		in.Items[i] = &svcapitypes.CacheBehavior{}
+		lateInitCacheBehavior(in.Items[i], from.Items[i])
+	}
+}
+
+// This is _almost_ identical to lateInitDefaultCacheBehaviour, but it has an
+// additional 'PathPattern' field.
+func lateInitCacheBehavior(in *svcapitypes.CacheBehavior, from *svcsdk.CacheBehavior) {
+	if from.AllowedMethods != nil {
+		if in.AllowedMethods == nil {
+			in.AllowedMethods = &svcapitypes.AllowedMethods{}
+		}
+
+		in.AllowedMethods.Items = awsclients.LateInitializeStringPtrSlice(in.AllowedMethods.Items, from.AllowedMethods.Items)
+		in.AllowedMethods.Quantity = awsclients.LateInitializeInt64Ptr(in.AllowedMethods.Quantity, from.AllowedMethods.Quantity)
+	}
+
+	if from.AllowedMethods.CachedMethods != nil {
+		if in.AllowedMethods.CachedMethods == nil {
+			in.AllowedMethods.CachedMethods = &svcapitypes.CachedMethods{}
+		}
+
+		in.AllowedMethods.CachedMethods.Items = awsclients.LateInitializeStringPtrSlice(in.AllowedMethods.CachedMethods.Items, from.AllowedMethods.CachedMethods.Items)
+		in.AllowedMethods.CachedMethods.Quantity = awsclients.LateInitializeInt64Ptr(in.AllowedMethods.CachedMethods.Quantity, from.AllowedMethods.CachedMethods.Quantity)
+	}
+
+	in.CachePolicyID = awsclients.LateInitializeStringPtr(in.CachePolicyID, from.CachePolicyId)
+	in.Compress = awsclients.LateInitializeBoolPtr(in.Compress, from.Compress)
+	in.DefaultTTL = awsclients.LateInitializeInt64Ptr(in.DefaultTTL, from.DefaultTTL)
+	in.FieldLevelEncryptionID = awsclients.LateInitializeStringPtr(in.FieldLevelEncryptionID, from.FieldLevelEncryptionId)
+
+	if from.ForwardedValues != nil {
+		if in.ForwardedValues == nil {
+			in.ForwardedValues = &svcapitypes.ForwardedValues{}
+		}
+
+		if from.ForwardedValues.Cookies != nil {
+			if in.ForwardedValues.Cookies == nil {
+				in.ForwardedValues.Cookies = &svcapitypes.CookiePreference{}
+			}
+
+			in.ForwardedValues.Cookies.Forward = awsclients.LateInitializeStringPtr(in.ForwardedValues.Cookies.Forward, from.ForwardedValues.Cookies.Forward)
+
+			if from.ForwardedValues.Cookies.WhitelistedNames != nil {
+				if in.ForwardedValues.Cookies.WhitelistedNames == nil {
+					in.ForwardedValues.Cookies.WhitelistedNames = &svcapitypes.CookieNames{}
+				}
+
+				in.ForwardedValues.Cookies.WhitelistedNames.Items = awsclients.LateInitializeStringPtrSlice(in.ForwardedValues.Cookies.WhitelistedNames.Items, from.ForwardedValues.Cookies.WhitelistedNames.Items)
+				in.ForwardedValues.Cookies.WhitelistedNames.Quantity = awsclients.LateInitializeInt64Ptr(in.ForwardedValues.Cookies.WhitelistedNames.Quantity, from.ForwardedValues.Cookies.WhitelistedNames.Quantity)
+			}
+		}
+
+		if from.ForwardedValues.Headers != nil {
+			if in.ForwardedValues.Headers == nil {
+				in.ForwardedValues.Headers = &svcapitypes.Headers{}
+			}
+
+			in.ForwardedValues.Headers.Items = awsclients.LateInitializeStringPtrSlice(in.ForwardedValues.Headers.Items, from.ForwardedValues.Headers.Items)
+			in.ForwardedValues.Headers.Quantity = awsclients.LateInitializeInt64Ptr(in.ForwardedValues.Headers.Quantity, from.ForwardedValues.Headers.Quantity)
+
+		}
+
+		in.ForwardedValues.QueryString = awsclients.LateInitializeBoolPtr(in.ForwardedValues.QueryString, from.ForwardedValues.QueryString)
+
+		if from.ForwardedValues.QueryStringCacheKeys != nil {
+			if in.ForwardedValues.QueryStringCacheKeys == nil {
+				in.ForwardedValues.QueryStringCacheKeys = &svcapitypes.QueryStringCacheKeys{}
+			}
+
+			in.ForwardedValues.QueryStringCacheKeys.Items = awsclients.LateInitializeStringPtrSlice(in.ForwardedValues.QueryStringCacheKeys.Items, from.ForwardedValues.QueryStringCacheKeys.Items)
+			in.ForwardedValues.QueryStringCacheKeys.Quantity = awsclients.LateInitializeInt64Ptr(in.ForwardedValues.QueryStringCacheKeys.Quantity, from.ForwardedValues.QueryStringCacheKeys.Quantity)
+		}
+	}
+
+	if from.LambdaFunctionAssociations != nil {
+		if in.LambdaFunctionAssociations == nil {
+			in.LambdaFunctionAssociations = &svcapitypes.LambdaFunctionAssociations{}
+		}
+
+		lateInitLambdaFunctionAssociations(in.LambdaFunctionAssociations, from.LambdaFunctionAssociations)
+	}
+
+	in.MaxTTL = awsclients.LateInitializeInt64Ptr(in.MaxTTL, from.MaxTTL)
+	in.MinTTL = awsclients.LateInitializeInt64Ptr(in.MinTTL, from.MinTTL)
+	in.OriginRequestPolicyID = awsclients.LateInitializeStringPtr(in.OriginRequestPolicyID, from.OriginRequestPolicyId)
+	in.PathPattern = awsclients.LateInitializeStringPtr(in.PathPattern, from.PathPattern)
+	in.RealtimeLogConfigARN = awsclients.LateInitializeStringPtr(in.RealtimeLogConfigARN, from.RealtimeLogConfigArn)
+	in.SmoothStreaming = awsclients.LateInitializeBoolPtr(in.SmoothStreaming, from.SmoothStreaming)
+	in.TargetOriginID = awsclients.LateInitializeStringPtr(in.TargetOriginID, from.TargetOriginId)
+
+	if from.TrustedKeyGroups != nil {
+		if in.TrustedKeyGroups == nil {
+			in.TrustedKeyGroups = &svcapitypes.TrustedKeyGroups{}
+		}
+
+		in.TrustedKeyGroups.Enabled = awsclients.LateInitializeBoolPtr(in.TrustedKeyGroups.Enabled, from.TrustedKeyGroups.Enabled)
+		in.TrustedKeyGroups.Items = awsclients.LateInitializeStringPtrSlice(in.TrustedKeyGroups.Items, from.TrustedKeyGroups.Items)
+		in.TrustedKeyGroups.Quantity = awsclients.LateInitializeInt64Ptr(in.TrustedKeyGroups.Quantity, from.TrustedKeyGroups.Quantity)
+	}
+
+	if from.TrustedSigners != nil {
+		if in.TrustedSigners == nil {
+			in.TrustedSigners = &svcapitypes.TrustedSigners{}
+		}
+
+		in.TrustedSigners.Enabled = awsclients.LateInitializeBoolPtr(in.TrustedSigners.Enabled, from.TrustedSigners.Enabled)
+		in.TrustedSigners.Items = awsclients.LateInitializeStringPtrSlice(in.TrustedSigners.Items, from.TrustedSigners.Items)
+		in.TrustedSigners.Quantity = awsclients.LateInitializeInt64Ptr(in.TrustedSigners.Quantity, from.TrustedSigners.Quantity)
+	}
+
+	in.ViewerProtocolPolicy = awsclients.LateInitializeStringPtr(in.ViewerProtocolPolicy, from.ViewerProtocolPolicy)
+}
+
+func lateInitCustomErrorResponses(in *svcapitypes.CustomErrorResponses, from *svcsdk.CustomErrorResponses) {
+	in.Quantity = awsclients.LateInitializeInt64Ptr(in.Quantity, from.Quantity)
+
+	if len(from.Items) == 0 || in.Items != nil {
+		return
+	}
+
+	in.Items = make([]*svcapitypes.CustomErrorResponse, len(from.Items))
+	for i := range from.Items {
+		in.Items[i] = &svcapitypes.CustomErrorResponse{}
+		lateInitCustomErrorResponse(in.Items[i], from.Items[i])
+	}
+}
+
+func lateInitCustomErrorResponse(in *svcapitypes.CustomErrorResponse, from *svcsdk.CustomErrorResponse) {
+	in.ErrorCachingMinTTL = awsclients.LateInitializeInt64Ptr(in.ErrorCachingMinTTL, from.ErrorCachingMinTTL)
+	in.ErrorCode = awsclients.LateInitializeInt64Ptr(in.ErrorCode, from.ErrorCode)
+	in.ResponseCode = awsclients.LateInitializeStringPtr(in.ResponseCode, from.ResponseCode)
+	in.ResponsePagePath = awsclients.LateInitializeStringPtr(in.ResponsePagePath, from.ResponsePagePath)
+}
+
+func lateInitOriginGroups(in *svcapitypes.OriginGroups, from *svcsdk.OriginGroups) {
+	in.Quantity = awsclients.LateInitializeInt64Ptr(in.Quantity, from.Quantity)
+
+	if len(from.Items) == 0 || in.Items != nil {
+		return
+	}
+
+	in.Items = make([]*svcapitypes.OriginGroup, len(from.Items))
+	for i := range from.Items {
+		in.Items[i] = &svcapitypes.OriginGroup{}
+		lateInitOriginGroup(in.Items[i], from.Items[i])
+	}
+}
+
+func lateInitOriginGroup(in *svcapitypes.OriginGroup, from *svcsdk.OriginGroup) {
+	if from.FailoverCriteria != nil {
+		if in.FailoverCriteria == nil {
+			in.FailoverCriteria = &svcapitypes.OriginGroupFailoverCriteria{}
+		}
+
+		if from.FailoverCriteria.StatusCodes != nil {
+			if in.FailoverCriteria.StatusCodes == nil {
+				in.FailoverCriteria.StatusCodes = &svcapitypes.StatusCodes{}
+			}
+		}
+
+		in.FailoverCriteria.StatusCodes.Items = awsclients.LateInitializeInt64PtrSlice(in.FailoverCriteria.StatusCodes.Items, from.FailoverCriteria.StatusCodes.Items)
+		in.FailoverCriteria.StatusCodes.Quantity = awsclients.LateInitializeInt64Ptr(in.FailoverCriteria.StatusCodes.Quantity, from.FailoverCriteria.StatusCodes.Quantity)
+	}
+
+	in.ID = awsclients.LateInitializeStringPtr(in.ID, from.Id)
+
+	if from.Members != nil {
+		if in.Members == nil {
+			in.Members = &svcapitypes.OriginGroupMembers{}
+		}
+
+		lateInitOriginGroupMembers(in.Members, from.Members)
+	}
+}
+
+func lateInitOriginGroupMembers(in *svcapitypes.OriginGroupMembers, from *svcsdk.OriginGroupMembers) {
+	in.Quantity = awsclients.LateInitializeInt64Ptr(in.Quantity, from.Quantity)
+
+	// TODO(negz): I believe OriginGroupMembers have an ID field, so we may
+	// be able to match them by ID when late-initializing like we do for
+	// Origins.
+	if len(from.Items) == 0 || in.Items != nil {
+		return
+	}
+
+	in.Items = make([]*svcapitypes.OriginGroupMember, len(from.Items))
+	for i := range from.Items {
+		in.Items[i] = &svcapitypes.OriginGroupMember{}
+		lateInitOriginGroupMember(in.Items[i], from.Items[i])
+	}
+}
+
+func lateInitOriginGroupMember(in *svcapitypes.OriginGroupMember, from *svcsdk.OriginGroupMember) {
+	in.OriginID = awsclients.LateInitializeStringPtr(in.OriginID, from.OriginId)
+}
+
+// NOTE(negz): The CloudFront API relies heavily on late-initialization. There
+// are more required fields when _updating_ a Distribution than there are when
+// creating a Distribution. Callers are expected to create a Distribution, read
+// back the defaulted fields, then supply those fields to do an update. This
+// means we need to thoroughly late-init those defaulted fields.
+//
+// This is a problem because the API has a lot of fields that are optional at
+// create time. It's an even bigger problem because many of the fields we need
+// to late initialize are fields of structs that are slice members, and because
+// the AWS API doesn't seem to return those slices in the same order they're
+// sent so we can't simply use ordering to match them.
+//
+// We know we need to late-init origins for updates to work, and we can do that
+// by using the ID key to match them.
+//
+// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-overview-required-fields.html
+func lateInitOrigins(in *svcapitypes.Origins, from *svcsdk.Origins) {
+	// NOTE(negz): This is the only type where we the code generator ignores
+	// the quantity field and we infer it from the slice's length.
+
+	if len(from.Items) == 0 {
+		return
+	}
+
+	// If we have no origins, just late init the entire slice.
+	if in.Items == nil {
+		in.Items = make([]*svcapitypes.Origin, len(from.Items))
+		for i := range from.Items {
+			in.Items[i] = &svcapitypes.Origin{}
+			lateInitOrigin(in.Items[i], from.Items[i])
+		}
+
+		return
+	}
+
+	// If we have some origins we need to late init each one from its
+	// corresponding origin in the API API (if any).
+	existing := make(map[string]*svcsdk.Origin)
+	for i := range from.Items {
+		o := from.Items[i]
+		if o.Id == nil {
+			continue
+		}
+		existing[awsclients.StringValue(o.Id)] = o
+	}
+
+	for i := range in.Items {
+		io := in.Items[i]
+		if io.ID == nil {
+			continue
+		}
+
+		fo := existing[awsclients.StringValue(io.ID)]
+		if fo == nil {
+			continue
+		}
+
+		lateInitOrigin(io, fo)
+	}
+}
+
+func lateInitOrigin(in *svcapitypes.Origin, from *svcsdk.Origin) {
+	in.ConnectionAttempts = awsclients.LateInitializeInt64Ptr(in.ConnectionAttempts, from.ConnectionAttempts)
+	in.ConnectionTimeout = awsclients.LateInitializeInt64Ptr(in.ConnectionTimeout, from.ConnectionTimeout)
+
+	if from.CustomHeaders != nil {
+		if in.CustomHeaders == nil {
+			in.CustomHeaders = &svcapitypes.CustomHeaders{}
+		}
+
+		lateInitOriginCustomHeaders(in.CustomHeaders, from.CustomHeaders)
+	}
+
+	if from.CustomOriginConfig != nil {
+		if in.CustomOriginConfig == nil {
+			in.CustomOriginConfig = &svcapitypes.CustomOriginConfig{}
+		}
+
+		in.CustomOriginConfig.HTTPPort = awsclients.LateInitializeInt64Ptr(in.CustomOriginConfig.HTTPPort, from.CustomOriginConfig.HTTPPort)
+		in.CustomOriginConfig.HTTPSPort = awsclients.LateInitializeInt64Ptr(in.CustomOriginConfig.HTTPSPort, from.CustomOriginConfig.HTTPSPort)
+		in.CustomOriginConfig.OriginKeepaliveTimeout = awsclients.LateInitializeInt64Ptr(in.CustomOriginConfig.OriginKeepaliveTimeout, from.CustomOriginConfig.OriginKeepaliveTimeout)
+		in.CustomOriginConfig.OriginProtocolPolicy = awsclients.LateInitializeStringPtr(in.CustomOriginConfig.OriginProtocolPolicy, from.CustomOriginConfig.OriginProtocolPolicy)
+		in.CustomOriginConfig.OriginReadTimeout = awsclients.LateInitializeInt64Ptr(in.CustomOriginConfig.OriginReadTimeout, from.CustomOriginConfig.OriginReadTimeout)
+
+		if from.CustomOriginConfig.OriginSslProtocols != nil {
+			if in.CustomOriginConfig.OriginSSLProtocols == nil {
+				in.CustomOriginConfig.OriginSSLProtocols = &svcapitypes.OriginSSLProtocols{}
+			}
+
+			in.CustomOriginConfig.OriginSSLProtocols.Items = awsclients.LateInitializeStringPtrSlice(in.CustomOriginConfig.OriginSSLProtocols.Items, from.CustomOriginConfig.OriginSslProtocols.Items)
+			in.CustomOriginConfig.OriginSSLProtocols.Quantity = awsclients.LateInitializeInt64Ptr(in.CustomOriginConfig.OriginSSLProtocols.Quantity, from.CustomOriginConfig.OriginSslProtocols.Quantity)
+		}
+	}
+
+	in.DomainName = awsclients.LateInitializeStringPtr(in.DomainName, from.DomainName)
+	in.ID = awsclients.LateInitializeStringPtr(in.ID, from.Id)
+	in.OriginPath = awsclients.LateInitializeStringPtr(in.OriginPath, from.OriginPath)
+
+	if from.OriginShield != nil {
+		if in.OriginShield == nil {
+			in.OriginShield = &svcapitypes.OriginShield{}
+		}
+
+		in.OriginShield.Enabled = awsclients.LateInitializeBoolPtr(in.OriginShield.Enabled, from.OriginShield.Enabled)
+		in.OriginShield.OriginShieldRegion = awsclients.LateInitializeStringPtr(in.OriginShield.OriginShieldRegion, from.OriginShield.OriginShieldRegion)
+	}
+
+	if from.S3OriginConfig != nil {
+		if in.S3OriginConfig == nil {
+			in.S3OriginConfig = &svcapitypes.S3OriginConfig{}
+		}
+
+		in.S3OriginConfig.OriginAccessIDentity = awsclients.LateInitializeStringPtr(in.S3OriginConfig.OriginAccessIDentity, from.S3OriginConfig.OriginAccessIdentity)
+	}
+}
+
+func lateInitOriginCustomHeaders(in *svcapitypes.CustomHeaders, from *svcsdk.CustomHeaders) {
+	in.Quantity = awsclients.LateInitializeInt64Ptr(in.Quantity, from.Quantity)
+
+	if len(from.Items) == 0 || in.Items != nil {
+		return
+	}
+
+	in.Items = make([]*svcapitypes.OriginCustomHeader, len(from.Items))
+	for i := range from.Items {
+		in.Items[i] = &svcapitypes.OriginCustomHeader{}
+		lateInitOriginCustomHeader(in.Items[i], from.Items[i])
+	}
+}
+
+func lateInitOriginCustomHeader(in *svcapitypes.OriginCustomHeader, from *svcsdk.OriginCustomHeader) {
+	in.HeaderName = awsclients.LateInitializeStringPtr(in.HeaderName, from.HeaderName)
+	in.HeaderValue = awsclients.LateInitializeStringPtr(in.HeaderValue, from.HeaderValue)
+}
+
+func lateInitLambdaFunctionAssociations(in *svcapitypes.LambdaFunctionAssociations, from *svcsdk.LambdaFunctionAssociations) {
+	in.Quantity = awsclients.LateInitializeInt64Ptr(in.Quantity, from.Quantity)
+
+	if len(from.Items) == 0 || in.Items != nil {
+		return
+	}
+
+	in.Items = make([]*svcapitypes.LambdaFunctionAssociation, len(from.Items))
+	for i := range from.Items {
+		in.Items[i] = &svcapitypes.LambdaFunctionAssociation{}
+		lateInitLambdaFunctionAssociation(in.Items[i], from.Items[i])
+	}
+}
+
+func lateInitLambdaFunctionAssociation(in *svcapitypes.LambdaFunctionAssociation, from *svcsdk.LambdaFunctionAssociation) {
+	in.EventType = awsclients.LateInitializeStringPtr(in.EventType, from.EventType)
+	in.IncludeBody = awsclients.LateInitializeBoolPtr(in.IncludeBody, from.IncludeBody)
+	in.LambdaFunctionARN = awsclients.LateInitializeStringPtr(in.LambdaFunctionARN, from.LambdaFunctionARN)
+}

--- a/pkg/controller/cloudfront/distribution/lateinit_test.go
+++ b/pkg/controller/cloudfront/distribution/lateinit_test.go
@@ -1,0 +1,550 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package distribution
+
+import (
+	"testing"
+
+	svcsdk "github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/google/go-cmp/cmp"
+
+	svcapitypes "github.com/crossplane/provider-aws/apis/cloudfront/v1alpha1"
+	awsclients "github.com/crossplane/provider-aws/pkg/clients"
+)
+
+func TestLateInitialize(t *testing.T) {
+	type args struct {
+		dp  *svcapitypes.DistributionParameters
+		gdo *svcsdk.GetDistributionOutput
+	}
+	cases := map[string]struct {
+		args args
+		want *svcapitypes.DistributionParameters
+	}{
+		"NilDistribution": {
+			args: args{
+				gdo: &svcsdk.GetDistributionOutput{},
+			},
+		},
+		"NilDistributionConfig": {
+			args: args{
+				gdo: &svcsdk.GetDistributionOutput{Distribution: &svcsdk.Distribution{}},
+			},
+		},
+		"LateInitAllFields": {
+			args: args{
+				dp: &svcapitypes.DistributionParameters{},
+				gdo: &svcsdk.GetDistributionOutput{
+					Distribution: &svcsdk.Distribution{
+						DistributionConfig: &svcsdk.DistributionConfig{
+							Aliases: &svcsdk.Aliases{
+								Items:    []*string{awsclients.String("example.org")},
+								Quantity: awsclients.Int64(1),
+							},
+							CacheBehaviors: &svcsdk.CacheBehaviors{
+								Items: []*svcsdk.CacheBehavior{{
+									AllowedMethods: &svcsdk.AllowedMethods{
+										Items:    []*string{awsclients.String("GET")},
+										Quantity: awsclients.Int64(1),
+										CachedMethods: &svcsdk.CachedMethods{
+											Items:    []*string{awsclients.String("GET")},
+											Quantity: awsclients.Int64(1),
+										},
+									},
+									CachePolicyId:          awsclients.String("example"),
+									Compress:               awsclients.Bool(true),
+									DefaultTTL:             awsclients.Int64(42),
+									FieldLevelEncryptionId: awsclients.String("example"),
+									ForwardedValues: &svcsdk.ForwardedValues{
+										Cookies: &svcsdk.CookiePreference{
+											Forward: awsclients.String("example"),
+											WhitelistedNames: &svcsdk.CookieNames{
+												Items:    []*string{awsclients.String("example")},
+												Quantity: awsclients.Int64(1),
+											},
+										},
+										Headers: &svcsdk.Headers{
+											Items:    []*string{awsclients.String("X-Hello")},
+											Quantity: awsclients.Int64(1),
+										},
+										QueryString: awsclients.Bool(true),
+										QueryStringCacheKeys: &svcsdk.QueryStringCacheKeys{
+											Items:    []*string{awsclients.String("search")},
+											Quantity: awsclients.Int64(1),
+										},
+									},
+									LambdaFunctionAssociations: &svcsdk.LambdaFunctionAssociations{
+										Items: []*svcsdk.LambdaFunctionAssociation{{
+											EventType:         awsclients.String("good"),
+											IncludeBody:       awsclients.Bool(true),
+											LambdaFunctionARN: awsclients.String("arn"),
+										}},
+										Quantity: awsclients.Int64(1),
+									},
+									MaxTTL:                awsclients.Int64(42),
+									MinTTL:                awsclients.Int64(42),
+									OriginRequestPolicyId: awsclients.String("example"),
+									PathPattern:           awsclients.String("example"),
+									RealtimeLogConfigArn:  awsclients.String("example"),
+									SmoothStreaming:       awsclients.Bool(true),
+									TargetOriginId:        awsclients.String("example"),
+									TrustedKeyGroups: &svcsdk.TrustedKeyGroups{
+										Enabled:  awsclients.Bool(true),
+										Items:    []*string{awsclients.String("the-good-key")},
+										Quantity: awsclients.Int64(1),
+									},
+									TrustedSigners: &svcsdk.TrustedSigners{
+										Enabled:  awsclients.Bool(true),
+										Items:    []*string{awsclients.String("the-good-signer")},
+										Quantity: awsclients.Int64(1),
+									},
+								}},
+								Quantity: awsclients.Int64(1),
+							},
+							CustomErrorResponses: &svcsdk.CustomErrorResponses{
+								Items: []*svcsdk.CustomErrorResponse{{
+									ErrorCachingMinTTL: awsclients.Int64(42),
+									ErrorCode:          awsclients.Int64(418),
+									ResponseCode:       awsclients.String("I'm a teapot"),
+									ResponsePagePath:   awsclients.String("/teapot"),
+								}},
+								Quantity: awsclients.Int64(1),
+							},
+							DefaultCacheBehavior: &svcsdk.DefaultCacheBehavior{
+								AllowedMethods: &svcsdk.AllowedMethods{
+									Items:    []*string{awsclients.String("GET")},
+									Quantity: awsclients.Int64(1),
+									CachedMethods: &svcsdk.CachedMethods{
+										Items:    []*string{awsclients.String("GET")},
+										Quantity: awsclients.Int64(1),
+									},
+								},
+								CachePolicyId:          awsclients.String("example"),
+								Compress:               awsclients.Bool(true),
+								DefaultTTL:             awsclients.Int64(42),
+								FieldLevelEncryptionId: awsclients.String("example"),
+								ForwardedValues: &svcsdk.ForwardedValues{
+									Cookies: &svcsdk.CookiePreference{
+										Forward: awsclients.String("example"),
+										WhitelistedNames: &svcsdk.CookieNames{
+											Items:    []*string{awsclients.String("example")},
+											Quantity: awsclients.Int64(1),
+										},
+									},
+									Headers: &svcsdk.Headers{
+										Items:    []*string{awsclients.String("X-Hello")},
+										Quantity: awsclients.Int64(1),
+									},
+									QueryString: awsclients.Bool(true),
+									QueryStringCacheKeys: &svcsdk.QueryStringCacheKeys{
+										Items:    []*string{awsclients.String("search")},
+										Quantity: awsclients.Int64(1),
+									},
+								},
+								LambdaFunctionAssociations: &svcsdk.LambdaFunctionAssociations{
+									Items: []*svcsdk.LambdaFunctionAssociation{{
+										EventType:         awsclients.String("good"),
+										IncludeBody:       awsclients.Bool(true),
+										LambdaFunctionARN: awsclients.String("arn"),
+									}},
+									Quantity: awsclients.Int64(1),
+								},
+								MaxTTL:                awsclients.Int64(42),
+								MinTTL:                awsclients.Int64(42),
+								OriginRequestPolicyId: awsclients.String("example"),
+								RealtimeLogConfigArn:  awsclients.String("example"),
+								SmoothStreaming:       awsclients.Bool(true),
+								TargetOriginId:        awsclients.String("example"),
+								TrustedKeyGroups: &svcsdk.TrustedKeyGroups{
+									Enabled:  awsclients.Bool(true),
+									Items:    []*string{awsclients.String("the-good-key")},
+									Quantity: awsclients.Int64(1),
+								},
+								TrustedSigners: &svcsdk.TrustedSigners{
+									Enabled:  awsclients.Bool(true),
+									Items:    []*string{awsclients.String("the-good-signer")},
+									Quantity: awsclients.Int64(1),
+								},
+							},
+							DefaultRootObject: awsclients.String("the-good-one"),
+							Enabled:           awsclients.Bool(true),
+							HttpVersion:       awsclients.String("1.1"),
+							IsIPV6Enabled:     awsclients.Bool(true),
+							Logging: &svcsdk.LoggingConfig{
+								Bucket:         awsclients.String("big-logs"),
+								Enabled:        awsclients.Bool(true),
+								IncludeCookies: awsclients.Bool(true),
+								Prefix:         awsclients.String("one-large-log-"),
+							},
+							OriginGroups: &svcsdk.OriginGroups{
+								Items: []*svcsdk.OriginGroup{{
+									FailoverCriteria: &svcsdk.OriginGroupFailoverCriteria{
+										StatusCodes: &svcsdk.StatusCodes{
+											Items:    []*int64{awsclients.Int64(418)},
+											Quantity: awsclients.Int64(1),
+										},
+									},
+									Members: &svcsdk.OriginGroupMembers{
+										Items: []*svcsdk.OriginGroupMember{{
+											OriginId: awsclients.String("example"),
+										}},
+										Quantity: awsclients.Int64(1),
+									},
+								}},
+								Quantity: awsclients.Int64(1),
+							},
+							Origins: &svcsdk.Origins{
+								Items: []*svcsdk.Origin{{
+									ConnectionAttempts: awsclients.Int64(42),
+									ConnectionTimeout:  awsclients.Int64(42),
+									CustomHeaders: &svcsdk.CustomHeaders{
+										Items: []*svcsdk.OriginCustomHeader{{
+											HeaderName:  awsclients.String("X-Cool"),
+											HeaderValue: awsclients.String("very"),
+										}},
+										Quantity: awsclients.Int64(1),
+									},
+									CustomOriginConfig: &svcsdk.CustomOriginConfig{
+										HTTPPort:               awsclients.Int64(8080),
+										HTTPSPort:              awsclients.Int64(443),
+										OriginKeepaliveTimeout: awsclients.Int64(42),
+										OriginProtocolPolicy:   awsclients.String("all-of-them"),
+										OriginReadTimeout:      awsclients.Int64(42),
+										OriginSslProtocols: &svcsdk.OriginSslProtocols{
+											Items:    []*string{awsclients.String("TLS_1.2")},
+											Quantity: awsclients.Int64(1),
+										},
+									},
+									DomainName: awsclients.String("example.org"),
+									Id:         awsclients.String("custom"),
+									OriginPath: awsclients.String("/"),
+									OriginShield: &svcsdk.OriginShield{
+										Enabled:            awsclients.Bool(true),
+										OriginShieldRegion: awsclients.String("us-east-1"),
+									},
+									S3OriginConfig: &svcsdk.S3OriginConfig{
+										OriginAccessIdentity: awsclients.String("cool-guy"),
+									},
+								}},
+								Quantity: awsclients.Int64(1),
+							},
+							PriceClass: awsclients.String("really-cheap"),
+							Restrictions: &svcsdk.Restrictions{
+								GeoRestriction: &svcsdk.GeoRestriction{
+									RestrictionType: awsclients.String("no-australians"),
+									Items:           []*string{awsclients.String("negz"), awsclients.String("kylie")},
+									Quantity:        awsclients.Int64(1),
+								},
+							},
+							ViewerCertificate: &svcsdk.ViewerCertificate{
+								ACMCertificateArn:            awsclients.String("example"),
+								Certificate:                  awsclients.String("example"),
+								CertificateSource:            awsclients.String("trusty-source"),
+								CloudFrontDefaultCertificate: awsclients.Bool(false),
+								IAMCertificateId:             awsclients.String("example"),
+								MinimumProtocolVersion:       awsclients.String("TLS_1.2"),
+								SSLSupportMethod:             awsclients.String("fax"),
+							},
+							WebACLId: awsclients.String("example"),
+						},
+					},
+				},
+			},
+			want: &svcapitypes.DistributionParameters{
+				DistributionConfig: &svcapitypes.DistributionConfig{
+					Aliases: &svcapitypes.Aliases{
+						Items:    []*string{awsclients.String("example.org")},
+						Quantity: awsclients.Int64(1),
+					},
+					CacheBehaviors: &svcapitypes.CacheBehaviors{
+						Items: []*svcapitypes.CacheBehavior{{
+							AllowedMethods: &svcapitypes.AllowedMethods{
+								Items:    []*string{awsclients.String("GET")},
+								Quantity: awsclients.Int64(1),
+								CachedMethods: &svcapitypes.CachedMethods{
+									Items:    []*string{awsclients.String("GET")},
+									Quantity: awsclients.Int64(1),
+								},
+							},
+							CachePolicyID:          awsclients.String("example"),
+							Compress:               awsclients.Bool(true),
+							DefaultTTL:             awsclients.Int64(42),
+							FieldLevelEncryptionID: awsclients.String("example"),
+							ForwardedValues: &svcapitypes.ForwardedValues{
+								Cookies: &svcapitypes.CookiePreference{
+									Forward: awsclients.String("example"),
+									WhitelistedNames: &svcapitypes.CookieNames{
+										Items:    []*string{awsclients.String("example")},
+										Quantity: awsclients.Int64(1),
+									},
+								},
+								Headers: &svcapitypes.Headers{
+									Items:    []*string{awsclients.String("X-Hello")},
+									Quantity: awsclients.Int64(1),
+								},
+								QueryString: awsclients.Bool(true),
+								QueryStringCacheKeys: &svcapitypes.QueryStringCacheKeys{
+									Items:    []*string{awsclients.String("search")},
+									Quantity: awsclients.Int64(1),
+								},
+							},
+							LambdaFunctionAssociations: &svcapitypes.LambdaFunctionAssociations{
+								Items: []*svcapitypes.LambdaFunctionAssociation{{
+									EventType:         awsclients.String("good"),
+									IncludeBody:       awsclients.Bool(true),
+									LambdaFunctionARN: awsclients.String("arn"),
+								}},
+								Quantity: awsclients.Int64(1),
+							},
+							MaxTTL:                awsclients.Int64(42),
+							MinTTL:                awsclients.Int64(42),
+							OriginRequestPolicyID: awsclients.String("example"),
+							PathPattern:           awsclients.String("example"),
+							RealtimeLogConfigARN:  awsclients.String("example"),
+							SmoothStreaming:       awsclients.Bool(true),
+							TargetOriginID:        awsclients.String("example"),
+							TrustedKeyGroups: &svcapitypes.TrustedKeyGroups{
+								Enabled:  awsclients.Bool(true),
+								Items:    []*string{awsclients.String("the-good-key")},
+								Quantity: awsclients.Int64(1),
+							},
+							TrustedSigners: &svcapitypes.TrustedSigners{
+								Enabled:  awsclients.Bool(true),
+								Items:    []*string{awsclients.String("the-good-signer")},
+								Quantity: awsclients.Int64(1),
+							},
+						}},
+						Quantity: awsclients.Int64(1),
+					},
+					CustomErrorResponses: &svcapitypes.CustomErrorResponses{
+						Items: []*svcapitypes.CustomErrorResponse{{
+							ErrorCachingMinTTL: awsclients.Int64(42),
+							ErrorCode:          awsclients.Int64(418),
+							ResponseCode:       awsclients.String("I'm a teapot"),
+							ResponsePagePath:   awsclients.String("/teapot"),
+						}},
+						Quantity: awsclients.Int64(1),
+					},
+					DefaultCacheBehavior: &svcapitypes.DefaultCacheBehavior{
+						AllowedMethods: &svcapitypes.AllowedMethods{
+							Items:    []*string{awsclients.String("GET")},
+							Quantity: awsclients.Int64(1),
+							CachedMethods: &svcapitypes.CachedMethods{
+								Items:    []*string{awsclients.String("GET")},
+								Quantity: awsclients.Int64(1),
+							},
+						},
+						CachePolicyID:          awsclients.String("example"),
+						Compress:               awsclients.Bool(true),
+						DefaultTTL:             awsclients.Int64(42),
+						FieldLevelEncryptionID: awsclients.String("example"),
+						ForwardedValues: &svcapitypes.ForwardedValues{
+							Cookies: &svcapitypes.CookiePreference{
+								Forward: awsclients.String("example"),
+								WhitelistedNames: &svcapitypes.CookieNames{
+									Items:    []*string{awsclients.String("example")},
+									Quantity: awsclients.Int64(1),
+								},
+							},
+							Headers: &svcapitypes.Headers{
+								Items:    []*string{awsclients.String("X-Hello")},
+								Quantity: awsclients.Int64(1),
+							},
+							QueryString: awsclients.Bool(true),
+							QueryStringCacheKeys: &svcapitypes.QueryStringCacheKeys{
+								Items:    []*string{awsclients.String("search")},
+								Quantity: awsclients.Int64(1),
+							},
+						},
+						LambdaFunctionAssociations: &svcapitypes.LambdaFunctionAssociations{
+							Items: []*svcapitypes.LambdaFunctionAssociation{{
+								EventType:         awsclients.String("good"),
+								IncludeBody:       awsclients.Bool(true),
+								LambdaFunctionARN: awsclients.String("arn"),
+							}},
+							Quantity: awsclients.Int64(1),
+						},
+						MaxTTL:                awsclients.Int64(42),
+						MinTTL:                awsclients.Int64(42),
+						OriginRequestPolicyID: awsclients.String("example"),
+						RealtimeLogConfigARN:  awsclients.String("example"),
+						SmoothStreaming:       awsclients.Bool(true),
+						TargetOriginID:        awsclients.String("example"),
+						TrustedKeyGroups: &svcapitypes.TrustedKeyGroups{
+							Enabled:  awsclients.Bool(true),
+							Items:    []*string{awsclients.String("the-good-key")},
+							Quantity: awsclients.Int64(1),
+						},
+						TrustedSigners: &svcapitypes.TrustedSigners{
+							Enabled:  awsclients.Bool(true),
+							Items:    []*string{awsclients.String("the-good-signer")},
+							Quantity: awsclients.Int64(1),
+						},
+					},
+					DefaultRootObject: awsclients.String("the-good-one"),
+					Enabled:           awsclients.Bool(true),
+					HTTPVersion:       awsclients.String("1.1"),
+					IsIPV6Enabled:     awsclients.Bool(true),
+					Logging: &svcapitypes.LoggingConfig{
+						Bucket:         awsclients.String("big-logs"),
+						Enabled:        awsclients.Bool(true),
+						IncludeCookies: awsclients.Bool(true),
+						Prefix:         awsclients.String("one-large-log-"),
+					},
+					OriginGroups: &svcapitypes.OriginGroups{
+						Items: []*svcapitypes.OriginGroup{{
+							FailoverCriteria: &svcapitypes.OriginGroupFailoverCriteria{
+								StatusCodes: &svcapitypes.StatusCodes{
+									Items:    []*int64{awsclients.Int64(418)},
+									Quantity: awsclients.Int64(1),
+								},
+							},
+							Members: &svcapitypes.OriginGroupMembers{
+								Items: []*svcapitypes.OriginGroupMember{{
+									OriginID: awsclients.String("example"),
+								}},
+								Quantity: awsclients.Int64(1),
+							},
+						}},
+						Quantity: awsclients.Int64(1),
+					},
+					Origins: &svcapitypes.Origins{
+						Items: []*svcapitypes.Origin{{
+							ConnectionAttempts: awsclients.Int64(42),
+							ConnectionTimeout:  awsclients.Int64(42),
+							CustomHeaders: &svcapitypes.CustomHeaders{
+								Items: []*svcapitypes.OriginCustomHeader{{
+									HeaderName:  awsclients.String("X-Cool"),
+									HeaderValue: awsclients.String("very"),
+								}},
+								Quantity: awsclients.Int64(1),
+							},
+							CustomOriginConfig: &svcapitypes.CustomOriginConfig{
+								HTTPPort:               awsclients.Int64(8080),
+								HTTPSPort:              awsclients.Int64(443),
+								OriginKeepaliveTimeout: awsclients.Int64(42),
+								OriginProtocolPolicy:   awsclients.String("all-of-them"),
+								OriginReadTimeout:      awsclients.Int64(42),
+								OriginSSLProtocols: &svcapitypes.OriginSSLProtocols{
+									Items:    []*string{awsclients.String("TLS_1.2")},
+									Quantity: awsclients.Int64(1),
+								},
+							},
+							DomainName: awsclients.String("example.org"),
+							ID:         awsclients.String("custom"),
+							OriginPath: awsclients.String("/"),
+							OriginShield: &svcapitypes.OriginShield{
+								Enabled:            awsclients.Bool(true),
+								OriginShieldRegion: awsclients.String("us-east-1"),
+							},
+							S3OriginConfig: &svcapitypes.S3OriginConfig{
+								OriginAccessIDentity: awsclients.String("cool-guy"),
+							},
+						}},
+					},
+					PriceClass: awsclients.String("really-cheap"),
+					Restrictions: &svcapitypes.Restrictions{
+						GeoRestriction: &svcapitypes.GeoRestriction{
+							RestrictionType: awsclients.String("no-australians"),
+							Items:           []*string{awsclients.String("negz"), awsclients.String("kylie")},
+							Quantity:        awsclients.Int64(1),
+						},
+					},
+					ViewerCertificate: &svcapitypes.ViewerCertificate{
+						ACMCertificateARN:            awsclients.String("example"),
+						Certificate:                  awsclients.String("example"),
+						CertificateSource:            awsclients.String("trusty-source"),
+						CloudFrontDefaultCertificate: awsclients.Bool(false),
+						IAMCertificateID:             awsclients.String("example"),
+						MinimumProtocolVersion:       awsclients.String("TLS_1.2"),
+						SSLSupportMethod:             awsclients.String("fax"),
+					},
+					WebACLID: awsclients.String("example"),
+				},
+			},
+		},
+		"LateInitOriginsByID": {
+			args: args{
+				dp: &svcapitypes.DistributionParameters{
+					DistributionConfig: &svcapitypes.DistributionConfig{
+						Origins: &svcapitypes.Origins{
+							Items: []*svcapitypes.Origin{
+								{}, // This one has a nil ID.
+								{
+									// This one only exists in desired state.
+									ID: awsclients.String("desired-only"),
+								},
+								{
+									// We want to late-init domain-name here.
+									ID: awsclients.String("custom"),
+								},
+							},
+						},
+					},
+				},
+				gdo: &svcsdk.GetDistributionOutput{
+					Distribution: &svcsdk.Distribution{
+						DistributionConfig: &svcsdk.DistributionConfig{
+							Origins: &svcsdk.Origins{
+								Items: []*svcsdk.Origin{
+									{}, // This one has a nil Id.
+									{
+										// This one only exists in actual state.
+										Id: awsclients.String("actual-only"),
+									},
+									{
+										DomainName: awsclients.String("example.org"),
+										Id:         awsclients.String("custom"),
+									},
+								},
+								Quantity: awsclients.Int64(3),
+							},
+						},
+					},
+				},
+			},
+			want: &svcapitypes.DistributionParameters{
+				DistributionConfig: &svcapitypes.DistributionConfig{
+					Origins: &svcapitypes.Origins{
+						Items: []*svcapitypes.Origin{
+							{}, // This one has a nil ID.
+							{
+								// This one only exists in desired state.
+								ID: awsclients.String("desired-only"),
+							},
+							{
+								DomainName: awsclients.String("example.org"),
+								ID:         awsclients.String("custom"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_ = lateInitialize(tc.args.dp, tc.args.gdo)
+			if diff := cmp.Diff(tc.want, tc.args.dp); diff != "" {
+				t.Errorf("\nlateInitialize(...): -want, +got:\n%s", diff)
+			}
+
+		})
+	}
+
+}

--- a/pkg/controller/cloudfront/distribution/lateinit_test.go
+++ b/pkg/controller/cloudfront/distribution/lateinit_test.go
@@ -45,6 +45,96 @@ func TestLateInitialize(t *testing.T) {
 				gdo: &svcsdk.GetDistributionOutput{Distribution: &svcsdk.Distribution{}},
 			},
 		},
+		// TODO(negz): Exhaustive tests for nil handling would be ideal.
+		"NilDistributionConfigFields": {
+			args: args{
+				gdo: &svcsdk.GetDistributionOutput{Distribution: &svcsdk.Distribution{
+					DistributionConfig: &svcsdk.DistributionConfig{},
+				}},
+				dp: &svcapitypes.DistributionParameters{
+					DistributionConfig: &svcapitypes.DistributionConfig{},
+				},
+			},
+			want: &svcapitypes.DistributionParameters{
+				DistributionConfig: &svcapitypes.DistributionConfig{},
+			},
+		},
+		"NilDistributionConfigChildrenFields": {
+			args: args{
+				gdo: &svcsdk.GetDistributionOutput{Distribution: &svcsdk.Distribution{
+					DistributionConfig: &svcsdk.DistributionConfig{
+						Aliases:              &svcsdk.Aliases{},
+						CacheBehaviors:       &svcsdk.CacheBehaviors{},
+						CustomErrorResponses: &svcsdk.CustomErrorResponses{},
+						DefaultCacheBehavior: &svcsdk.DefaultCacheBehavior{},
+						Logging:              &svcsdk.LoggingConfig{},
+						OriginGroups:         &svcsdk.OriginGroups{},
+						Origins:              &svcsdk.Origins{},
+						Restrictions:         &svcsdk.Restrictions{},
+						ViewerCertificate:    &svcsdk.ViewerCertificate{},
+					},
+				}},
+				dp: &svcapitypes.DistributionParameters{
+					DistributionConfig: &svcapitypes.DistributionConfig{},
+				},
+			},
+			want: &svcapitypes.DistributionParameters{
+				DistributionConfig: &svcapitypes.DistributionConfig{
+					Aliases:              &svcapitypes.Aliases{},
+					CacheBehaviors:       &svcapitypes.CacheBehaviors{},
+					CustomErrorResponses: &svcapitypes.CustomErrorResponses{},
+					DefaultCacheBehavior: &svcapitypes.DefaultCacheBehavior{},
+					Logging:              &svcapitypes.LoggingConfig{},
+					OriginGroups:         &svcapitypes.OriginGroups{},
+					Origins:              &svcapitypes.Origins{},
+					Restrictions:         &svcapitypes.Restrictions{},
+					ViewerCertificate:    &svcapitypes.ViewerCertificate{},
+				},
+			},
+		},
+		"NilDistributionConfigGrandchildrenFields": {
+			args: args{
+				gdo: &svcsdk.GetDistributionOutput{Distribution: &svcsdk.Distribution{
+					DistributionConfig: &svcsdk.DistributionConfig{
+						CacheBehaviors: &svcsdk.CacheBehaviors{
+							Items: []*svcsdk.CacheBehavior{{}},
+						},
+						CustomErrorResponses: &svcsdk.CustomErrorResponses{
+							Items: []*svcsdk.CustomErrorResponse{{}},
+						},
+						OriginGroups: &svcsdk.OriginGroups{
+							Items: []*svcsdk.OriginGroup{{}},
+						},
+						Origins: &svcsdk.Origins{
+							Items: []*svcsdk.Origin{{}},
+						},
+						Restrictions: &svcsdk.Restrictions{
+							GeoRestriction: &svcsdk.GeoRestriction{},
+						},
+					},
+				}},
+				dp: &svcapitypes.DistributionParameters{},
+			},
+			want: &svcapitypes.DistributionParameters{
+				DistributionConfig: &svcapitypes.DistributionConfig{
+					CacheBehaviors: &svcapitypes.CacheBehaviors{
+						Items: []*svcapitypes.CacheBehavior{{}},
+					},
+					CustomErrorResponses: &svcapitypes.CustomErrorResponses{
+						Items: []*svcapitypes.CustomErrorResponse{{}},
+					},
+					OriginGroups: &svcapitypes.OriginGroups{
+						Items: []*svcapitypes.OriginGroup{{}},
+					},
+					Origins: &svcapitypes.Origins{
+						Items: []*svcapitypes.Origin{{}},
+					},
+					Restrictions: &svcapitypes.Restrictions{
+						GeoRestriction: &svcapitypes.GeoRestriction{},
+					},
+				},
+			},
+		},
 		"LateInitAllFields": {
 			args: args{
 				dp: &svcapitypes.DistributionParameters{},

--- a/pkg/controller/cloudfront/distribution/setup.go
+++ b/pkg/controller/cloudfront/distribution/setup.go
@@ -117,8 +117,8 @@ func isUpToDate(cr *svcapitypes.Distribution, gdo *svcsdk.GetDistributionOutput)
 	// It's not possible to cmpopts.IgnoreField a specific 'leaf' field
 	// because cmp still considers the parent field being non-nil in the
 	// patch to mean there's a diff, and we obviously don't want to ignore
-	// the entire parent field because then we'd never be able detect when
-	// an update was needed.
+	// the entire parent field because then we'd never be able to detect
+	// when an update was needed.
 
 	currentParams := &svcapitypes.DistributionParameters{}
 	_ = lateInitialize(currentParams, gdo)

--- a/pkg/controller/cloudfront/distribution/setup.go
+++ b/pkg/controller/cloudfront/distribution/setup.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/cloudfront"
@@ -36,11 +38,13 @@ import (
 
 	svcapitypes "github.com/crossplane/provider-aws/apis/cloudfront/v1alpha1"
 	awsclients "github.com/crossplane/provider-aws/pkg/clients"
-	"github.com/crossplane/provider-aws/pkg/controller/cloudfront"
 )
 
-// TODO: isn't this defined as an API constant somewhere in aws-sdk-go? Generated zz_enums.go seems not to contain it either
-const stateDeployed = "Deployed"
+// TODO: Aren't these defined as an API constant somewhere in aws-sdk-go?
+// Generated zz_enums.go seems not to contain it either
+const (
+	stateDeployed = "Deployed"
+)
 
 // SetupDistribution adds a controller that reconciles Distribution.
 func SetupDistribution(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
@@ -100,25 +104,47 @@ func preObserve(_ context.Context, cr *svcapitypes.Distribution, gdi *svcsdk.Get
 	return nil
 }
 
-var mappingOptions = []cloudfront.LateInitOption{
-	cloudfront.Replacer("ID", "Id"),
-	cloudfront.Replacer("ARN", "Arn"),
-	cloudfront.MapReplacer(map[string]string{
-		"HTTPVersion":        "HttpVersion",
-		"OriginSSLProtocols": "OriginSslProtocols",
-	})}
-
-func lateInitialize(in *svcapitypes.DistributionParameters, gdo *svcsdk.GetDistributionOutput) error {
-	inConfig, respConfig := in.DistributionConfig, gdo.Distribution.DistributionConfig
-
-	_, err := cloudfront.LateInitializeFromResponse("", inConfig, respConfig,
-		mappingOptions...)
-	return err
-}
-
 func isUpToDate(cr *svcapitypes.Distribution, gdo *svcsdk.GetDistributionOutput) (bool, error) {
-	return cloudfront.IsUpToDate(gdo.Distribution.DistributionConfig, cr.Spec.ForProvider.DistributionConfig,
-		mappingOptions...)
+	// We can only update a Distribution that's in state 'Deployed' so we
+	// temporarily consider it 'up to date' until it is since updating it
+	// wouldn't work.
+	if awsclients.StringValue(cr.Status.AtProvider.Distribution.Status) != stateDeployed {
+		return true, nil
+	}
+
+	// NOTE(negz): As far as I can tell we can't use the typical CreatePatch
+	// pattern, because this type has a bunch of nested, updatable fields.
+	// It's not possible to cmpopts.IgnoreField a specific 'leaf' field
+	// because cmp still considers the parent field being non-nil in the
+	// patch to mean there's a diff, and we obviously don't want to ignore
+	// the entire parent field because then we'd never be able detect when
+	// an update was needed.
+
+	currentParams := &svcapitypes.DistributionParameters{}
+	_ = lateInitialize(currentParams, gdo)
+
+	return cmp.Equal(*currentParams, cr.Spec.ForProvider,
+		// We don't late init region - it's not in the output.
+		cmpopts.IgnoreFields(svcapitypes.DistributionParameters{}, "Region"),
+
+		// This appears to always be nil in GetDistributionOutput, which
+		// causes false positives for IsUpToDate.
+		cmpopts.IgnoreFields(svcapitypes.ViewerCertificate{}, "CloudFrontDefaultCertificate"),
+
+		// There's quite a few slices of *string and *int64 in this API
+		// that we want to consider equal regardless of order.
+		cmpopts.SortSlices(func(x, y *string) bool { return awsclients.StringValue(x) > awsclients.StringValue(y) }),
+		cmpopts.SortSlices(func(x, y *int64) bool { return awsclients.Int64Value(x) > awsclients.Int64Value(y) }),
+
+		// TODO(negz): Do we need to do something like this for all the
+		// other 'Items' slices with struct elements in this API? I've
+		// observed that the API doesn't return Origins.Items in the
+		// same order it's supplied (at a glance it seems to be returned
+		// ordered lexicographically by ID).
+		cmpopts.SortSlices(func(x, y *svcapitypes.Origin) bool {
+			return awsclients.StringValue(x.ID) > awsclients.StringValue(y.ID)
+		}),
+	), nil
 }
 
 func postObserve(_ context.Context, cr *svcapitypes.Distribution, gdo *svcsdk.GetDistributionOutput,
@@ -152,6 +178,7 @@ func preUpdate(_ context.Context, cr *svcapitypes.Distribution, udi *svcsdk.Upda
 	udi.DistributionConfig.CallerReference = awsclients.String(string(cr.UID))
 	udi.DistributionConfig.Origins.Quantity =
 		awsclients.Int64(len(cr.Spec.ForProvider.DistributionConfig.Origins.Items))
+
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane/provider-aws/issues/894

CloudFront Distributions and CachePolicies were built to use a generic reflect based late initialization library that can match two similar structs. While this approach is probably good for simpler APIs and is much more scalable than hand writing code as I've done here, we found that it was tricky to debug and customise the late-init logic and the IsUpToDate functions that use it.

Notably, the Distribution API seems to:

* Always return CloudFrontDefaultCertificate: nil, which causes false positives in IsUpToDate.
* Not return slices in the order they were supplied, making it impossible to late init slices of structs based on index alone.
* Require some slices of structs (e.g. Origins) to be late initialized.

I believe the reflect based late-init library attempts to late init slices under the assumption that the actual and desired elements will be in the same order. It also appears to append actual elements to the desired slice when the actual slice is longer than the desired slice, which would prevent us from removing elements from the desired slice (since they'd be late-init-ed right back in during Observe, resetting the desired state).

This manual implementation follows our typical pattern of only late-initing nil slices which avoids the above problem. However in some cases we _must_ late init elements of slices (e.g. late init the Origin structs) in order to be able to perform an update. The Distribution API requires a create, read, then update flow where many of the fields that are optional at create time are defaulted and subsequently required at update time. In order to handle this we special case Origins, matching them on their (unique) ID fields. We may need to do this for other slices of structs such as OriginGroups.

At a glance the CachePolicy API appears simpler and thus hopefully doesn't suffer from many of these issues, but it probably warrants a closer look in future to be sure.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've tested this with both Distribution examples under `examples/cloudfront` and also several variants of the following:

```yaml
apiVersion: cloudfront.aws.crossplane.io/v1alpha1
kind: Distribution
metadata:
  name: negztest
spec:
  forProvider:
    region: us-east-1
    distributionConfig:
      enabled: true
      comment: Example CloudFront Distribution
      defaultRootObject: index.html
      origins:
        items:
         - domainName: negztest.example.com.s3.us-west-2.amazonaws.com
           id: negz
           s3OriginConfig:
             originAccessIDentity: ""
      defaultCacheBehavior:
        targetOriginID: negz
        viewerProtocolPolicy: allow-all
        minTTL: 0
        forwardedValues:
          cookies:
            forward: none
          queryString: false
      viewerCertificate:
        sslSupportMethod: sni-only
        cloudFrontDefaultCertificate: false
        aCMCertificateARN: REDACTED
```

Notably I was not able to test how `aliases` works because I couldn't figure out any value that the AWS API would allow - it would only give me vague 'invalid CNAME' errors despite using seemingly valid values (e.g. `foo.example.com`, while using a private cert for `*.example.com`.)