### PR TITLE
identity.iampolicy: Disable gocyclo after two merges broke CI

### DIFF
--- a/pkg/controller/identity/iampolicy/controller.go
+++ b/pkg/controller/identity/iampolicy/controller.go
@@ -97,7 +97,7 @@ type external struct {
 	kube   client.Client
 }
 
-func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.ExternalObservation, error) {
+func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.ExternalObservation, error) { // nolint:gocyclo
 	cr, ok := mgd.(*v1alpha1.IAMPolicy)
 	if !ok {
 		return managed.ExternalObservation{}, errors.New(errUnexpectedObject)


### PR DESCRIPTION
### Description of your changes

CI tests for two individual PRs were OK, but after the merge, CI fails
due to the combined cyclomatic complexity of the function.

Since every PR from master at this point will fail until it is fixed, I
think the lowest risk now is to disable this lint check.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

No code changes.

[contribution process]: https://git.io/fj2m9
