### PR TITLE
Servicediscovery delete fix

### DIFF
--- a/apis/servicediscovery/v1alpha1/custom_types.go
+++ b/apis/servicediscovery/v1alpha1/custom_types.go
@@ -2,7 +2,6 @@ package v1alpha1
 
 import (
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
-
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 
 	aws "github.com/crossplane/provider-aws/pkg/clients"

--- a/apis/servicediscovery/v1alpha1/custom_types.go
+++ b/apis/servicediscovery/v1alpha1/custom_types.go
@@ -1,6 +1,16 @@
 package v1alpha1
 
-import xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+import (
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+
+	aws "github.com/crossplane/provider-aws/pkg/clients"
+)
+
+// AnnotationKeyOperationID is the key in the annotations map of a
+// Cloud Map managed resource for the OperationId returned by API calls
+const AnnotationKeyOperationID = Group + "/operation-id"
 
 // CustomServiceParameters are custom parameters for Services.
 type CustomServiceParameters struct{}
@@ -27,12 +37,15 @@ type CustomPublicDNSNamespaceParameters struct{}
 
 // GetOperationID returns the last operation id.
 func (in *HTTPNamespace) GetOperationID() *string {
-	return in.Status.AtProvider.OperationID
+	if val, ok := in.GetAnnotations()[AnnotationKeyOperationID]; ok {
+		return &val
+	}
+	return nil
 }
 
 // SetOperationID sets the last operation id.
 func (in *HTTPNamespace) SetOperationID(id *string) {
-	in.Status.AtProvider.OperationID = id
+	meta.AddAnnotations(in, map[string]string{AnnotationKeyOperationID: aws.StringValue(id)})
 }
 
 // GetDescription returns the description.
@@ -47,12 +60,15 @@ func (in *HTTPNamespace) SetDescription(d *string) {
 
 // GetOperationID returns the last operation id.
 func (in *PrivateDNSNamespace) GetOperationID() *string {
-	return in.Status.AtProvider.OperationID
+	if val, ok := in.GetAnnotations()[AnnotationKeyOperationID]; ok {
+		return &val
+	}
+	return nil
 }
 
 // SetOperationID sets the last operation id.
 func (in *PrivateDNSNamespace) SetOperationID(id *string) {
-	in.Status.AtProvider.OperationID = id
+	meta.AddAnnotations(in, map[string]string{AnnotationKeyOperationID: aws.StringValue(id)})
 }
 
 // GetDescription returns the description.
@@ -67,12 +83,15 @@ func (in *PrivateDNSNamespace) SetDescription(d *string) {
 
 // GetOperationID returns the last operation id.
 func (in *PublicDNSNamespace) GetOperationID() *string {
-	return in.Status.AtProvider.OperationID
+	if val, ok := in.GetAnnotations()[AnnotationKeyOperationID]; ok {
+		return &val
+	}
+	return nil
 }
 
 // SetOperationID sets the last operation id.
 func (in *PublicDNSNamespace) SetOperationID(id *string) {
-	in.Status.AtProvider.OperationID = id
+	meta.AddAnnotations(in, map[string]string{AnnotationKeyOperationID: aws.StringValue(id)})
 }
 
 // GetDescription returns the description.

--- a/pkg/controller/servicediscovery/commonnamespace/hooks_test.go
+++ b/pkg/controller/servicediscovery/commonnamespace/hooks_test.go
@@ -106,30 +106,30 @@ func TestObserve(t *testing.T) {
 				},
 				kube: nil,
 				cr: &svcapitypes.HTTPNamespace{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"servicediscovery.aws.crossplane.io/operation-id": validOpID,
+						},
+					},
 					Spec: svcapitypes.HTTPNamespaceSpec{
 						ForProvider: svcapitypes.HTTPNamespaceParameters{
 							Region: "eu-central-1",
 							Name:   aws.String("test"),
-						},
-					},
-					Status: svcapitypes.HTTPNamespaceStatus{
-						AtProvider: svcapitypes.HTTPNamespaceObservation{
-							OperationID: aws.String(validOpID),
 						},
 					},
 				},
 			},
 			want: want{
 				cr: &svcapitypes.HTTPNamespace{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"servicediscovery.aws.crossplane.io/operation-id": validOpID,
+						},
+					},
 					Spec: svcapitypes.HTTPNamespaceSpec{
 						ForProvider: svcapitypes.HTTPNamespaceParameters{
 							Region: "eu-central-1",
 							Name:   aws.String("test"),
-						},
-					},
-					Status: svcapitypes.HTTPNamespaceStatus{
-						AtProvider: svcapitypes.HTTPNamespaceObservation{
-							OperationID: aws.String(validOpID),
 						},
 					},
 				},
