### PR TITLE
chore: dynamically generate GENERATED_SERVICES var

### DIFF
--- a/CODE_GENERATION.md
+++ b/CODE_GENERATION.md
@@ -46,7 +46,7 @@ ignore:
     - <other CRD kinds you want to ignore>
 ```
 
-If you'd like to specify an API version for a generated resource other than 
+If you'd like to specify an API version for a generated resource other than
 the default `v1alpha1`, you can do so with a configuration in `generator-config.yaml`
 as follows:
 ```yaml
@@ -55,24 +55,14 @@ resources:
     api_versions:
     - name: "v1beta1"
 ```
-If not overridden in the `generator-config.yaml` file, the default version generated is 
+If not overridden in the `generator-config.yaml` file, the default version generated is
 `v1alpha1`.
 
 When you re-run the generation with this configuration, existing files won't be
-deleted. So you may want to delete everything in `apis/<serviceid>/v1alpha1`and 
+deleted. So you may want to delete everything in `apis/<serviceid>/v1alpha1`and
 then re-run the command.
 
 If `apis/<serviceid>` is created from scratch, please add the new service name to the list called GENERATED_SERVICES in [Makefile](https://github.com/crossplane/provider-aws/blob/master/Makefile#L10).
-
-### Makefile
-
-```bash
-- GENERATED_SERVICES="apigatewayv2"
-+ GENERATED_SERVICES="apigatewayv2,<serviceid>"
-```
-
-If this step fails for some reason, please raise an issue in [code-generator](https://github.com/aws-controllers-k8s/code-generator)
-and mention that you're using Crossplane pipeline.
 
 ### Crossplane Code Generation
 
@@ -420,16 +410,16 @@ to test the real-world scenario. There are two Docker images to be built; one ha
 the controller image, the other one has package metadata and CRDs. We need to choose a
 controller image before building metadata image. Then we'll start the build process.
 
-Pre-requisites: 
+Pre-requisites:
 * Install Crossplane on the kind cluster following the steps [here](https://crossplane.io/docs/v1.5/reference/install.html).
-* Install Crossplane CLI following the steps [here](https://crossplane.io/docs/v1.5/getting-started/install-configure.html#install-crossplane-cli). 
+* Install Crossplane CLI following the steps [here](https://crossplane.io/docs/v1.5/getting-started/install-configure.html#install-crossplane-cli).
 * Docker hub account with your own public repository.
 
 Follow the steps below to get set-up for in-cluster testing:
 * Run `make build DOCKER_REGISTRY=<username> VERSION=test-version` in `provider-aws`. This will create two images mentioned above:
-  * `build-<short-sha>/provider-aws-amd64:latest //Controller Image This is the one that will be running in the cluster.` 
+  * `build-<short-sha>/provider-aws-amd64:latest //Controller Image This is the one that will be running in the cluster.`
   * `build-<short-sha>/provider-aws-controller-amd64:latest //Metadata Image This is the one we'll use when we install the provider.`
-  
+
 
 * Tag and push both the images to your personal docker repository.
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PROJECT_REPO := github.com/crossplane/$(PROJECT_NAME)
 PLATFORMS ?= linux_amd64 linux_arm64
 
 CODE_GENERATOR_COMMIT ?= c7d9f6bbcaf8f628910202fa126e03faa970502b
-GENERATED_SERVICES="apigatewayv2,athena,cloudfront,cloudwatchlogs,docdb,dynamodb,elbv2,ec2,efs,eks,glue,iot,kafka,kinesis,kms,lambda,mq,rds,route53resolver,secretsmanager,servicediscovery,sfn,transfer,ram"
+GENERATED_SERVICES := $(shell find ./apis/ -type f -name generator-config.yaml | cut -d/ -f 3 | tr '\n' ' ')
 
 # kind-related versions
 KIND_VERSION ?= v0.11.1
@@ -123,16 +123,11 @@ run: go.build
 # NOTE(muvaf): ACK Code Generator is a separate Go module, hence we need to
 # be in its root directory to call "go run" properly.
 services: $(GOIMPORTS)
-	@if [ "$(SERVICES)" = "" ]; then \
-		echo "Error: Please specify the comma-seperated list of services via 'SERVICES' variable."; \
-		echo "For more info: https://github.com/crossplane/provider-aws/blob/master/CODE_GENERATION.md#code-generation"; \
-		exit 1; \
-	fi
 	@if [ ! -d "$(WORK_DIR)/code-generator" ]; then \
 		cd $(WORK_DIR) && git clone "https://github.com/aws-controllers-k8s/code-generator.git"; \
 	fi
 	@cd $(WORK_DIR)/code-generator && git fetch origin && git checkout $(CODE_GENERATOR_COMMIT)
-	@for svc in $$(echo "$(SERVICES)" | tr ',' ' '); do \
+	@for svc in $(SERVICES); do \
 		$(INFO) Generating $$svc controllers and CRDs; \
 		PATH="${PATH}:$(TOOLS_HOST_DIR)"; \
 		cd $(WORK_DIR)/code-generator && go run -tags codegen cmd/ack-generate/main.go crossplane $$svc --output ../../ || exit 1; \
@@ -140,7 +135,7 @@ services: $(GOIMPORTS)
 	done
 
 services.all:
-	@$(MAKE) services SERVICES=$(GENERATED_SERVICES)
+	@$(MAKE) services SERVICES="$(GENERATED_SERVICES)"
 
 # ====================================================================================
 # Special Targets


### PR DESCRIPTION
Signed-off-by: Daniel Werdermann <daniel.werdermann@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

The variable in the Makefile is now generated from the paths of the generatec-config.yaml files. So no more editingof the Makefile and no merge conflicts.

Fixes #861
Fixes #862

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

`make reviewable` works without changes.

[contribution process]: https://git.io/fj2m9
