### PR TITLE
read endpoint info from dbinstance status rather than aws out values

### DIFF
--- a/pkg/controller/rds/dbinstance/setup.go
+++ b/pkg/controller/rds/dbinstance/setup.go
@@ -131,12 +131,12 @@ func (e *custom) postCreate(ctx context.Context, cr *svcapitypes.DBInstance, out
 	if pw != "" {
 		conn[xpv1.ResourceCredentialsSecretPasswordKey] = []byte(pw)
 	}
-	if out.DBInstance.Endpoint != nil {
-		if aws.StringValue(out.DBInstance.Endpoint.Address) != "" {
-			conn[xpv1.ResourceCredentialsSecretEndpointKey] = []byte(*out.DBInstance.Endpoint.Address)
+	if cr.Status.AtProvider.Endpoint != nil {
+		if aws.StringValue(cr.Status.AtProvider.Endpoint.Address) != "" {
+			conn[xpv1.ResourceCredentialsSecretEndpointKey] = []byte(aws.StringValue(cr.Status.AtProvider.Endpoint.Address))
 		}
-		if aws.Int64Value(out.DBInstance.Endpoint.Port) > 0 {
-			conn[xpv1.ResourceCredentialsSecretPortKey] = []byte(strconv.FormatInt(*out.DBInstance.Endpoint.Port, 10))
+		if aws.Int64Value(cr.Status.AtProvider.Endpoint.Port) > 0 {
+			conn[xpv1.ResourceCredentialsSecretPortKey] = []byte(strconv.FormatInt(*cr.Status.AtProvider.Endpoint.Port, 10))
 		}
 	}
 	return managed.ExternalCreation{


### PR DESCRIPTION
copied the strategy used in dbcloud of reading the endpoint info
from the dbinstance status rather than the aws api out result
in order to get the endpoint info. A manual test confirms that
this results in the secret containing the host

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1090 

I have:

- [x ] Read and followed Crossplane's [contribution process].
- [ x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Manually  ran the controller locally and created a new db instance and the endpoint host was then contained in the output secret which it previously wasn't.

[contribution process]: https://git.io/fj2m9
