### PR TITLE
Late initialize SecurityGroup ingress and egress rules

### DIFF
--- a/pkg/clients/ec2/address.go
+++ b/pkg/clients/ec2/address.go
@@ -72,7 +72,7 @@ func LateInitializeAddress(in *v1beta1.AddressParameters, a *ec2types.Address) {
 
 // IsAddressUpToDate checks whether there is a change in any of the modifiable fields.
 func IsAddressUpToDate(e v1beta1.AddressParameters, a ec2types.Address) bool {
-	return CompareTags(e.Tags, a.Tags)
+	return TagsMatch(e.Tags, a.Tags)
 }
 
 // IsStandardDomain checks whether it is set for standard domain
@@ -102,8 +102,8 @@ func BuildFromEC2Tags(tags []ec2types.Tag) []v1beta1.Tag {
 	return res
 }
 
-// CompareTags compares arrays of v1beta1.Tag and ec2types.Tag
-func CompareTags(tags []v1beta1.Tag, ec2Tags []ec2types.Tag) bool {
+// TagsMatch returns true if the supplied arrays of tags are equal.
+func TagsMatch(tags []v1beta1.Tag, ec2Tags []ec2types.Tag) bool {
 	if len(tags) != len(ec2Tags) {
 		return false
 	}

--- a/pkg/clients/ec2/securitygroup_diff_test.go
+++ b/pkg/clients/ec2/securitygroup_diff_test.go
@@ -113,51 +113,49 @@ func TestDiffPermissions(t *testing.T) {
 			remove: sgPermissions(port100, cidr),
 		},
 		{
-			name:   "Add block",
+			name:   "AddBlock",
 			want:   sgPermissions(port100, cidr, "192.168.0.1/32"),
 			have:   sgPermissions(port100, cidr),
 			add:    sgPermissions(port100, "192.168.0.1/32"),
 			remove: nil,
 		},
 		{
-			name:   "Remove block",
+			name:   "RemoveBlock",
 			want:   sgPermissions(port100, cidr),
 			have:   sgPermissions(port100, cidr, "192.168.0.1/32"),
 			add:    nil,
 			remove: sgPermissions(port100, "192.168.0.1/32"),
 		},
 		{
-			name:   "Replace block",
+			name:   "ReplaceBlock",
 			want:   sgPermissions(port100, cidr, "172.240.1.1/32", "192.168.0.1/32"),
 			have:   sgPermissions(port100, cidr, "172.240.2.2/32", "192.168.0.1/32"),
 			add:    sgPermissions(port100, "172.240.1.1/32"),
 			remove: sgPermissions(port100, "172.240.2.2/32"),
 		},
-		/*
-			{
-				name:   "Dedupe want",
-				want:   append(sgPersmissions(port100, cidr, "172.240.1.1/32", "172.240.1.1/32", "192.168.0.1/32"), sgPersmissions(port100, cidr, "172.240.1.1/32", "172.240.1.1/32", "192.168.0.1/32")...),
-				have:   sgPersmissions(port100, cidr, "172.240.2.2/32", "192.168.0.1/32"),
-				add:    sgPersmissions(port100, "172.240.1.1/32"),
-				remove: sgPersmissions(port100, "172.240.2.2/32"),
-			},
-		*/
 		{
-			name:   "Merge want",
+			name:   "DedupeWant",
+			want:   append(sgPermissions(port100, cidr, "172.240.1.1/32", "172.240.1.1/32", "192.168.0.1/32"), sgPermissions(port100, cidr, "172.240.1.1/32", "172.240.1.1/32", "192.168.0.1/32")...),
+			have:   sgPermissions(port100, cidr, "172.240.2.2/32", "192.168.0.1/32"),
+			add:    sgPermissions(port100, "172.240.1.1/32"),
+			remove: sgPermissions(port100, "172.240.2.2/32"),
+		},
+		{
+			name:   "MergeWant",
 			want:   append(sgPermissions(port100, "192.168.0.1/32"), sgPermissions(port100, "172.240.1.1/32")...),
 			have:   nil,
 			add:    sgPermissions(port100, "192.168.0.1/32", "172.240.1.1/32"),
 			remove: nil,
 		},
 		{
-			name:   "Ignore order",
+			name:   "IgnoreOrder",
 			want:   append(sgUserIDGroupPair(port100, "sg-2", "sg-1"), sgPermissions(port100, "172.240.1.1/32", "192.168.0.1/32", cidr)...),
 			have:   append(sgUserIDGroupPair(port100, "sg-1", "sg-2"), sgPermissions(port100, "192.168.0.1/32", cidr, "172.240.1.1/32")...),
 			add:    nil,
 			remove: nil,
 		},
 		{
-			name: "Ignore protocol case",
+			name: "IgnoreProtocolCase",
 			want: []ec2types.IpPermission{
 				{
 					IpProtocol: aws.String("TCP"),

--- a/pkg/clients/ec2/securitygroup_test.go
+++ b/pkg/clients/ec2/securitygroup_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/smithy-go/document"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/crossplane/provider-aws/apis/ec2/v1beta1"
 )
@@ -52,6 +54,92 @@ func sgIPPermission(ports ...int) (ret []ec2types.IpPermission) {
 	return ret
 }
 
+func TestLateInitializeSG(t *testing.T) {
+	type args struct {
+		in *v1beta1.SecurityGroupParameters
+		sg *ec2types.SecurityGroup
+	}
+
+	cases := map[string]struct {
+		args args
+		want *v1beta1.SecurityGroupParameters
+	}{
+		"NilSG": {
+			args: args{
+				in: &v1beta1.SecurityGroupParameters{
+					Tags:        []v1beta1.Tag{{Key: "k", Value: "v"}},
+					Description: sgDesc,
+					GroupName:   sgName,
+					VPCID:       aws.String(sgVpc),
+					Ingress:     specIPPermission(80),
+				},
+			},
+			want: &v1beta1.SecurityGroupParameters{
+				Tags:        []v1beta1.Tag{{Key: "k", Value: "v"}},
+				Description: sgDesc,
+				GroupName:   sgName,
+				VPCID:       aws.String(sgVpc),
+				Ingress:     specIPPermission(80),
+			},
+		},
+		"NoOp": {
+			args: args{
+				in: &v1beta1.SecurityGroupParameters{
+					Tags:        []v1beta1.Tag{{Key: "k", Value: "v"}},
+					Description: sgDesc,
+					GroupName:   sgName,
+					VPCID:       aws.String(sgVpc),
+					Ingress:     specIPPermission(80),
+				},
+				sg: &ec2types.SecurityGroup{
+					Tags:          []ec2types.Tag{{Key: aws.String("k"), Value: aws.String("v")}},
+					Description:   aws.String(sgDesc),
+					GroupName:     aws.String(sgName),
+					VpcId:         aws.String(sgVpc),
+					IpPermissions: sgIPPermission(80),
+				},
+			},
+			want: &v1beta1.SecurityGroupParameters{
+				Tags:        []v1beta1.Tag{{Key: "k", Value: "v"}},
+				Description: sgDesc,
+				GroupName:   sgName,
+				VPCID:       aws.String(sgVpc),
+				Ingress:     specIPPermission(80),
+			},
+		},
+		"EmptySG": {
+			args: args{
+				in: &v1beta1.SecurityGroupParameters{},
+				sg: &ec2types.SecurityGroup{
+					Tags:                []ec2types.Tag{{Key: aws.String("k"), Value: aws.String("v")}},
+					Description:         aws.String(sgDesc),
+					GroupName:           aws.String(sgName),
+					VpcId:               aws.String(sgVpc),
+					IpPermissions:       sgIPPermission(80),
+					IpPermissionsEgress: sgIPPermission(80),
+				},
+			},
+			want: &v1beta1.SecurityGroupParameters{
+				Tags:        []v1beta1.Tag{{Key: "k", Value: "v"}},
+				Description: sgDesc,
+				GroupName:   sgName,
+				VPCID:       aws.String(sgVpc),
+				Ingress:     specIPPermission(80),
+				Egress:      specIPPermission(80),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			LateInitializeSG(tc.args.in, tc.args.sg)
+			if diff := cmp.Diff(tc.want, tc.args.in); diff != "" {
+				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestIsSGUpToDate(t *testing.T) {
 	type args struct {
 		sg ec2types.SecurityGroup
@@ -65,12 +153,14 @@ func TestIsSGUpToDate(t *testing.T) {
 		"SameFields": {
 			args: args{
 				sg: ec2types.SecurityGroup{
+					Tags:          []ec2types.Tag{{Key: aws.String("k"), Value: aws.String("v")}},
 					Description:   aws.String(sgDesc),
 					GroupName:     aws.String(sgName),
 					VpcId:         aws.String(sgVpc),
 					IpPermissions: sgIPPermission(80),
 				},
 				p: v1beta1.SecurityGroupParameters{
+					Tags:        []v1beta1.Tag{{Key: "k", Value: "v"}},
 					Description: sgDesc,
 					GroupName:   sgName,
 					VPCID:       aws.String(sgVpc),
@@ -96,7 +186,24 @@ func TestIsSGUpToDate(t *testing.T) {
 			},
 			want: true,
 		},
-		"DifferentFields": {
+		"DifferentTags": {
+			args: args{
+				sg: ec2types.SecurityGroup{
+					Description: aws.String(sgDesc),
+					GroupName:   aws.String(sgName),
+					VpcId:       aws.String(sgVpc),
+				},
+				p: v1beta1.SecurityGroupParameters{
+					Tags:        []v1beta1.Tag{{Key: "k", Value: "v"}},
+					Ingress:     specIPPermission(100),
+					Description: sgDesc,
+					GroupName:   sgName,
+					VPCID:       aws.String(sgVpc),
+				},
+			},
+			want: false,
+		},
+		"DifferentIngress": {
 			args: args{
 				sg: ec2types.SecurityGroup{
 					Description:   aws.String(sgDesc),
@@ -109,6 +216,25 @@ func TestIsSGUpToDate(t *testing.T) {
 					GroupName:   sgName,
 					VPCID:       aws.String(sgVpc),
 					Ingress:     specIPPermission(100),
+				},
+			},
+			want: false,
+		},
+		"DifferentEgress": {
+			args: args{
+				sg: ec2types.SecurityGroup{
+					Description:         aws.String(sgDesc),
+					GroupName:           aws.String(sgName),
+					VpcId:               aws.String(sgVpc),
+					IpPermissions:       sgIPPermission(80),
+					IpPermissionsEgress: sgIPPermission(80),
+				},
+				p: v1beta1.SecurityGroupParameters{
+					Description: sgDesc,
+					GroupName:   sgName,
+					VPCID:       aws.String(sgVpc),
+					Ingress:     specIPPermission(80),
+					Egress:      specIPPermission(100),
 				},
 			},
 			want: false,
@@ -155,6 +281,152 @@ func TestGenerateSGObservation(t *testing.T) {
 			r := GenerateSGObservation(tc.in)
 			if diff := cmp.Diff(r, tc.out); diff != "" {
 				t.Errorf("GenerateNetworkObservation(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBuildFromEC2Permissions(t *testing.T) {
+	cases := map[string]struct {
+		in   []ec2types.IpPermission
+		want []v1beta1.IPPermission
+	}{
+		"NilPermissions": {
+			in:   nil,
+			want: nil,
+		},
+		"FullyPopulated": {
+			in: []ec2types.IpPermission{{
+				FromPort:   aws.Int32(80),
+				IpProtocol: aws.String("tcp"),
+				ToPort:     aws.Int32(80),
+				IpRanges: []ec2types.IpRange{{
+					CidrIp:      aws.String("10.0.0.0/8"),
+					Description: aws.String("Only the finest IP addresses."),
+				}},
+				Ipv6Ranges: []ec2types.Ipv6Range{{
+					CidrIpv6:    aws.String("2001:db8:1234:1a00::/64"),
+					Description: aws.String("Only the finest IPv6 addresses."),
+				}},
+				PrefixListIds: []ec2types.PrefixListId{{
+					PrefixListId: aws.String("really-good-prefix"),
+					Description:  aws.String("Only the finest prefixes."),
+				}},
+				UserIdGroupPairs: []ec2types.UserIdGroupPair{{
+					Description:            aws.String("Only the finest pairs."),
+					GroupId:                aws.String("really-good-group-id"),
+					GroupName:              aws.String("really-good-group"),
+					UserId:                 aws.String("really-good-user-id"),
+					VpcId:                  aws.String("really-good-vpc-id"),
+					VpcPeeringConnectionId: aws.String("really-good-peering-id"),
+				}},
+			}},
+			want: []v1beta1.IPPermission{{
+				FromPort:   aws.Int32(80),
+				IPProtocol: "tcp",
+				ToPort:     aws.Int32(80),
+				IPRanges: []v1beta1.IPRange{{
+					CIDRIP:      "10.0.0.0/8",
+					Description: aws.String("Only the finest IP addresses."),
+				}},
+				IPv6Ranges: []v1beta1.IPv6Range{{
+					CIDRIPv6:    "2001:db8:1234:1a00::/64",
+					Description: aws.String("Only the finest IPv6 addresses."),
+				}},
+				PrefixListIDs: []v1beta1.PrefixListID{{
+					PrefixListID: "really-good-prefix",
+					Description:  aws.String("Only the finest prefixes."),
+				}},
+				UserIDGroupPairs: []v1beta1.UserIDGroupPair{{
+					Description:            aws.String("Only the finest pairs."),
+					GroupID:                aws.String("really-good-group-id"),
+					GroupName:              aws.String("really-good-group"),
+					UserID:                 aws.String("really-good-user-id"),
+					VPCID:                  aws.String("really-good-vpc-id"),
+					VPCPeeringConnectionID: aws.String("really-good-peering-id"),
+				}},
+			}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := BuildFromEC2Permissions(tc.in)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("BuildFromEC2Permissions(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGenerateEC2Permissions(t *testing.T) {
+	cases := map[string]struct {
+		in   []v1beta1.IPPermission
+		want []ec2types.IpPermission
+	}{
+		"NilPermissions": {
+			in:   nil,
+			want: nil,
+		},
+		"FullyPopulated": {
+			in: []v1beta1.IPPermission{{
+				FromPort:   aws.Int32(80),
+				IPProtocol: "tcp",
+				ToPort:     aws.Int32(80),
+				IPRanges: []v1beta1.IPRange{{
+					CIDRIP:      "10.0.0.0/8",
+					Description: aws.String("Only the finest IP addresses."),
+				}},
+				IPv6Ranges: []v1beta1.IPv6Range{{
+					CIDRIPv6:    "2001:db8:1234:1a00::/64",
+					Description: aws.String("Only the finest IPv6 addresses."),
+				}},
+				PrefixListIDs: []v1beta1.PrefixListID{{
+					PrefixListID: "really-good-prefix",
+					Description:  aws.String("Only the finest prefixes."),
+				}},
+				UserIDGroupPairs: []v1beta1.UserIDGroupPair{{
+					Description:            aws.String("Only the finest pairs."),
+					GroupID:                aws.String("really-good-group-id"),
+					GroupName:              aws.String("really-good-group"),
+					UserID:                 aws.String("really-good-user-id"),
+					VPCID:                  aws.String("really-good-vpc-id"),
+					VPCPeeringConnectionID: aws.String("really-good-peering-id"),
+				}},
+			}},
+			want: []ec2types.IpPermission{{
+				FromPort:   aws.Int32(80),
+				IpProtocol: aws.String("tcp"),
+				ToPort:     aws.Int32(80),
+				IpRanges: []ec2types.IpRange{{
+					CidrIp:      aws.String("10.0.0.0/8"),
+					Description: aws.String("Only the finest IP addresses."),
+				}},
+				Ipv6Ranges: []ec2types.Ipv6Range{{
+					CidrIpv6:    aws.String("2001:db8:1234:1a00::/64"),
+					Description: aws.String("Only the finest IPv6 addresses."),
+				}},
+				PrefixListIds: []ec2types.PrefixListId{{
+					PrefixListId: aws.String("really-good-prefix"),
+					Description:  aws.String("Only the finest prefixes."),
+				}},
+				UserIdGroupPairs: []ec2types.UserIdGroupPair{{
+					Description:            aws.String("Only the finest pairs."),
+					GroupId:                aws.String("really-good-group-id"),
+					GroupName:              aws.String("really-good-group"),
+					UserId:                 aws.String("really-good-user-id"),
+					VpcId:                  aws.String("really-good-vpc-id"),
+					VpcPeeringConnectionId: aws.String("really-good-peering-id"),
+				}},
+			}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := GenerateEC2Permissions(tc.in)
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreTypes(document.NoSerde{})); diff != "" {
+				t.Errorf("GenerateEC2Permissions(...): -want, +got:\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR is a small follow up to https://github.com/crossplane/provider-aws/pull/631 that will now late init ingress and egress rules only when the desired array of rules is empty. This can be handy when importing security groups. It also adds a few more unit tests around the late init and up-to-date checking functionality.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've tested this by:

1. Applying the SG at `examples/ec2/securitygroup.yaml`.
2. Validating that if I add an egress and update the ingress, those changes are reflected.
3. Deleting the SG with `deletionPolicy: Orphan`.
4. Validating that if I re-import the SG with empty ingress and egress arrays they will be late initialized.