### PR TITLE
fix(secretsmanager): Ignore isUpToDate if resource was deleted

### DIFF
--- a/pkg/controller/secretsmanager/secret/setup.go
+++ b/pkg/controller/secretsmanager/secret/setup.go
@@ -114,6 +114,10 @@ type hooks struct {
 }
 
 func (e *hooks) isUpToDate(cr *svcapitypes.Secret, resp *svcsdk.DescribeSecretOutput) (bool, error) { // nolint:gocyclo
+	if meta.WasDeleted(cr) {
+		return false, nil
+	}
+
 	// NOTE(muvaf): No operation can be done on secrets that are marked for deletion.
 	if resp.DeletedDate != nil {
 		return true, nil


### PR DESCRIPTION
### Description of your changes

Always return `false, nil` in `isUpToDate` if resource is marked as deleted.

Fixes #1094 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually

[contribution process]: https://git.io/fj2m9
