### PR TITLE
fix(lables): eks-nodegroup - both or either addOrUpdateLabels or removeLabels must not be empty

### DIFF
--- a/pkg/clients/eks/nodegroup.go
+++ b/pkg/clients/eks/nodegroup.go
@@ -96,9 +96,12 @@ func GenerateUpdateNodeGroupConfigInput(name string, p *manualv1alpha1.NodeGroup
 
 	if len(p.Labels) > 0 {
 		addOrModify, remove := awsclient.DiffLabels(p.Labels, ng.Labels)
-		u.Labels = &ekstypes.UpdateLabelsPayload{
-			AddOrUpdateLabels: addOrModify,
-			RemoveLabels:      remove,
+		// error: both or either addOrUpdateLabels or removeLabels must not be empty
+		if len(addOrModify) > 0 || len(remove) > 0 {
+			u.Labels = &ekstypes.UpdateLabelsPayload{
+				AddOrUpdateLabels: addOrModify,
+				RemoveLabels:      remove,
+			}
 		}
 	}
 	if p.ScalingConfig != nil {

--- a/pkg/clients/eks/nodegroup_test.go
+++ b/pkg/clients/eks/nodegroup_test.go
@@ -308,11 +308,8 @@ func TestGenerateUpdateNodeGroupInput(t *testing.T) {
 				},
 			},
 			want: &eks.UpdateNodegroupConfigInput{
-				ClusterName: &clusterName,
-				Labels: &ekstypes.UpdateLabelsPayload{
-					AddOrUpdateLabels: map[string]string{},
-					RemoveLabels:      []string{},
-				},
+				ClusterName:   &clusterName,
+				Labels:        nil,
 				NodegroupName: &ngName,
 				ScalingConfig: &ekstypes.NodegroupScalingConfig{
 					DesiredSize: &currentSize,
@@ -356,11 +353,8 @@ func TestGenerateUpdateNodeGroupInput(t *testing.T) {
 				},
 			},
 			want: &eks.UpdateNodegroupConfigInput{
-				ClusterName: &clusterName,
-				Labels: &ekstypes.UpdateLabelsPayload{
-					AddOrUpdateLabels: map[string]string{},
-					RemoveLabels:      []string{},
-				},
+				ClusterName:   &clusterName,
+				Labels:        nil,
 				NodegroupName: &ngName,
 				ScalingConfig: &ekstypes.NodegroupScalingConfig{
 					DesiredSize: awsclients.Int32(6),


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
fixed error both or either addOrUpdateLabels or removeLabels must not be empty which leads in Ready false for NodeGroup
also our friends from terraform did it this way https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/eks/node_group.go#L806 and add nil if nothing changed for addOrUpdateLabels / removeLables ;)
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #975

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
NodeGroup Scaling Config is updated with this fix in our environment

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
