### PR TITLE
add basic install command

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,4 +68,6 @@ make run
 
 ## Install
 
-TBD: Steps to install the AWS provider package into a Crossplane cluster
+```console
+kubectl crossplane install provider crossplane/provider-aws:v0.21.2
+```


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add basic install instruction for the aws provider

I have:

- [x] Read and followed Crossplane's [contribution process].

[contribution process]: https://git.io/fj2m9