@@ -155,30 +155,30 @@ func TestObserve(t *testing.T) {
 				},
 				kube: nil,
 				cr: &svcapitypes.HTTPNamespace{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"servicediscovery.aws.crossplane.io/operation-id": validOpID,
+						},
+					},
 					Spec: svcapitypes.HTTPNamespaceSpec{
 						ForProvider: svcapitypes.HTTPNamespaceParameters{
 							Region: "eu-central-1",
 							Name:   aws.String("test"),
-						},
-					},
-					Status: svcapitypes.HTTPNamespaceStatus{
-						AtProvider: svcapitypes.HTTPNamespaceObservation{
-							OperationID: aws.String(validOpID),
 						},
 					},
 				},
 			},
 			want: want{
 				cr: &svcapitypes.HTTPNamespace{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"servicediscovery.aws.crossplane.io/operation-id": validOpID,
+						},
+					},
 					Spec: svcapitypes.HTTPNamespaceSpec{
 						ForProvider: svcapitypes.HTTPNamespaceParameters{
 							Region: "eu-central-1",
 							Name:   aws.String("test"),
-						},
-					},
-					Status: svcapitypes.HTTPNamespaceStatus{
-						AtProvider: svcapitypes.HTTPNamespaceObservation{
-							OperationID: aws.String(validOpID),
 						},
 					},
 				},
