### PR TITLE
fix(init): #1049 fix problem that kms-key ref picks wrong metadata.name

### DIFF
--- a/pkg/controller/kms/key/setup.go
+++ b/pkg/controller/kms/key/setup.go
@@ -50,6 +50,7 @@ func SetupKey(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll
 			resource.ManagedKind(svcapitypes.KeyGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithPollInterval(poll),
+			managed.WithInitializers(),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
- fixed following problem:

in kms alias:`cannot create Alias in AWS: NotFoundException: Invalid keyId my-key`
in rds dbcluster: ` KMSKeyNotAccessibleFault: The specified KMS key [rg-test-cluster-5bp8r-zzp65] does not exist, is not enabled or you do not have permissions to access it.`

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #902 #1049

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

created in one shot:
```
 apiVersion: kms.aws.crossplane.io/v1alpha1
 kind: Key
 metadata:
     name: my-key
 spec:
     deletionPolicy: Delete
     forProvider:
         region: us-west-2
         pendingWindowInDays: 21 
         tags:
         - tagKey: app
           tagValue: test
     providerConfigRef:
         name: example
---
apiVersion: kms.aws.crossplane.io/v1alpha1
kind: Alias
metadata:
    name: my-test
spec:
    deletionPolicy: Delete
    forProvider:
        region: us-west-2
        targetKeyIdRef:
            name: my-key
    providerConfigRef:
        name: example

```

```
NAME                                  READY   SYNCED   EXTERNAL-NAME
alias.kms.aws.crossplane.io/my-test   True    True     my-test

NAME                                READY   SYNCED   EXTERNAL-NAME
key.kms.aws.crossplane.io/my-key    True    True     34bf6b70-acc2-4bd0-80a0-184dbdf971d8
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
