### PR TITLE
Add support for keeping previous generated versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PROJECT_REPO := github.com/crossplane/$(PROJECT_NAME)
 
 PLATFORMS ?= linux_amd64 linux_arm64
 
-CODE_GENERATOR_COMMIT ?= 3f6e80a8af7a4335d6ae8b2d9d98b776e9298f97
+CODE_GENERATOR_COMMIT ?= c7d9f6bbcaf8f628910202fa126e03faa970502b
 GENERATED_SERVICES="apigatewayv2,athena,cloudfront,cloudwatchlogs,dynamodb,elbv2,ec2,efs,glue,iot,kafka,kinesis,kms,lambda,mq,rds,secretsmanager,servicediscovery,sfn,transfer,ram"
 
 # kind-related versions

--- a/apis/apigatewayv2/v1alpha1/zz_api.go
+++ b/apis/apigatewayv2/v1alpha1/zz_api.go
@@ -94,6 +94,7 @@ type APIStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type API struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/apigatewayv2/v1alpha1/zz_api_mapping.go
+++ b/apis/apigatewayv2/v1alpha1/zz_api_mapping.go
@@ -62,6 +62,7 @@ type APIMappingStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type APIMapping struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/apigatewayv2/v1alpha1/zz_authorizer.go
+++ b/apis/apigatewayv2/v1alpha1/zz_authorizer.go
@@ -79,6 +79,7 @@ type AuthorizerStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Authorizer struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/apigatewayv2/v1alpha1/zz_deployment.go
+++ b/apis/apigatewayv2/v1alpha1/zz_deployment.go
@@ -68,6 +68,7 @@ type DeploymentStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Deployment struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/apigatewayv2/v1alpha1/zz_domain_name.go
+++ b/apis/apigatewayv2/v1alpha1/zz_domain_name.go
@@ -64,6 +64,7 @@ type DomainNameStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type DomainName struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/apigatewayv2/v1alpha1/zz_integration.go
+++ b/apis/apigatewayv2/v1alpha1/zz_integration.go
@@ -93,6 +93,7 @@ type IntegrationStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Integration struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/apigatewayv2/v1alpha1/zz_integration_response.go
+++ b/apis/apigatewayv2/v1alpha1/zz_integration_response.go
@@ -67,6 +67,7 @@ type IntegrationResponseStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type IntegrationResponse struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/apigatewayv2/v1alpha1/zz_model.go
+++ b/apis/apigatewayv2/v1alpha1/zz_model.go
@@ -66,6 +66,7 @@ type ModelStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Model struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/apigatewayv2/v1alpha1/zz_route.go
+++ b/apis/apigatewayv2/v1alpha1/zz_route.go
@@ -81,6 +81,7 @@ type RouteStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Route struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/apigatewayv2/v1alpha1/zz_route_response.go
+++ b/apis/apigatewayv2/v1alpha1/zz_route_response.go
@@ -65,6 +65,7 @@ type RouteResponseStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type RouteResponse struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/apigatewayv2/v1alpha1/zz_stage.go
+++ b/apis/apigatewayv2/v1alpha1/zz_stage.go
@@ -82,6 +82,7 @@ type StageStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Stage struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/apigatewayv2/v1alpha1/zz_vpc_link.go
+++ b/apis/apigatewayv2/v1alpha1/zz_vpc_link.go
@@ -73,6 +73,7 @@ type VPCLinkStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type VPCLink struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/athena/v1alpha1/zz_work_group.go
+++ b/apis/athena/v1alpha1/zz_work_group.go
@@ -67,6 +67,7 @@ type WorkGroupStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type WorkGroup struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/cloudfront/v1alpha1/zz_cache_policy.go
+++ b/apis/cloudfront/v1alpha1/zz_cache_policy.go
@@ -64,6 +64,7 @@ type CachePolicyStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type CachePolicy struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/cloudfront/v1alpha1/zz_cloud_front_origin_access_identity.go
+++ b/apis/cloudfront/v1alpha1/zz_cloud_front_origin_access_identity.go
@@ -64,6 +64,7 @@ type CloudFrontOriginAccessIdentityStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type CloudFrontOriginAccessIdentity struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/cloudfront/v1alpha1/zz_distribution.go
+++ b/apis/cloudfront/v1alpha1/zz_distribution.go
@@ -64,6 +64,7 @@ type DistributionStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Distribution struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/cloudwatchlogs/v1alpha1/zz_log_group.go
+++ b/apis/cloudwatchlogs/v1alpha1/zz_log_group.go
@@ -60,6 +60,7 @@ type LogGroupStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type LogGroup struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/dynamodb/v1alpha1/zz_backup.go
+++ b/apis/dynamodb/v1alpha1/zz_backup.go
@@ -80,6 +80,7 @@ type BackupStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Backup struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/dynamodb/v1alpha1/zz_global_table.go
+++ b/apis/dynamodb/v1alpha1/zz_global_table.go
@@ -74,6 +74,7 @@ type GlobalTableStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type GlobalTable struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/dynamodb/v1alpha1/zz_table.go
+++ b/apis/dynamodb/v1alpha1/zz_table.go
@@ -246,6 +246,7 @@ type TableStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Table struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/ec2/v1alpha1/zz_launch_template.go
+++ b/apis/ec2/v1alpha1/zz_launch_template.go
@@ -71,6 +71,7 @@ type LaunchTemplateStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type LaunchTemplate struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/ec2/v1alpha1/zz_launch_template_version.go
+++ b/apis/ec2/v1alpha1/zz_launch_template_version.go
@@ -72,6 +72,7 @@ type LaunchTemplateVersionStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type LaunchTemplateVersion struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/ec2/v1alpha1/zz_route.go
+++ b/apis/ec2/v1alpha1/zz_route.go
@@ -80,6 +80,7 @@ type RouteStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Route struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/ec2/v1alpha1/zz_transit_gateway.go
+++ b/apis/ec2/v1alpha1/zz_transit_gateway.go
@@ -73,6 +73,7 @@ type TransitGatewayStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type TransitGateway struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/ec2/v1alpha1/zz_transit_gateway_route.go
+++ b/apis/ec2/v1alpha1/zz_transit_gateway_route.go
@@ -69,6 +69,7 @@ type TransitGatewayRouteStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type TransitGatewayRoute struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/ec2/v1alpha1/zz_transit_gateway_route_table.go
+++ b/apis/ec2/v1alpha1/zz_transit_gateway_route_table.go
@@ -73,6 +73,7 @@ type TransitGatewayRouteTableStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type TransitGatewayRouteTable struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/ec2/v1alpha1/zz_transit_gateway_vpc_attachment.go
+++ b/apis/ec2/v1alpha1/zz_transit_gateway_vpc_attachment.go
@@ -76,6 +76,7 @@ type TransitGatewayVPCAttachmentStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type TransitGatewayVPCAttachment struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/ec2/v1alpha1/zz_volume.go
+++ b/apis/ec2/v1alpha1/zz_volume.go
@@ -156,6 +156,7 @@ type VolumeStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Volume struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/ec2/v1alpha1/zz_vpc_endpoint.go
+++ b/apis/ec2/v1alpha1/zz_vpc_endpoint.go
@@ -91,6 +91,7 @@ type VPCEndpointStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type VPCEndpoint struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/ec2/v1alpha1/zz_vpc_endpoint_service_configuration.go
+++ b/apis/ec2/v1alpha1/zz_vpc_endpoint_service_configuration.go
@@ -68,6 +68,7 @@ type VPCEndpointServiceConfigurationStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type VPCEndpointServiceConfiguration struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/ec2/v1alpha1/zz_vpc_peering_connection.go
+++ b/apis/ec2/v1alpha1/zz_vpc_peering_connection.go
@@ -85,6 +85,7 @@ type VPCPeeringConnectionStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type VPCPeeringConnection struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/efs/v1alpha1/zz_file_system.go
+++ b/apis/efs/v1alpha1/zz_file_system.go
@@ -131,6 +131,7 @@ type FileSystemStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type FileSystem struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/efs/v1alpha1/zz_mount_target.go
+++ b/apis/efs/v1alpha1/zz_mount_target.go
@@ -81,6 +81,7 @@ type MountTargetStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type MountTarget struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/elbv2/v1alpha1/zz_listener.go
+++ b/apis/elbv2/v1alpha1/zz_listener.go
@@ -95,6 +95,7 @@ type ListenerStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Listener struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/elbv2/v1alpha1/zz_load_balancer.go
+++ b/apis/elbv2/v1alpha1/zz_load_balancer.go
@@ -128,6 +128,7 @@ type LoadBalancerStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type LoadBalancer struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/elbv2/v1alpha1/zz_target_group.go
+++ b/apis/elbv2/v1alpha1/zz_target_group.go
@@ -148,6 +148,7 @@ type TargetGroupStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type TargetGroup struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/glue/v1alpha1/zz_classifier.go
+++ b/apis/glue/v1alpha1/zz_classifier.go
@@ -55,6 +55,7 @@ type ClassifierStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Classifier struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/glue/v1alpha1/zz_connection.go
+++ b/apis/glue/v1alpha1/zz_connection.go
@@ -58,6 +58,7 @@ type ConnectionStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Connection struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/glue/v1alpha1/zz_crawler.go
+++ b/apis/glue/v1alpha1/zz_crawler.go
@@ -91,6 +91,7 @@ type CrawlerStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Crawler struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/glue/v1alpha1/zz_database.go
+++ b/apis/glue/v1alpha1/zz_database.go
@@ -58,6 +58,7 @@ type DatabaseStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Database struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/glue/v1alpha1/zz_job.go
+++ b/apis/glue/v1alpha1/zz_job.go
@@ -154,6 +154,7 @@ type JobStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Job struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/glue/v1alpha1/zz_security_configuration.go
+++ b/apis/glue/v1alpha1/zz_security_configuration.go
@@ -59,6 +59,7 @@ type SecurityConfigurationStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type SecurityConfiguration struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/iot/v1alpha1/zz_policy.go
+++ b/apis/iot/v1alpha1/zz_policy.go
@@ -71,6 +71,7 @@ type PolicyStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Policy struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/iot/v1alpha1/zz_thing.go
+++ b/apis/iot/v1alpha1/zz_thing.go
@@ -68,6 +68,7 @@ type ThingStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Thing struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/kafka/v1alpha1/zz_cluster.go
+++ b/apis/kafka/v1alpha1/zz_cluster.go
@@ -81,6 +81,7 @@ type ClusterStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/kafka/v1alpha1/zz_configuration.go
+++ b/apis/kafka/v1alpha1/zz_configuration.go
@@ -71,6 +71,7 @@ type ConfigurationStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Configuration struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/kinesis/v1alpha1/zz_stream.go
+++ b/apis/kinesis/v1alpha1/zz_stream.go
@@ -111,6 +111,7 @@ type StreamStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Stream struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/kms/v1alpha1/zz_key.go
+++ b/apis/kms/v1alpha1/zz_key.go
@@ -252,6 +252,7 @@ type KeyStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Key struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/lambda/v1alpha1/zz_function.go
+++ b/apis/lambda/v1alpha1/zz_function.go
@@ -147,6 +147,7 @@ type FunctionStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Function struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/mq/v1alpha1/zz_broker.go
+++ b/apis/mq/v1alpha1/zz_broker.go
@@ -92,6 +92,7 @@ type BrokerStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Broker struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/mq/v1alpha1/zz_user.go
+++ b/apis/mq/v1alpha1/zz_user.go
@@ -59,6 +59,7 @@ type UserStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type User struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/ram/v1alpha1/zz_resource_share.go
+++ b/apis/ram/v1alpha1/zz_resource_share.go
@@ -78,6 +78,7 @@ type ResourceShareStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type ResourceShare struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/rds/v1alpha1/zz_db_cluster.go
+++ b/apis/rds/v1alpha1/zz_db_cluster.go
@@ -479,6 +479,7 @@ type DBClusterStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type DBCluster struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/rds/v1alpha1/zz_db_cluster_parameter_group.go
+++ b/apis/rds/v1alpha1/zz_db_cluster_parameter_group.go
@@ -78,6 +78,7 @@ type DBClusterParameterGroupStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type DBClusterParameterGroup struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/rds/v1alpha1/zz_db_instance.go
+++ b/apis/rds/v1alpha1/zz_db_instance.go
@@ -868,6 +868,7 @@ type DBInstanceStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type DBInstance struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/rds/v1alpha1/zz_db_parameter_group.go
+++ b/apis/rds/v1alpha1/zz_db_parameter_group.go
@@ -77,6 +77,7 @@ type DBParameterGroupStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type DBParameterGroup struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/rds/v1alpha1/zz_global_cluster.go
+++ b/apis/rds/v1alpha1/zz_global_cluster.go
@@ -90,6 +90,7 @@ type GlobalClusterStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type GlobalCluster struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/secretsmanager/v1alpha1/zz_secret.go
+++ b/apis/secretsmanager/v1alpha1/zz_secret.go
@@ -129,6 +129,7 @@ type SecretStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Secret struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/servicediscovery/v1alpha1/zz_http_namespace.go
+++ b/apis/servicediscovery/v1alpha1/zz_http_namespace.go
@@ -67,6 +67,7 @@ type HTTPNamespaceStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type HTTPNamespace struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/servicediscovery/v1alpha1/zz_private_dns_namespace.go
+++ b/apis/servicediscovery/v1alpha1/zz_private_dns_namespace.go
@@ -69,6 +69,7 @@ type PrivateDNSNamespaceStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type PrivateDNSNamespace struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/servicediscovery/v1alpha1/zz_public_dns_namespace.go
+++ b/apis/servicediscovery/v1alpha1/zz_public_dns_namespace.go
@@ -67,6 +67,7 @@ type PublicDNSNamespaceStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type PublicDNSNamespace struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/sfn/v1alpha1/zz_activity.go
+++ b/apis/sfn/v1alpha1/zz_activity.go
@@ -90,6 +90,7 @@ type ActivityStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Activity struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/sfn/v1alpha1/zz_state_machine.go
+++ b/apis/sfn/v1alpha1/zz_state_machine.go
@@ -99,6 +99,7 @@ type StateMachineStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type StateMachine struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/transfer/v1alpha1/zz_server.go
+++ b/apis/transfer/v1alpha1/zz_server.go
@@ -152,6 +152,7 @@ type ServerStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type Server struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/apis/transfer/v1alpha1/zz_user.go
+++ b/apis/transfer/v1alpha1/zz_user.go
@@ -115,6 +115,7 @@ type UserStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type User struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
In order to be able to keep the previous versions of a CRD when a new version is added, we are now marking the version being actively generated as the storage version with ACK code-generator. 
Older versions are to be maintained manually:
- They need to be deprecated
- Their storageversion markers need to be removed.
- Custom types need to be copied/adjusted if needed
- In the controller's setup (as an example in `pkg/controller/apigatewayv2/vpclink/setup.go`), the newly generated version need to be consumed (import statement updated)


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested with `make reviewable` by bumping `VpcLink` to `v1beta1` and keeping the `v1alpha1` version with the changes discussed above:
```yaml
resources:
  "VpcLink":
    api_versions:
    - name: v1beta1
      storage: true
```

[contribution process]: https://git.io/fj2m9