@@ -204,21 +204,26 @@ func TestObserve(t *testing.T) {
 				},
 				kube: nil,
 				cr: &svcapitypes.HTTPNamespace{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"servicediscovery.aws.crossplane.io/operation-id": validOpID,
+						},
+					},
 					Spec: svcapitypes.HTTPNamespaceSpec{
 						ForProvider: svcapitypes.HTTPNamespaceParameters{
 							Region: "eu-central-1",
 							Name:   aws.String("test"),
-						},
-					},
-					Status: svcapitypes.HTTPNamespaceStatus{
-						AtProvider: svcapitypes.HTTPNamespaceObservation{
-							OperationID: aws.String(validOpID),
 						},
 					},
 				},
 			},
 			want: want{
 				cr: &svcapitypes.HTTPNamespace{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"servicediscovery.aws.crossplane.io/operation-id": validOpID,
+						},
+					},
 					Spec: svcapitypes.HTTPNamespaceSpec{
 						ForProvider: svcapitypes.HTTPNamespaceParameters{
 							Region: "eu-central-1",
@@ -226,9 +231,6 @@ func TestObserve(t *testing.T) {
 						},
 					},
 					Status: svcapitypes.HTTPNamespaceStatus{
-						AtProvider: svcapitypes.HTTPNamespaceObservation{
-							OperationID: aws.String(validOpID),
-						},
 						ResourceStatus: xpv1.ResourceStatus{
 							ConditionedStatus: xpv1.ConditionedStatus{
 								Conditions: []xpv1.Condition{xpv1.Unavailable()},
@@ -258,6 +260,11 @@ func TestObserve(t *testing.T) {
 				},
 				kube: nil,
 				cr: &svcapitypes.HTTPNamespace{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"servicediscovery.aws.crossplane.io/operation-id": validOpID,
+						},
+					},
 					Spec: svcapitypes.HTTPNamespaceSpec{
 						ForProvider: svcapitypes.HTTPNamespaceParameters{
 							Region: "eu-central-1",
@@ -265,9 +272,6 @@ func TestObserve(t *testing.T) {
 						},
 					},
 					Status: svcapitypes.HTTPNamespaceStatus{
-						AtProvider: svcapitypes.HTTPNamespaceObservation{
-							OperationID: aws.String(validOpID),
-						},
 						ResourceStatus: xpv1.ResourceStatus{
 							ConditionedStatus: xpv1.ConditionedStatus{
 								Conditions: []xpv1.Condition{xpv1.Deleting()},
@@ -278,6 +282,11 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				cr: &svcapitypes.HTTPNamespace{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"servicediscovery.aws.crossplane.io/operation-id": validOpID,
+						},
+					},
 					Spec: svcapitypes.HTTPNamespaceSpec{
 						ForProvider: svcapitypes.HTTPNamespaceParameters{
 							Region: "eu-central-1",
@@ -285,9 +294,6 @@ func TestObserve(t *testing.T) {
 						},
 					},
 					Status: svcapitypes.HTTPNamespaceStatus{
-						AtProvider: svcapitypes.HTTPNamespaceObservation{
-							OperationID: aws.String(validOpID),
-						},
 						ResourceStatus: xpv1.ResourceStatus{
 							ConditionedStatus: xpv1.ConditionedStatus{
 								Conditions: []xpv1.Condition{xpv1.Unavailable()},
@@ -332,16 +338,16 @@ func TestObserve(t *testing.T) {
 					MockUpdate: test.NewMockUpdateFn(nil),
 				},
 				cr: &svcapitypes.HTTPNamespace{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"servicediscovery.aws.crossplane.io/operation-id": validOpID,
+						},
+					},
 					Spec: svcapitypes.HTTPNamespaceSpec{
 						ForProvider: svcapitypes.HTTPNamespaceParameters{
 							Region:      "eu-central-1",
 							Name:        aws.String("test"),
 							Description: aws.String(validDescription),
-						},
-					},
-					Status: svcapitypes.HTTPNamespaceStatus{
-						AtProvider: svcapitypes.HTTPNamespaceObservation{
-							OperationID: aws.String(validOpID),
 						},
 					},
 				},
@@ -349,7 +355,10 @@ func TestObserve(t *testing.T) {
 			want: want{
 				cr: &svcapitypes.HTTPNamespace{
 					ObjectMeta: v1.ObjectMeta{
-						Annotations: map[string]string{"crossplane.io/external-name": validNSID},
+						Annotations: map[string]string{
+							"crossplane.io/external-name":                     validNSID,
+							"servicediscovery.aws.crossplane.io/operation-id": validOpID,
+						},
 					},
 					Spec: svcapitypes.HTTPNamespaceSpec{
 						ForProvider: svcapitypes.HTTPNamespaceParameters{
@@ -359,9 +368,6 @@ func TestObserve(t *testing.T) {
 						},
 					},
 					Status: svcapitypes.HTTPNamespaceStatus{
-						AtProvider: svcapitypes.HTTPNamespaceObservation{
-							OperationID: aws.String(validOpID),
-						},
 						ResourceStatus: xpv1.ResourceStatus{
 							ConditionedStatus: xpv1.ConditionedStatus{
 								Conditions: []xpv1.Condition{xpv1.Available()},
@@ -406,7 +412,10 @@ func TestObserve(t *testing.T) {
 				kube: nil,
 				cr: &svcapitypes.HTTPNamespace{
 					ObjectMeta: v1.ObjectMeta{
-						Annotations: map[string]string{"crossplane.io/external-name": validNSID},
+						Annotations: map[string]string{
+							"crossplane.io/external-name":                     validNSID,
+							"servicediscovery.aws.crossplane.io/operation-id": validOpID,
+						},
 					},
 					Spec: svcapitypes.HTTPNamespaceSpec{
 						ForProvider: svcapitypes.HTTPNamespaceParameters{
@@ -414,17 +423,15 @@ func TestObserve(t *testing.T) {
 							Name:   aws.String("test"),
 						},
 					},
-					Status: svcapitypes.HTTPNamespaceStatus{
-						AtProvider: svcapitypes.HTTPNamespaceObservation{
-							OperationID: aws.String(validOpID),
-						},
-					},
 				},
 			},
 			want: want{
 				cr: &svcapitypes.HTTPNamespace{
 					ObjectMeta: v1.ObjectMeta{
-						Annotations: map[string]string{"crossplane.io/external-name": validNSID},
+						Annotations: map[string]string{
+							"crossplane.io/external-name":                     validNSID,
+							"servicediscovery.aws.crossplane.io/operation-id": validOpID,
+						},
 					},
 					Spec: svcapitypes.HTTPNamespaceSpec{
 						ForProvider: svcapitypes.HTTPNamespaceParameters{
@@ -434,9 +441,6 @@ func TestObserve(t *testing.T) {
 						},
 					},
 					Status: svcapitypes.HTTPNamespaceStatus{
-						AtProvider: svcapitypes.HTTPNamespaceObservation{
-							OperationID: aws.String(validOpID),
-						},
 						ResourceStatus: xpv1.ResourceStatus{
 							ConditionedStatus: xpv1.ConditionedStatus{
 								Conditions: []xpv1.Condition{xpv1.Available()},
@@ -495,30 +499,30 @@ func TestDelete(t *testing.T) {
 				},
 				kube: nil,
 				cr: &svcapitypes.HTTPNamespace{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"servicediscovery.aws.crossplane.io/operation-id": validOpID,
+						},
+					},
 					Spec: svcapitypes.HTTPNamespaceSpec{
 						ForProvider: svcapitypes.HTTPNamespaceParameters{
 							Region: "eu-central-1",
 							Name:   aws.String("test"),
-						},
-					},
-					Status: svcapitypes.HTTPNamespaceStatus{
-						AtProvider: svcapitypes.HTTPNamespaceObservation{
-							OperationID: aws.String(validOpID),
 						},
 					},
 				},
 			},
 			want: want{
 				cr: &svcapitypes.HTTPNamespace{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							"servicediscovery.aws.crossplane.io/operation-id": validOpID,
+						},
+					},
 					Spec: svcapitypes.HTTPNamespaceSpec{
 						ForProvider: svcapitypes.HTTPNamespaceParameters{
 							Region: "eu-central-1",
 							Name:   aws.String("test"),
-						},
-					},
-					Status: svcapitypes.HTTPNamespaceStatus{
-						AtProvider: svcapitypes.HTTPNamespaceObservation{
-							OperationID: aws.String(validOpID),
 						},
 					},
 				},

--- a/pkg/controller/servicediscovery/httpnamespace/setup.go
+++ b/pkg/controller/servicediscovery/httpnamespace/setup.go
@@ -43,6 +43,7 @@ func SetupHTTPNamespace(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLim
 		func(e *external) {
 			h := commonnamespace.NewHooks(e.kube, e.client)
 			e.preCreate = preCreate
+			e.postCreate = postCreate
 			e.delete = h.Delete
 			e.observe = h.Observe
 		},
@@ -65,4 +66,9 @@ func SetupHTTPNamespace(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLim
 func preCreate(_ context.Context, cr *svcapitypes.HTTPNamespace, obj *svcsdk.CreateHttpNamespaceInput) error {
 	obj.CreatorRequestId = awsclient.String(string(cr.UID))
 	return nil
+}
+
+func postCreate(_ context.Context, cr *svcapitypes.HTTPNamespace, resp *svcsdk.CreateHttpNamespaceOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
+	cr.SetOperationID(resp.OperationId)
+	return cre, err
 }

--- a/pkg/controller/servicediscovery/privatednsnamespace/setup.go
+++ b/pkg/controller/servicediscovery/privatednsnamespace/setup.go
@@ -43,6 +43,7 @@ func SetupPrivateDNSNamespace(mgr ctrl.Manager, l logging.Logger, rl workqueue.R
 		func(e *external) {
 			h := commonnamespace.NewHooks(e.kube, e.client)
 			e.preCreate = preCreate
+			e.postCreate = postCreate
 			e.delete = h.Delete
 			e.observe = h.Observe
 		},
@@ -67,4 +68,9 @@ func preCreate(_ context.Context, cr *svcapitypes.PrivateDNSNamespace, obj *svcs
 	obj.CreatorRequestId = awsclient.String(string(cr.UID))
 	obj.Vpc = cr.Spec.ForProvider.VPC
 	return nil
+}
+
+func postCreate(_ context.Context, cr *svcapitypes.PrivateDNSNamespace, resp *svcsdk.CreatePrivateDnsNamespaceOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
+	cr.SetOperationID(resp.OperationId)
+	return cre, err
 }

--- a/pkg/controller/servicediscovery/publicdnsnamespace/setup.go
+++ b/pkg/controller/servicediscovery/publicdnsnamespace/setup.go
@@ -45,6 +45,7 @@ func SetupPublicDNSNamespace(mgr ctrl.Manager, l logging.Logger, rl workqueue.Ra
 			e.preCreate = preCreate
 			e.delete = h.Delete
 			e.observe = h.Observe
+			e.postCreate = postCreate
 		},
 	}
 	return ctrl.NewControllerManagedBy(mgr).
@@ -65,4 +66,9 @@ func SetupPublicDNSNamespace(mgr ctrl.Manager, l logging.Logger, rl workqueue.Ra
 func preCreate(_ context.Context, cr *svcapitypes.PublicDNSNamespace, obj *svcsdk.CreatePublicDnsNamespaceInput) error {
 	obj.CreatorRequestId = awsclient.String(string(cr.UID))
 	return nil
+}
+
+func postCreate(_ context.Context, cr *svcapitypes.PublicDNSNamespace, resp *svcsdk.CreatePublicDnsNamespaceOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
+	cr.SetOperationID(resp.OperationId)
+	return cre, err
 }


### PR DESCRIPTION

### Description of your changes

Fixes #944

This PR moves the storage of the OperationID returned by the AWS Cloud Map [API call](https://docs.aws.amazon.com/cloud-map/latest/api/API_CreatePublicDnsNamespace.html) into an annotation so that it is persisted.  

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I created and deleted the following AWS resources, ensuring the resources were created and deleted in the AWS console. 

- HTTPNamespace
- PrivateDNSNamespace (with VPC)
- PublicDNSNamespace

[contribution process]: https://git.io/fj2m9
