### PR TITLE
Role - add iamrole shortname

### DIFF
--- a/apis/iam/v1beta1/role_types.go
+++ b/apis/iam/v1beta1/role_types.go
@@ -114,7 +114,7 @@ type RoleStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws},shortName=iamrole
 type Role struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/package/crds/iam.aws.crossplane.io_roles.yaml
+++ b/package/crds/iam.aws.crossplane.io_roles.yaml
@@ -15,6 +15,8 @@ spec:
     kind: Role
     listKind: RoleList
     plural: roles
+    shortNames:
+    - iamrole
     singular: role
   scope: Cluster
   versions:


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes


`IAMRole` was renamed to `Role` as part of https://github.com/crossplane/provider-aws/pull/996
When you `kubectl get Role` it will default to native kubernetes Role since Role kind exists in multiple apis -
```
kubectl get Role
NAME               CREATED AT
crossplane-admin   2021-03-03T21:51:54Z
crossplane-edit    2021-03-03T21:51:54Z
crossplane-view    2021-03-03T21:51:54Z
```
_Hey but I wanted IAM Roles!!!!!_
```
kubectl api-resources | grep -e " Role$"
roles                              iamrole            iam.aws.crossplane.io/v1beta1                                            false        Role
roles                                                 rbac.authorization.k8s.io/v1                                             true         Role
```

One current workaround is `kubectl get roles.iam.aws.crossplane.io` but this is verbose.

As a convenience this PR implements short names to allow `kubectl get iamrole`
This makes it much easier for end users to get iam roles without having to worry about the api.
Plus `iamrole` is much more distinct than `role`

Users with the older crds/apis can still `kubectl get IAMRole` or `kubectl get roles.identity.aws.crossplane.io`
In fact I don't believe the `iamrole` shortname will work until the older crds have been deleted so this should not break any existing functionality, only convenience for users who have upgraded.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [X ] Read and followed Crossplane's [contribution process].
- [X ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
* locally with kubectl commands

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
