### PR TITLE
Add support for external ID when assume role

### DIFF
--- a/apis/v1beta1/providerconfig_types.go
+++ b/apis/v1beta1/providerconfig_types.go
@@ -31,6 +31,10 @@ type ProviderConfigSpec struct {
 	// +optional
 	AssumeRoleARN *string `json:"assumeRoleARN,omitempty"`
 
+	// ExternalID is the external ID used when assuming role.
+	// +optional
+	ExternalID *string `json:"externalID,omitempty"`
+
 	// Endpoint is where you can override the default endpoint configuration
 	// of AWS calls made by the provider.
 	// +optional

--- a/apis/v1beta1/zz_generated.deepcopy.go
+++ b/apis/v1beta1/zz_generated.deepcopy.go
@@ -153,6 +153,11 @@ func (in *ProviderConfigSpec) DeepCopyInto(out *ProviderConfigSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ExternalID != nil {
+		in, out := &in.ExternalID, &out.ExternalID
+		*out = new(string)
+		**out = **in
+	}
 	if in.Endpoint != nil {
 		in, out := &in.Endpoint, &out.Endpoint
 		*out = new(EndpointConfig)

--- a/package/crds/aws.crossplane.io_providerconfigs.yaml
+++ b/package/crds/aws.crossplane.io_providerconfigs.yaml
@@ -207,6 +207,9 @@ spec:
                 required:
                 - url
                 type: object
+              externalID:
+                description: ExternalID is the external ID used when assuming role.
+                type: string
             required:
             - credentials
             type: object

--- a/pkg/clients/aws.go
+++ b/pkg/clients/aws.go
@@ -298,7 +298,11 @@ func UseProviderSecretAssumeRole(ctx context.Context, data []byte, profile, regi
 	}))
 
 	stsSvc := sts.NewFromConfig(config)
-	stsAssume := stscreds.NewAssumeRoleProvider(stsSvc, StringValue(pc.Spec.AssumeRoleARN))
+	stsAssume := stscreds.NewAssumeRoleProvider(
+		stsSvc,
+		StringValue(pc.Spec.AssumeRoleARN),
+		func(opt *stscreds.AssumeRoleOptions) { opt.ExternalID = pc.Spec.ExternalID },
+	)
 	config.Credentials = aws.NewCredentialsCache(stsAssume)
 
 	return &config, err
@@ -320,6 +324,7 @@ func UsePodServiceAccountAssumeRole(ctx context.Context, _ []byte, _, region str
 			stscreds.NewAssumeRoleProvider(
 				stsclient,
 				StringValue(pc.Spec.AssumeRoleARN),
+				func(opt *stscreds.AssumeRoleOptions) { opt.ExternalID = pc.Spec.ExternalID },
 			)),
 		),
 	)
@@ -411,7 +416,11 @@ func UseProviderSecretV1AssumeRole(ctx context.Context, data []byte, pc *v1beta1
 	}
 
 	stsSvc := sts.NewFromConfig(config)
-	stsAssume := stscreds.NewAssumeRoleProvider(stsSvc, StringValue(pc.Spec.AssumeRoleARN))
+	stsAssume := stscreds.NewAssumeRoleProvider(
+		stsSvc,
+		StringValue(pc.Spec.AssumeRoleARN),
+		func(opt *stscreds.AssumeRoleOptions) { opt.ExternalID = pc.Spec.ExternalID },
+	)
 	config.Credentials = aws.NewCredentialsCache(stsAssume)
 
 	v2creds, err := config.Credentials.Retrieve(ctx)
@@ -475,6 +484,7 @@ func UsePodServiceAccountV1AssumeRole(ctx context.Context, _ []byte, pc *v1beta1
 			stscreds.NewAssumeRoleProvider(
 				stsclient,
 				StringValue(pc.Spec.AssumeRoleARN),
+				func(opt *stscreds.AssumeRoleOptions) { opt.ExternalID = pc.Spec.ExternalID },
 			)),
 		),
 	)


### PR DESCRIPTION
Signed-off-by: Hanlin Shi <shihanlin9@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Added support for external ID when assuming aws role.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1012

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Manually created IAM role that can be assumed when passing an external ID, and create a provider config containing that IAM info. Created an S3 bucket using that provider config successfully.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
