### PR TITLE
fix(generated-services) added docdb to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PROJECT_REPO := github.com/crossplane/$(PROJECT_NAME)
 PLATFORMS ?= linux_amd64 linux_arm64
 
 CODE_GENERATOR_COMMIT ?= 285d87b66b62fbfb859986ddf74c9f9b6ae743fb
-GENERATED_SERVICES="apigatewayv2,cloudfront,cloudwatchlogs,dynamodb,ec2,efs,glue,kafka,kms,lambda,mq,rds,secretsmanager,servicediscovery,sfn,transfer"
+GENERATED_SERVICES="apigatewayv2,cloudfront,cloudwatchlogs,docdb,dynamodb,ec2,efs,glue,kafka,kms,lambda,mq,rds,secretsmanager,servicediscovery,sfn,transfer"
 
 # kind-related versions
 KIND_VERSION ?= v0.11.1

--- a/apis/docdb/v1alpha1/zz_types.go
+++ b/apis/docdb/v1alpha1/zz_types.go
@@ -27,10 +27,12 @@ var (
 	_ = &metav1.Time{}
 )
 
+// +kubebuilder:skipversion
 type AvailabilityZone struct {
 	Name *string `json:"name,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type Certificate struct {
 	CertificateARN *string `json:"certificateARN,omitempty"`
 
@@ -45,12 +47,14 @@ type Certificate struct {
 	ValidTill *metav1.Time `json:"validTill,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type CloudwatchLogsExportConfiguration struct {
 	DisableLogTypes []*string `json:"disableLogTypes,omitempty"`
 
 	EnableLogTypes []*string `json:"enableLogTypes,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type DBClusterMember struct {
 	DBClusterParameterGroupStatus *string `json:"dbClusterParameterGroupStatus,omitempty"`
 
@@ -61,6 +65,7 @@ type DBClusterMember struct {
 	PromotionTier *int64 `json:"promotionTier,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type DBClusterParameterGroup_SDK struct {
 	DBClusterParameterGroupARN *string `json:"dbClusterParameterGroupARN,omitempty"`
 
@@ -71,12 +76,14 @@ type DBClusterParameterGroup_SDK struct {
 	Description *string `json:"description,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type DBClusterRole struct {
 	RoleARN *string `json:"roleARN,omitempty"`
 
 	Status *string `json:"status,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type DBClusterSnapshot struct {
 	AvailabilityZones []*string `json:"availabilityZones,omitempty"`
 
@@ -113,14 +120,17 @@ type DBClusterSnapshot struct {
 	VPCID *string `json:"vpcID,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type DBClusterSnapshotAttribute struct {
 	AttributeName *string `json:"attributeName,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type DBClusterSnapshotAttributesResult struct {
 	DBClusterSnapshotIdentifier *string `json:"dbClusterSnapshotIdentifier,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type DBCluster_SDK struct {
 	AssociatedRoles []*DBClusterRole `json:"associatedRoles,omitempty"`
 
@@ -181,6 +191,7 @@ type DBCluster_SDK struct {
 	VPCSecurityGroups []*VPCSecurityGroupMembership `json:"vpcSecurityGroups,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type DBEngineVersion struct {
 	DBEngineDescription *string `json:"dbEngineDescription,omitempty"`
 
@@ -197,6 +208,7 @@ type DBEngineVersion struct {
 	SupportsLogExportsToCloudwatchLogs *bool `json:"supportsLogExportsToCloudwatchLogs,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type DBInstanceStatusInfo struct {
 	Message *string `json:"message,omitempty"`
 
@@ -207,6 +219,7 @@ type DBInstanceStatusInfo struct {
 	StatusType *string `json:"statusType,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type DBInstance_SDK struct {
 	AutoMinorVersionUpgrade *bool `json:"autoMinorVersionUpgrade,omitempty"`
 
@@ -263,6 +276,7 @@ type DBInstance_SDK struct {
 	VPCSecurityGroups []*VPCSecurityGroupMembership `json:"vpcSecurityGroups,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type DBSubnetGroup_SDK struct {
 	DBSubnetGroupARN *string `json:"dbSubnetGroupARN,omitempty"`
 
@@ -277,6 +291,7 @@ type DBSubnetGroup_SDK struct {
 	VPCID *string `json:"vpcID,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type Endpoint struct {
 	Address *string `json:"address,omitempty"`
 
@@ -285,6 +300,7 @@ type Endpoint struct {
 	Port *int64 `json:"port,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type EngineDefaults struct {
 	DBParameterGroupFamily *string `json:"dbParameterGroupFamily,omitempty"`
 
@@ -293,6 +309,7 @@ type EngineDefaults struct {
 	Parameters []*Parameter `json:"parameters,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type Event struct {
 	Date *metav1.Time `json:"date,omitempty"`
 
@@ -303,16 +320,19 @@ type Event struct {
 	SourceIdentifier *string `json:"sourceIdentifier,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type EventCategoriesMap struct {
 	SourceType *string `json:"sourceType,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type Filter struct {
 	Name *string `json:"name,omitempty"`
 
 	Values []*string `json:"values,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type OrderableDBInstanceOption struct {
 	DBInstanceClass *string `json:"dbInstanceClass,omitempty"`
 
@@ -325,6 +345,7 @@ type OrderableDBInstanceOption struct {
 	VPC *bool `json:"vpc,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type Parameter struct {
 	AllowedValues *string `json:"allowedValues,omitempty"`
 
@@ -347,12 +368,14 @@ type Parameter struct {
 	Source *string `json:"source,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type PendingCloudwatchLogsExports struct {
 	LogTypesToDisable []*string `json:"logTypesToDisable,omitempty"`
 
 	LogTypesToEnable []*string `json:"logTypesToEnable,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type PendingMaintenanceAction struct {
 	Action *string `json:"action,omitempty"`
 
@@ -367,6 +390,7 @@ type PendingMaintenanceAction struct {
 	OptInStatus *string `json:"optInStatus,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type PendingModifiedValues struct {
 	AllocatedStorage *int64 `json:"allocatedStorage,omitempty"`
 
@@ -398,10 +422,12 @@ type PendingModifiedValues struct {
 	StorageType *string `json:"storageType,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type ResourcePendingMaintenanceActions struct {
 	ResourceIdentifier *string `json:"resourceIdentifier,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type Subnet struct {
 	// Information about an Availability Zone.
 	SubnetAvailabilityZone *AvailabilityZone `json:"subnetAvailabilityZone,omitempty"`
@@ -411,12 +437,14 @@ type Subnet struct {
 	SubnetStatus *string `json:"subnetStatus,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type Tag struct {
 	Key *string `json:"key,omitempty"`
 
 	Value *string `json:"value,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type UpgradeTarget struct {
 	AutoUpgrade *bool `json:"autoUpgrade,omitempty"`
 
@@ -429,6 +457,7 @@ type UpgradeTarget struct {
 	IsMajorVersionUpgrade *bool `json:"isMajorVersionUpgrade,omitempty"`
 }
 
+// +kubebuilder:skipversion
 type VPCSecurityGroupMembership struct {
 	Status *string `json:"status,omitempty"`
 

--- a/pkg/controller/docdb/dbcluster/zz_controller.go
+++ b/pkg/controller/docdb/dbcluster/zz_controller.go
@@ -135,6 +135,22 @@ func (e *external) Create(ctx context.Context, mg cpresource.Managed) (managed.E
 	} else {
 		cr.Status.AtProvider.AssociatedRoles = nil
 	}
+	if resp.DBCluster.AvailabilityZones != nil {
+		f1 := []*string{}
+		for _, f1iter := range resp.DBCluster.AvailabilityZones {
+			var f1elem string
+			f1elem = *f1iter
+			f1 = append(f1, &f1elem)
+		}
+		cr.Spec.ForProvider.AvailabilityZones = f1
+	} else {
+		cr.Spec.ForProvider.AvailabilityZones = nil
+	}
+	if resp.DBCluster.BackupRetentionPeriod != nil {
+		cr.Spec.ForProvider.BackupRetentionPeriod = resp.DBCluster.BackupRetentionPeriod
+	} else {
+		cr.Spec.ForProvider.BackupRetentionPeriod = nil
+	}
 	if resp.DBCluster.ClusterCreateTime != nil {
 		cr.Status.AtProvider.ClusterCreateTime = &metav1.Time{*resp.DBCluster.ClusterCreateTime}
 	} else {
@@ -187,6 +203,11 @@ func (e *external) Create(ctx context.Context, mg cpresource.Managed) (managed.E
 	} else {
 		cr.Status.AtProvider.DBClusterResourceID = nil
 	}
+	if resp.DBCluster.DeletionProtection != nil {
+		cr.Spec.ForProvider.DeletionProtection = resp.DBCluster.DeletionProtection
+	} else {
+		cr.Spec.ForProvider.DeletionProtection = nil
+	}
 	if resp.DBCluster.EarliestRestorableTime != nil {
 		cr.Status.AtProvider.EarliestRestorableTime = &metav1.Time{*resp.DBCluster.EarliestRestorableTime}
 	} else {
@@ -208,15 +229,35 @@ func (e *external) Create(ctx context.Context, mg cpresource.Managed) (managed.E
 	} else {
 		cr.Status.AtProvider.Endpoint = nil
 	}
+	if resp.DBCluster.Engine != nil {
+		cr.Spec.ForProvider.Engine = resp.DBCluster.Engine
+	} else {
+		cr.Spec.ForProvider.Engine = nil
+	}
+	if resp.DBCluster.EngineVersion != nil {
+		cr.Spec.ForProvider.EngineVersion = resp.DBCluster.EngineVersion
+	} else {
+		cr.Spec.ForProvider.EngineVersion = nil
+	}
 	if resp.DBCluster.HostedZoneId != nil {
 		cr.Status.AtProvider.HostedZoneID = resp.DBCluster.HostedZoneId
 	} else {
 		cr.Status.AtProvider.HostedZoneID = nil
 	}
+	if resp.DBCluster.KmsKeyId != nil {
+		cr.Spec.ForProvider.KMSKeyID = resp.DBCluster.KmsKeyId
+	} else {
+		cr.Spec.ForProvider.KMSKeyID = nil
+	}
 	if resp.DBCluster.LatestRestorableTime != nil {
 		cr.Status.AtProvider.LatestRestorableTime = &metav1.Time{*resp.DBCluster.LatestRestorableTime}
 	} else {
 		cr.Status.AtProvider.LatestRestorableTime = nil
+	}
+	if resp.DBCluster.MasterUsername != nil {
+		cr.Spec.ForProvider.MasterUsername = resp.DBCluster.MasterUsername
+	} else {
+		cr.Spec.ForProvider.MasterUsername = nil
 	}
 	if resp.DBCluster.MultiAZ != nil {
 		cr.Status.AtProvider.MultiAZ = resp.DBCluster.MultiAZ
@@ -228,6 +269,21 @@ func (e *external) Create(ctx context.Context, mg cpresource.Managed) (managed.E
 	} else {
 		cr.Status.AtProvider.PercentProgress = nil
 	}
+	if resp.DBCluster.Port != nil {
+		cr.Spec.ForProvider.Port = resp.DBCluster.Port
+	} else {
+		cr.Spec.ForProvider.Port = nil
+	}
+	if resp.DBCluster.PreferredBackupWindow != nil {
+		cr.Spec.ForProvider.PreferredBackupWindow = resp.DBCluster.PreferredBackupWindow
+	} else {
+		cr.Spec.ForProvider.PreferredBackupWindow = nil
+	}
+	if resp.DBCluster.PreferredMaintenanceWindow != nil {
+		cr.Spec.ForProvider.PreferredMaintenanceWindow = resp.DBCluster.PreferredMaintenanceWindow
+	} else {
+		cr.Spec.ForProvider.PreferredMaintenanceWindow = nil
+	}
 	if resp.DBCluster.ReaderEndpoint != nil {
 		cr.Status.AtProvider.ReaderEndpoint = resp.DBCluster.ReaderEndpoint
 	} else {
@@ -237,6 +293,11 @@ func (e *external) Create(ctx context.Context, mg cpresource.Managed) (managed.E
 		cr.Status.AtProvider.Status = resp.DBCluster.Status
 	} else {
 		cr.Status.AtProvider.Status = nil
+	}
+	if resp.DBCluster.StorageEncrypted != nil {
+		cr.Spec.ForProvider.StorageEncrypted = resp.DBCluster.StorageEncrypted
+	} else {
+		cr.Spec.ForProvider.StorageEncrypted = nil
 	}
 	if resp.DBCluster.VpcSecurityGroups != nil {
 		f28 := []*svcapitypes.VPCSecurityGroupMembership{}

--- a/pkg/controller/docdb/dbclusterparametergroup/zz_controller.go
+++ b/pkg/controller/docdb/dbclusterparametergroup/zz_controller.go
@@ -128,6 +128,16 @@ func (e *external) Create(ctx context.Context, mg cpresource.Managed) (managed.E
 	} else {
 		cr.Status.AtProvider.DBClusterParameterGroupName = nil
 	}
+	if resp.DBClusterParameterGroup.DBParameterGroupFamily != nil {
+		cr.Spec.ForProvider.DBParameterGroupFamily = resp.DBClusterParameterGroup.DBParameterGroupFamily
+	} else {
+		cr.Spec.ForProvider.DBParameterGroupFamily = nil
+	}
+	if resp.DBClusterParameterGroup.Description != nil {
+		cr.Spec.ForProvider.Description = resp.DBClusterParameterGroup.Description
+	} else {
+		cr.Spec.ForProvider.Description = nil
+	}
 
 	return e.postCreate(ctx, cr, resp, managed.ExternalCreation{}, err)
 }

--- a/pkg/controller/docdb/dbinstance/zz_controller.go
+++ b/pkg/controller/docdb/dbinstance/zz_controller.go
@@ -119,6 +119,16 @@ func (e *external) Create(ctx context.Context, mg cpresource.Managed) (managed.E
 		return managed.ExternalCreation{}, awsclient.Wrap(err, errCreate)
 	}
 
+	if resp.DBInstance.AutoMinorVersionUpgrade != nil {
+		cr.Spec.ForProvider.AutoMinorVersionUpgrade = resp.DBInstance.AutoMinorVersionUpgrade
+	} else {
+		cr.Spec.ForProvider.AutoMinorVersionUpgrade = nil
+	}
+	if resp.DBInstance.AvailabilityZone != nil {
+		cr.Spec.ForProvider.AvailabilityZone = resp.DBInstance.AvailabilityZone
+	} else {
+		cr.Spec.ForProvider.AvailabilityZone = nil
+	}
 	if resp.DBInstance.BackupRetentionPeriod != nil {
 		cr.Status.AtProvider.BackupRetentionPeriod = resp.DBInstance.BackupRetentionPeriod
 	} else {
@@ -138,6 +148,11 @@ func (e *external) Create(ctx context.Context, mg cpresource.Managed) (managed.E
 		cr.Status.AtProvider.DBInstanceARN = resp.DBInstance.DBInstanceArn
 	} else {
 		cr.Status.AtProvider.DBInstanceARN = nil
+	}
+	if resp.DBInstance.DBInstanceClass != nil {
+		cr.Spec.ForProvider.DBInstanceClass = resp.DBInstance.DBInstanceClass
+	} else {
+		cr.Spec.ForProvider.DBInstanceClass = nil
 	}
 	if resp.DBInstance.DBInstanceIdentifier != nil {
 		cr.Status.AtProvider.DBInstanceIdentifier = resp.DBInstance.DBInstanceIdentifier
@@ -221,6 +236,11 @@ func (e *external) Create(ctx context.Context, mg cpresource.Managed) (managed.E
 		cr.Status.AtProvider.Endpoint = f12
 	} else {
 		cr.Status.AtProvider.Endpoint = nil
+	}
+	if resp.DBInstance.Engine != nil {
+		cr.Spec.ForProvider.Engine = resp.DBInstance.Engine
+	} else {
+		cr.Spec.ForProvider.Engine = nil
 	}
 	if resp.DBInstance.EngineVersion != nil {
 		cr.Status.AtProvider.EngineVersion = resp.DBInstance.EngineVersion
@@ -313,6 +333,16 @@ func (e *external) Create(ctx context.Context, mg cpresource.Managed) (managed.E
 		cr.Status.AtProvider.PreferredBackupWindow = resp.DBInstance.PreferredBackupWindow
 	} else {
 		cr.Status.AtProvider.PreferredBackupWindow = nil
+	}
+	if resp.DBInstance.PreferredMaintenanceWindow != nil {
+		cr.Spec.ForProvider.PreferredMaintenanceWindow = resp.DBInstance.PreferredMaintenanceWindow
+	} else {
+		cr.Spec.ForProvider.PreferredMaintenanceWindow = nil
+	}
+	if resp.DBInstance.PromotionTier != nil {
+		cr.Spec.ForProvider.PromotionTier = resp.DBInstance.PromotionTier
+	} else {
+		cr.Spec.ForProvider.PromotionTier = nil
 	}
 	if resp.DBInstance.PubliclyAccessible != nil {
 		cr.Status.AtProvider.PubliclyAccessible = resp.DBInstance.PubliclyAccessible

--- a/pkg/controller/docdb/dbsubnetgroup/zz_controller.go
+++ b/pkg/controller/docdb/dbsubnetgroup/zz_controller.go
@@ -123,6 +123,11 @@ func (e *external) Create(ctx context.Context, mg cpresource.Managed) (managed.E
 	} else {
 		cr.Status.AtProvider.DBSubnetGroupARN = nil
 	}
+	if resp.DBSubnetGroup.DBSubnetGroupDescription != nil {
+		cr.Spec.ForProvider.DBSubnetGroupDescription = resp.DBSubnetGroup.DBSubnetGroupDescription
+	} else {
+		cr.Spec.ForProvider.DBSubnetGroupDescription = nil
+	}
 	if resp.DBSubnetGroup.DBSubnetGroupName != nil {
 		cr.Status.AtProvider.DBSubnetGroupName = resp.DBSubnetGroup.DBSubnetGroupName
 	} else {


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
added docdb to makefile for generated-services
rerun make generate
test is failing

```
--- FAIL: TestCreate (0.00s)
    --- FAIL: TestCreate/SuccessfulCreate (0.00s)
        /Users/haarchri/Documents/test/provider-aws/pkg/controller/docdb/dbcluster/setup_test.go:2203: r: -want, +got:
              &v1alpha1.DBCluster{
              	TypeMeta:   {},
              	ObjectMeta: {Annotations: {"crossplane.io/external-name": "some-db-cluster"}},
              	Spec: v1alpha1.DBClusterSpec{
              		ResourceSpec: {},
              		ForProvider: v1alpha1.DBClusterParameters{
              			Region:                      "",
            - 			AvailabilityZones:           []*string{&"test-zone-a", &"test-zone-b"},
            + 			AvailabilityZones:           nil,
            - 			BackupRetentionPeriod:       &10,
            + 			BackupRetentionPeriod:       nil,
              			DBClusterParameterGroupName: &"some-db-cluster-parameter-group",
              			DBSubnetGroupName:           &"some-db-subnet-group",
            - 			DeletionProtection:          &true,
            + 			DeletionProtection:          nil,
              			EnableCloudwatchLogsExports: {&"some-log", &"some-other-log"},
            - 			Engine:                      &"some-engine",
            + 			Engine:                      nil,
            - 			EngineVersion:               &"some-engine-version",
            + 			EngineVersion:               nil,
            - 			KMSKeyID:                    &"some-key",
            + 			KMSKeyID:                    nil,
            - 			MasterUsername:              &"some-user",
            + 			MasterUsername:              nil,
              			Port:                        &3210,
              			PreSignedURL:                &"some-url",
            - 			PreferredBackupWindow:       &"some-window",
            + 			PreferredBackupWindow:       nil,
            - 			PreferredMaintenanceWindow:  &"some-window",
            + 			PreferredMaintenanceWindow:  nil,
            - 			StorageEncrypted:            &true,
            + 			StorageEncrypted:            nil,
              			Tags:                        {&{Key: &"some-tag-key", Value: &"some-tag-value"}, &{Key: &"some-other-tag-key", Value: &"some-other-tag-value"}},
              			VPCSecurityGroupIDs:         {&"some-group", &"some-other-group"},
              			CustomDBClusterParameters:   {MasterUserPasswordSecretRef: &{SecretReference: {Name: "some-name"}, Key: "some-key"}},
              		},
              	},
              	Status: {ResourceStatus: {ConditionedStatus: {Conditions: {{Type: "Ready", Status: "False", LastTransitionTime: s"2021-12-14 20:08:16.591356 +0100"..., Reason: "Creating"}}}}, AtProvider: {DBClusterARN: &"some-db-cluster-arn", DBClusterIdentifier: &"some-db-cluster", Endpoint: &"some-endpoint", ReaderEndpoint: &"some-reader-endpoint", ...}},
              }
        /Users/haarchri/Documents/test/provider-aws/pkg/controller/docdb/dbcluster/setup_test.go:2206: r: -want, +got:
              managed.ExternalCreation{
              	ExternalNameAssigned: false,
              	ConnectionDetails: managed.ConnectionDetails{
              		... // 2 identical entries
              		"port":           {0x33, 0x32, 0x31, 0x30},
              		"readerEndpoint": {0x73, 0x6f, 0x6d, 0x65, ...},
              		"username": {
            - 			0x73,
            - 			0x6f,
            - 			0x6d,
            - 			0x65,
            - 			0x2d,
            - 			0x75,
            - 			0x73,
            - 			0x65,
            - 			0x72,
              		},
              	},
              }
FAIL
FAIL	github.com/crossplane/provider-aws/pkg/controller/docdb/dbcluster	0.351s
FAIL
```


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
