### PR TITLE
Fixing constantly update requests problem of replicationgroup

### DIFF
--- a/pkg/clients/aws.go
+++ b/pkg/clients/aws.go
@@ -586,6 +586,10 @@ func LateInitializeIntPtr(in *int, from *int64) *int {
 
 // LateInitializeIntFrom32Ptr returns in if it's non-nil, otherwise returns from
 // which is the backup for the cases in is nil.
+// This function considered that nil and 0 values are same. However, for a *int32, nil and 0 values must be different
+// because if the external Azure resource has a field with 0 value, during late initialization setting this value
+// in CR must be allowed. Please see the LateInitializeIntFromInt32Ptr func.
+// Deprecated: Please use LateInitializeIntFromInt32Ptr instead.
 func LateInitializeIntFrom32Ptr(in *int, from *int32) *int {
 	if in != nil {
 		return in
@@ -594,6 +598,21 @@ func LateInitializeIntFrom32Ptr(in *int, from *int32) *int {
 		i := int(*from)
 		return &i
 	}
+	return nil
+}
+
+// LateInitializeIntFromInt32Ptr returns in if it's non-nil, otherwise returns from
+// which is the backup for the cases in is nil.
+func LateInitializeIntFromInt32Ptr(in *int, from *int32) *int {
+	if in != nil {
+		return in
+	}
+
+	if from != nil {
+		i := int(*from)
+		return &i
+	}
+
 	return nil
 }
 

--- a/pkg/clients/elasticache/elasticache.go
+++ b/pkg/clients/elasticache/elasticache.go
@@ -175,7 +175,7 @@ func LateInitialize(s *v1beta1.ReplicationGroupParameters, rg elasticachetypes.R
 	s.AtRestEncryptionEnabled = clients.LateInitializeBoolPtr(s.AtRestEncryptionEnabled, rg.AtRestEncryptionEnabled)
 	s.AuthEnabled = clients.LateInitializeBoolPtr(s.AuthEnabled, rg.AuthTokenEnabled)
 	s.AutomaticFailoverEnabled = clients.LateInitializeBoolPtr(s.AutomaticFailoverEnabled, automaticFailoverEnabled(rg.AutomaticFailover))
-	s.SnapshotRetentionLimit = clients.LateInitializeIntFrom32Ptr(s.SnapshotRetentionLimit, rg.SnapshotRetentionLimit)
+	s.SnapshotRetentionLimit = clients.LateInitializeIntFromInt32Ptr(s.SnapshotRetentionLimit, rg.SnapshotRetentionLimit)
 	s.SnapshotWindow = clients.LateInitializeStringPtr(s.SnapshotWindow, rg.SnapshotWindow)
 	s.SnapshottingClusterID = clients.LateInitializeStringPtr(s.SnapshottingClusterID, rg.SnapshottingClusterId)
 	s.TransitEncryptionEnabled = clients.LateInitializeBoolPtr(s.TransitEncryptionEnabled, rg.TransitEncryptionEnabled)


### PR DESCRIPTION
Signed-off-by: Sergen Yalçın <yalcinsergen97@gmail.com>

### Description of your changes

Fixes: https://github.com/crossplane/provider-aws/issues/909

This PR addresses the constantly update requests problem of replicationgroup. `snapshotRetentionLimit` field set to 0 in the sdk side when it is skipped in MR manifest. During `LateInitialization`, since `nil` and `0` values are considered the same value in the function used, the value `0` is not written to CR and the value in CR remains `nil`. Therefore, the update call is repeated in each reconcile loop. Reference: https://github.com/crossplane/provider-aws/blob/1e29728f989c14d07b5325e3cc4fa8d6d298c51a/pkg/clients/aws.go#L589

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

A ReplicationGroup resource was provisioned without setting `snapshotRetentionLimit`. Then I noticed that, this field set to 0 after late initialization. I did not observe any continuous update call.

[contribution process]: https://git.io/fj2m9
