### PR TITLE
secretsmanager.secret: make late init work only if the input secret does not exist

### DIFF
--- a/package/crds/secretsmanager.aws.crossplane.io_secrets.yaml
+++ b/package/crds/secretsmanager.aws.crossplane.io_secrets.yaml
@@ -65,7 +65,8 @@ spec:
                       data will be encoded as binary data to AWS. If key parameter
                       is given, only the value of that key will be used. Otherwise,
                       all data in the Secret will be marshalled into JSON and sent
-                      to AWS.
+                      to AWS. Either StringSecretRef or BinarySecretRef must be set,
+                      but not both.
                     properties:
                       key:
                         description: Key whose value will be used. If not given, the
@@ -169,6 +170,8 @@ spec:
                       data will be sent as string to AWS. If key parameter is given,
                       only the value of that key will be used. Otherwise, all data
                       in the Secret will be marshalled into JSON and sent to AWS.
+                      Either StringSecretRef or BinarySecretRef must be set, but not
+                      both.
                     properties:
                       key:
                         description: Key whose value will be used. If not given, the


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Follow-up for https://github.com/crossplane/provider-aws/pull/669#pullrequestreview-876202252

cc @MisterMX 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually tested by creating a secret, deleting it via orphan policy and importing it to see if it creates the input secret. I tested the normal flow of creation as well to make sure we don't late-init in all cases.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
