### PR TITLE
Added default tags to CertificateAuthority

### DIFF
--- a/pkg/controller/acmpca/certificateauthority/controller.go
+++ b/pkg/controller/acmpca/certificateauthority/controller.go
@@ -73,10 +73,7 @@ func SetupCertificateAuthority(mgr ctrl.Manager, l logging.Logger, rl workqueue.
 			managed.WithExternalConnecter(&connector{client: mgr.GetClient(), newClientFn: acmpca.NewClient}),
 			managed.WithConnectionPublishers(),
 			managed.WithPollInterval(poll),
-
-			// TODO: implement tag initializer
-
-			managed.WithInitializers(),
+			managed.WithInitializers(&tagger{kube: mgr.GetClient()}),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }
@@ -255,4 +252,34 @@ func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
 	})
 
 	return awsclient.Wrap(resource.Ignore(acmpca.IsErrorNotFound, err), errDelete)
+}
+
+type tagger struct {
+	kube client.Client
+}
+
+func (t *tagger) Initialize(ctx context.Context, mgd resource.Managed) error {
+	cr, ok := mgd.(*v1beta1.CertificateAuthority)
+	if !ok {
+		return errors.New(errUnexpectedObject)
+	}
+	added := false
+	tagMap := map[string]string{}
+	for _, t := range cr.Spec.ForProvider.Tags {
+		tagMap[t.Key] = t.Value
+	}
+	for k, v := range resource.GetExternalTags(mgd) {
+		if p, ok := tagMap[k]; !ok || v != p {
+			cr.Spec.ForProvider.Tags = append(cr.Spec.ForProvider.Tags, v1beta1.Tag{Key: k, Value: v})
+			added = true
+		}
+	}
+	if !added {
+		return nil
+	}
+	err := t.kube.Update(ctx, cr)
+	if err != nil {
+		return errors.Wrap(err, errKubeUpdateFailed)
+	}
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: Cecilia Bernardi <cbernardi@expediagroup.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This PR adds the default tags to `acmpca.CertificateAuthority` resource ("crossplane-kind", "crossplane-name", "crossplane-providerconfig") 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1143

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
- Unit Tests
- Manual Test on a kind cluster:
    - spin up a new kind cluster (kind create cluster --name crossplane-aws)
    - install CRDs (kubectl apply -f package/crds)
    - create resource scenario:
        - create an acmpca.CertificateAuthority in the cluster (kubectl apply -f examples/acmpca/certificateauthority.yaml)
       - start crossplane-aws controller
       - verify that the tags "crossplane-kind", "crossplane-name", "crossplane-providerconfig" are added as expected
    - modify resource scenario:
       - delete tags from the resource: kubectl patch certificateauthorities.acmpca.aws.crossplane.io/example --type=json -p='[{"op": "remove", "path":"/spec/forProvider/tags"}]'
      - verify that the tags "crossplane-kind", "crossplane-name", "crossplane-providerconfig" are re-added as expected
    - start controller scenario:
        - stop provider-aws controller
        - reset the acmpca.CertificateAuthority (kubectl apply -f examples/acmpca/certificateauthority.yaml)
        - start crossplane-aws controller
        - verify that the tags "crossplane-kind", "crossplane-name", "crossplane-providerconfig" are added as expected 

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
