### PR TITLE
fix(ec2-instance): make some blockDevicMapping fields in CRD optional

### DIFF
--- a/apis/ec2/manualv1alpha1/common.go
+++ b/apis/ec2/manualv1alpha1/common.go
@@ -37,7 +37,7 @@ type BlockDeviceMapping struct {
 
 	// Suppresses the specified device included in the block device mapping of the
 	// AMI.
-	NoDevice *string `json:"noDevice"`
+	NoDevice *string `json:"noDevice,omitempty"`
 
 	// The virtual device name (ephemeralN). Instance store volumes are numbered
 	// starting from 0. An instance type with 2 available instance store volumes
@@ -52,7 +52,7 @@ type BlockDeviceMapping struct {
 	// the block device mapping for the instance. When you launch an M3 instance,
 	// we ignore any instance store volumes specified in the block device mapping
 	// for the AMI.
-	VirtualName *string `json:"virtualName"`
+	VirtualName *string `json:"virtualName,omitempty"`
 }
 
 // CapacityReservationSpecification describes an instance's Capacity Reservation targeting option. You can specify
@@ -136,7 +136,7 @@ type EBSBlockDevice struct {
 	// more information, see Preserving Amazon EBS Volumes on Instance Termination
 	// (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#preserving-volumes-on-termination)
 	// in the Amazon Elastic Compute Cloud User Guide.
-	DeleteOnTermination *bool `json:"deleteOnTermination"`
+	DeleteOnTermination *bool `json:"deleteOnTermination,omitempty"`
 
 	// Indicates whether the encryption state of an EBS volume is changed while
 	// being restored from a backing snapshot. The effect of setting the encryption
@@ -151,7 +151,7 @@ type EBSBlockDevice struct {
 	// encryption. For more information, see Supported Instance Types (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#EBSEncryption_supported_instances).
 	//
 	// This parameter is not returned by .
-	Encrypted *bool `json:"encrypted"`
+	Encrypted *bool `json:"encrypted,omitempty"`
 
 	// The number of I/O operations per second (IOPS) that the volume supports.
 	// For io1 volumes, this represents the number of IOPS that are provisioned
@@ -169,7 +169,7 @@ type EBSBlockDevice struct {
 	//
 	// Condition: This parameter is required for requests to create io1 volumes;
 	// it is not used in requests to create gp2, st1, sc1, or standard volumes.
-	IOps *int32 `json:"iops"`
+	IOps *int32 `json:"iops,omitempty"`
 
 	// Identifier (key ID, key alias, ID ARN, or alias ARN) for a customer managed
 	// CMK under which the EBS volume is encrypted.
@@ -178,10 +178,10 @@ type EBSBlockDevice struct {
 	// RunInstances (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html),
 	// RequestSpotFleet (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotFleet.html),
 	// and RequestSpotInstances (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotInstances.html).
-	KmsKeyID *string `json:"kmsKeyId"`
+	KmsKeyID *string `json:"kmsKeyId,omitempty"`
 
 	// The ID of the snapshot.
-	SnapshotID *string `json:"snapshotId"`
+	SnapshotID *string `json:"snapshotId,omitempty"`
 
 	// The size of the volume, in GiB.
 	//
@@ -200,7 +200,7 @@ type EBSBlockDevice struct {
 	// the Iops parameter.
 	//
 	// Default: gp2
-	VolumeType string `json:"volumeType"`
+	VolumeType string `json:"volumeType,omitempty"`
 }
 
 // EBSInstanceBlockDevice describes a parameter used to set up an EBS volume in a block device mapping.

--- a/examples/ec2/instance.yaml
+++ b/examples/ec2/instance.yaml
@@ -6,6 +6,10 @@ spec:
   forProvider:
     region: us-east-1
     imageId: ami-0dc2d3e4c0f9ebd18
+    blockDeviceMappings:
+     - deviceName: /dev/sdx
+       ebs:
+         volumeSize: 100
     securityGroupRefs:
       - name: sample-cluster-sg
     subnetIdRef:

--- a/package/crds/ec2.aws.crossplane.io_instances.yaml
+++ b/package/crds/ec2.aws.crossplane.io_instances.yaml
@@ -177,13 +177,7 @@ spec:
                                 must omit the Iops parameter. \n Default: gp2"
                               type: string
                           required:
-                          - deleteOnTermination
-                          - encrypted
-                          - iops
-                          - kmsKeyId
-                          - snapshotId
                           - volumeSize
-                          - volumeType
                           type: object
                         noDevice:
                           description: Suppresses the specified device included in
@@ -207,8 +201,6 @@ spec:
                       required:
                       - deviceName
                       - ebs
-                      - noDevice
-                      - virtualName
                       type: object
                     type: array
                   capacityReservationSpecification:


### PR DESCRIPTION
Signed-off-by: Mario Bris <bris.mario@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
I've changed some of EC2 CRD fields from mandatory to optional. 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1088

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
I've tested with new instance which extends [examples/ec2/instance.yaml](https://github.com/crossplane/provider-aws/blob/master/examples/ec2/instance.yaml)  manifest with EBS section
```
spec:
  forProvider:
    ...
    blockDeviceMappings:
    - deviceName: /dev/sdx
      ebs:
        volumeSize: 100
    ...
```
delete the instnace also delete the volume.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
