### PR TITLE
Ignore fields in `glue.Crawler` and `lambda.Function` that block code-generator bump

### DIFF
--- a/apis/glue/v1alpha1/generator-config.yaml
+++ b/apis/glue/v1alpha1/generator-config.yaml
@@ -24,6 +24,8 @@ ignore:
     - CreateClassifierInput.JsonClassifier
     - CreateClassifierInput.GrokClassifier
     - CreateConnectionInput.ConnectionInput
+    # See https://github.com/aws-controllers-k8s/community/issues/1078
+    - Crawler.Schedule
 
 resources:
   Job:

--- a/apis/glue/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/glue/v1alpha1/zz_generated.deepcopy.go
@@ -1253,11 +1253,6 @@ func (in *Crawler_SDK) DeepCopyInto(out *Crawler_SDK) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.Schedule != nil {
-		in, out := &in.Schedule, &out.Schedule
-		*out = new(Schedule)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.SchemaChangePolicy != nil {
 		in, out := &in.SchemaChangePolicy, &out.SchemaChangePolicy
 		*out = new(SchemaChangePolicy)
@@ -4249,11 +4244,6 @@ func (in *Schedule) DeepCopyInto(out *Schedule) {
 	*out = *in
 	if in.ScheduleExpression != nil {
 		in, out := &in.ScheduleExpression, &out.ScheduleExpression
-		*out = new(string)
-		**out = **in
-	}
-	if in.State != nil {
-		in, out := &in.State, &out.State
 		*out = new(string)
 		**out = **in
 	}

--- a/apis/glue/v1alpha1/zz_types.go
+++ b/apis/glue/v1alpha1/zz_types.go
@@ -220,8 +220,6 @@ type Crawler_SDK struct {
 	RecrawlPolicy *RecrawlPolicy `json:"recrawlPolicy,omitempty"`
 
 	Role *string `json:"role,omitempty"`
-	// A scheduling object using a cron statement to schedule an event.
-	Schedule *Schedule `json:"schedule,omitempty"`
 	// A policy that specifies update and deletion behaviors for the crawler.
 	SchemaChangePolicy *SchemaChangePolicy `json:"schemaChangePolicy,omitempty"`
 
@@ -787,8 +785,6 @@ type S3Target struct {
 
 type Schedule struct {
 	ScheduleExpression *string `json:"scheduleExpression,omitempty"`
-
-	State *string `json:"state,omitempty"`
 }
 
 type SchemaChangePolicy struct {

--- a/apis/lambda/v1alpha1/generator-config.yaml
+++ b/apis/lambda/v1alpha1/generator-config.yaml
@@ -6,6 +6,8 @@ ignore:
     - GetFunctionInput.FunctionName
     - DeleteFunctionInput.FunctionName
     - CreateFunctionInput.Role
+    # See https://github.com/aws-controllers-k8s/community/issues/1078
+    - FunctionConfiguration.Layers
   resource_names:
     - Alias
     - CodeSigningConfig

--- a/pkg/controller/glue/crawler/setup.go
+++ b/pkg/controller/glue/crawler/setup.go
@@ -42,7 +42,6 @@ func SetupCrawler(mgr ctrl.Manager, l logging.Logger, limiter workqueue.RateLimi
 			e.preObserve = preObserve
 			e.postObserve = postObserve
 			e.preDelete = preDelete
-			e.postCreate = postCreate
 			e.preCreate = preCreate
 		},
 	}
@@ -71,7 +70,7 @@ func preObserve(_ context.Context, cr *svcapitypes.Crawler, obj *svcsdk.GetCrawl
 	return nil
 }
 
-func postObserve(_ context.Context, cr *svcapitypes.Crawler, obj *svcsdk.GetCrawlerOutput, obs managed.ExternalObservation, err error) (managed.ExternalObservation, error) {
+func postObserve(_ context.Context, cr *svcapitypes.Crawler, _ *svcsdk.GetCrawlerOutput, obs managed.ExternalObservation, err error) (managed.ExternalObservation, error) {
 	if err != nil {
 		return managed.ExternalObservation{}, err
 	}
@@ -79,16 +78,9 @@ func postObserve(_ context.Context, cr *svcapitypes.Crawler, obj *svcsdk.GetCraw
 	return obs, nil
 }
 
-func postCreate(_ context.Context, cr *svcapitypes.Crawler, obj *svcsdk.CreateCrawlerOutput, _ managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
-	if err != nil {
-		return managed.ExternalCreation{}, err
-	}
-	meta.SetExternalName(cr, cr.Name)
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
-}
-
 func preCreate(_ context.Context, cr *svcapitypes.Crawler, obj *svcsdk.CreateCrawlerInput) error {
-	obj.Name = &cr.Name
+	obj.Name = awsclients.String(meta.GetExternalName(cr))
 	obj.Role = &cr.Spec.ForProvider.RoleArn
+	obj.Schedule = cr.Spec.ForProvider.Schedule
 	return nil
 }

--- a/pkg/controller/lambda/function/setup.go
+++ b/pkg/controller/lambda/function/setup.go
@@ -81,6 +81,7 @@ func preCreate(_ context.Context, cr *svcapitypes.Function, obj *svcsdk.CreateFu
 			SubnetIds:        cr.Spec.ForProvider.CustomFunctionVPCConfigParameters.SubnetIDs,
 		}
 	}
+	obj.Layers = cr.Spec.ForProvider.Layers
 	return nil
 }
 

--- a/pkg/controller/lambda/function/zz_controller.go
+++ b/pkg/controller/lambda/function/zz_controller.go
@@ -241,29 +241,29 @@ func (e *external) Create(ctx context.Context, mg cpresource.Managed) (managed.E
 		cr.Status.AtProvider.Version = nil
 	}
 	if resp.VpcConfig != nil {
-		f30 := &svcapitypes.VPCConfigResponse{}
+		f29 := &svcapitypes.VPCConfigResponse{}
 		if resp.VpcConfig.SecurityGroupIds != nil {
-			f30f0 := []*string{}
-			for _, f30f0iter := range resp.VpcConfig.SecurityGroupIds {
-				var f30f0elem string
-				f30f0elem = *f30f0iter
-				f30f0 = append(f30f0, &f30f0elem)
+			f29f0 := []*string{}
+			for _, f29f0iter := range resp.VpcConfig.SecurityGroupIds {
+				var f29f0elem string
+				f29f0elem = *f29f0iter
+				f29f0 = append(f29f0, &f29f0elem)
 			}
-			f30.SecurityGroupIDs = f30f0
+			f29.SecurityGroupIDs = f29f0
 		}
 		if resp.VpcConfig.SubnetIds != nil {
-			f30f1 := []*string{}
-			for _, f30f1iter := range resp.VpcConfig.SubnetIds {
-				var f30f1elem string
-				f30f1elem = *f30f1iter
-				f30f1 = append(f30f1, &f30f1elem)
+			f29f1 := []*string{}
+			for _, f29f1iter := range resp.VpcConfig.SubnetIds {
+				var f29f1elem string
+				f29f1elem = *f29f1iter
+				f29f1 = append(f29f1, &f29f1elem)
 			}
-			f30.SubnetIDs = f30f1
+			f29.SubnetIDs = f29f1
 		}
 		if resp.VpcConfig.VpcId != nil {
-			f30.VPCID = resp.VpcConfig.VpcId
+			f29.VPCID = resp.VpcConfig.VpcId
 		}
-		cr.Status.AtProvider.VPCConfig = f30
+		cr.Status.AtProvider.VPCConfig = f29
 	} else {
 		cr.Status.AtProvider.VPCConfig = nil
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Due to https://github.com/aws-controllers-k8s/community/issues/1078 , we cannot use the code generated to set these fields. To unblock code-generator upgrade, we can ignore them so that their getter/setter logic is not generated and handwritten by us in `setup.go` 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
