### PR TITLE
Remove inaccurate deprecation warning from v1beta1 type

### DIFF
--- a/apis/acmpca/v1beta1/certificateauthoritypermission_types.go
+++ b/apis/acmpca/v1beta1/certificateauthoritypermission_types.go
@@ -79,8 +79,6 @@ type CertificateAuthorityPermissionParameters struct {
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
-// +kubebuilder:deprecatedversion:warning="Please use v1beta1 version of this resource that has identical schema."
-// Deprecated: Please use v1beta1 version of this resource.
 type CertificateAuthorityPermission struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -92,8 +90,6 @@ type CertificateAuthorityPermission struct {
 // +kubebuilder:object:root=true
 
 // CertificateAuthorityPermissionList contains a list of CertificateAuthorityPermission
-// +kubebuilder:deprecatedversion:warning="Please use v1beta1 version of this resource that has identical schema."
-// Deprecated: Please use v1beta1 version of this resource.
 type CertificateAuthorityPermissionList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/package/crds/acmpca.aws.crossplane.io_certificateauthoritypermissions.yaml
+++ b/package/crds/acmpca.aws.crossplane.io_certificateauthoritypermissions.yaml
@@ -212,15 +212,11 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
-    deprecated: true
-    deprecationWarning: Please use v1beta1 version of this resource that has identical
-      schema.
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: 'CertificateAuthorityPermission is a managed resource that represents
-          an AWS CertificateAuthorityPermission Manager. Deprecated: Please use v1beta1
-          version of this resource.'
+        description: CertificateAuthorityPermission is a managed resource that represents
+          an AWS CertificateAuthorityPermission Manager.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Removes the deprecation warning from certificate authority permission
v1beta1 as it should only exist on v1alpha1.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes https://github.com/crossplane/provider-aws/issues/1030

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Install `provider-aws` and make sure deprecation warning is not surfaced for this resource.

[contribution process]: https://git.io/fj2m9
