### PR TITLE
feat(glue): followup cleanup cr.name to external.name

### DIFF
--- a/pkg/controller/glue/classifier/setup.go
+++ b/pkg/controller/glue/classifier/setup.go
@@ -54,7 +54,6 @@ func SetupClassifier(mgr ctrl.Manager, l logging.Logger, limiter workqueue.RateL
 		For(&svcapitypes.Classifier{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(svcapitypes.ClassifierGroupVersionKind),
-			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
@@ -91,7 +90,7 @@ func preCreate(_ context.Context, cr *svcapitypes.Classifier, obj *svcsdk.Create
 
 	if cr.Spec.ForProvider.CustomCsvClassifier != nil {
 		obj.CsvClassifier = &svcsdk.CreateCsvClassifierRequest{
-			Name:                 &cr.Name,
+			Name:                 awsclients.String(meta.GetExternalName(cr)),
 			AllowSingleColumn:    cr.Spec.ForProvider.CustomCsvClassifier.AllowSingleColumn,
 			ContainsHeader:       cr.Spec.ForProvider.CustomCsvClassifier.ContainsHeader,
 			Delimiter:            cr.Spec.ForProvider.CustomCsvClassifier.Delimiter,
@@ -103,7 +102,7 @@ func preCreate(_ context.Context, cr *svcapitypes.Classifier, obj *svcsdk.Create
 
 	if cr.Spec.ForProvider.CustomXMLClassifier != nil {
 		obj.XMLClassifier = &svcsdk.CreateXMLClassifierRequest{
-			Name:           &cr.Name,
+			Name:           awsclients.String(meta.GetExternalName(cr)),
 			Classification: cr.Spec.ForProvider.CustomXMLClassifier.Classification,
 			RowTag:         cr.Spec.ForProvider.CustomXMLClassifier.RowTag,
 		}
@@ -111,7 +110,7 @@ func preCreate(_ context.Context, cr *svcapitypes.Classifier, obj *svcsdk.Create
 
 	if cr.Spec.ForProvider.CustomGrokClassifier != nil {
 		obj.GrokClassifier = &svcsdk.CreateGrokClassifierRequest{
-			Name:           &cr.Name,
+			Name:           awsclients.String(meta.GetExternalName(cr)),
 			Classification: cr.Spec.ForProvider.CustomGrokClassifier.Classification,
 			CustomPatterns: cr.Spec.ForProvider.CustomGrokClassifier.CustomPatterns,
 			GrokPattern:    cr.Spec.ForProvider.CustomGrokClassifier.GrokPattern,
@@ -120,7 +119,7 @@ func preCreate(_ context.Context, cr *svcapitypes.Classifier, obj *svcsdk.Create
 
 	if cr.Spec.ForProvider.CustomJSONClassifier != nil {
 		obj.JsonClassifier = &svcsdk.CreateJsonClassifierRequest{
-			Name:     &cr.Name,
+			Name:     awsclients.String(meta.GetExternalName(cr)),
 			JsonPath: cr.Spec.ForProvider.CustomJSONClassifier.JSONPath,
 		}
 	}

--- a/pkg/controller/glue/connection/setup.go
+++ b/pkg/controller/glue/connection/setup.go
@@ -54,7 +54,6 @@ func SetupConnection(mgr ctrl.Manager, l logging.Logger, limiter workqueue.RateL
 		For(&svcapitypes.Connection{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(svcapitypes.ConnectionGroupVersionKind),
-			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
@@ -91,7 +90,7 @@ func preCreate(_ context.Context, cr *svcapitypes.Connection, obj *svcsdk.Create
 
 	if cr.Spec.ForProvider.CustomConnectionInput != nil && cr.Spec.ForProvider.CustomConnectionInput.CustomPhysicalConnectionRequirements != nil {
 		obj.ConnectionInput = &svcsdk.ConnectionInput{
-			Name:                 &cr.Name,
+			Name:                 awsclients.String(meta.GetExternalName(cr)),
 			ConnectionProperties: cr.Spec.ForProvider.CustomConnectionInput.ConnectionProperties,
 			ConnectionType:       cr.Spec.ForProvider.CustomConnectionInput.ConnectionType,
 			Description:          cr.Spec.ForProvider.CustomConnectionInput.Description,

--- a/pkg/controller/glue/crawler/setup.go
+++ b/pkg/controller/glue/crawler/setup.go
@@ -53,7 +53,6 @@ func SetupCrawler(mgr ctrl.Manager, l logging.Logger, limiter workqueue.RateLimi
 		For(&svcapitypes.Crawler{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(svcapitypes.CrawlerGroupVersionKind),
-			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
@@ -80,7 +79,7 @@ func postObserve(_ context.Context, cr *svcapitypes.Crawler, _ *svcsdk.GetCrawle
 
 func preCreate(_ context.Context, cr *svcapitypes.Crawler, obj *svcsdk.CreateCrawlerInput) error {
 	obj.Name = awsclients.String(meta.GetExternalName(cr))
-	obj.Role = &cr.Spec.ForProvider.RoleArn
+	obj.Role = awsclients.String(cr.Spec.ForProvider.RoleArn)
 	obj.Schedule = cr.Spec.ForProvider.Schedule
 	return nil
 }

--- a/pkg/controller/glue/database/setup.go
+++ b/pkg/controller/glue/database/setup.go
@@ -54,7 +54,6 @@ func SetupDatabase(mgr ctrl.Manager, l logging.Logger, limiter workqueue.RateLim
 		For(&svcapitypes.Database{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(svcapitypes.DatabaseGroupVersionKind),
-			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
@@ -91,11 +90,11 @@ func preCreate(_ context.Context, cr *svcapitypes.Database, obj *svcsdk.CreateDa
 
 	if cr.Spec.ForProvider.CustomDatabaseInput == nil {
 		obj.DatabaseInput = &svcsdk.DatabaseInput{
-			Name: &cr.Name,
+			Name: awsclients.String(meta.GetExternalName(cr)),
 		}
 	} else {
 		obj.DatabaseInput = &svcsdk.DatabaseInput{
-			Name:        &cr.Name,
+			Name:        awsclients.String(meta.GetExternalName(cr)),
 			Description: cr.Spec.ForProvider.CustomDatabaseInput.Description,
 			LocationUri: cr.Spec.ForProvider.CustomDatabaseInput.LocationURI,
 			Parameters:  cr.Spec.ForProvider.CustomDatabaseInput.Parameters,

--- a/pkg/controller/glue/job/setup.go
+++ b/pkg/controller/glue/job/setup.go
@@ -55,7 +55,6 @@ func SetupJob(mgr ctrl.Manager, l logging.Logger, limiter workqueue.RateLimiter,
 		For(&svcapitypes.Job{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(svcapitypes.JobGroupVersionKind),
-			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient())),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithPollInterval(poll),
 			managed.WithLogger(l.WithValues("controller", name)),
@@ -89,7 +88,7 @@ func postCreate(_ context.Context, cr *svcapitypes.Job, obj *svcsdk.CreateJobOut
 }
 
 func preCreate(_ context.Context, cr *svcapitypes.Job, obj *svcsdk.CreateJobInput) error {
-	obj.Name = &cr.Name
-	obj.Role = &cr.Spec.ForProvider.RoleArn
+	obj.Name = awsclients.String(meta.GetExternalName(cr))
+	obj.Role = awsclients.String(cr.Spec.ForProvider.RoleArn)
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
as followup for https://github.com/crossplane/provider-aws/pull/992 
cleanup cr.Name to external.name 
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1018

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested


setup complete all needed resources:

```
NAME                                          READY   SYNCED   ID                         VPC                     CIDR          AGE
NAME                                                     READY   SYNCED   EXTERNAL-NAME
classifier.glue.aws.crossplane.io/glue-classifier-csv    True    True     glue-classifier-csv
classifier.glue.aws.crossplane.io/glue-classifier-grok   True    True     glue-classifier-grok
classifier.glue.aws.crossplane.io/glue-classifier-json   True    True     glue-classifier-json
classifier.glue.aws.crossplane.io/glue-classifier-xml    True    True     glue-classifier-xml

NAME                                  READY   SYNCED   EXTERNAL-NAME
job.glue.aws.crossplane.io/glue-job   True    True     glue-job

NAME                                            READY   SYNCED   EXTERNAL-NAME
database.glue.aws.crossplane.io/glue-database   True    True     glue-database

NAME                                                                      READY   SYNCED   EXTERNAL-NAME
securityconfiguration.glue.aws.crossplane.io/glue-securityconfiguration   True    True     glue-securityconfiguration

NAME                                          READY   SYNCED   EXTERNAL-NAME
crawler.glue.aws.crossplane.io/glue-crawler   True   True    glue-crawler

NAME                                                READY   SYNCED   EXTERNAL-NAME
connection.glue.aws.crossplane.io/glue-connection   True    True     glue-connection

NAME                                      READY   SYNCED   AGE
role.iam.aws.crossplane.io/glue-role      True    True     4m53s
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
