### PR TITLE
s3: Empty routing rules refused by AWS

### DIFF
--- a/pkg/controller/s3/bucket/websiteConfig.go
+++ b/pkg/controller/s3/bucket/websiteConfig.go
@@ -146,23 +146,25 @@ func GenerateWebsiteConfiguration(config *v1beta1.WebsiteConfiguration) *types.W
 			Protocol: types.Protocol(config.RedirectAllRequestsTo.Protocol),
 		}
 	}
-	wi.RoutingRules = make([]types.RoutingRule, len(config.RoutingRules))
-	for i, rule := range config.RoutingRules {
-		rr := types.RoutingRule{
-			Redirect: &types.Redirect{
-				HostName:             rule.Redirect.HostName,
-				HttpRedirectCode:     rule.Redirect.HTTPRedirectCode,
-				Protocol:             types.Protocol(rule.Redirect.Protocol),
-				ReplaceKeyPrefixWith: rule.Redirect.ReplaceKeyPrefixWith,
-				ReplaceKeyWith:       rule.Redirect.ReplaceKeyWith,
-			},
-		}
-		if rule.Condition != nil {
-			rr.Condition = &types.Condition{
-				HttpErrorCodeReturnedEquals: rule.Condition.HTTPErrorCodeReturnedEquals,
-				KeyPrefixEquals:             rule.Condition.KeyPrefixEquals,
+	if len(config.RoutingRules) > 0 {
+		wi.RoutingRules = make([]types.RoutingRule, len(config.RoutingRules))
+		for i, rule := range config.RoutingRules {
+			rr := types.RoutingRule{
+				Redirect: &types.Redirect{
+					HostName:             rule.Redirect.HostName,
+					HttpRedirectCode:     rule.Redirect.HTTPRedirectCode,
+					Protocol:             types.Protocol(rule.Redirect.Protocol),
+					ReplaceKeyPrefixWith: rule.Redirect.ReplaceKeyPrefixWith,
+					ReplaceKeyWith:       rule.Redirect.ReplaceKeyWith,
+				},
 			}
-			wi.RoutingRules[i] = rr
+			if rule.Condition != nil {
+				rr.Condition = &types.Condition{
+					HttpErrorCodeReturnedEquals: rule.Condition.HTTPErrorCodeReturnedEquals,
+					KeyPrefixEquals:             rule.Condition.KeyPrefixEquals,
+				}
+				wi.RoutingRules[i] = rr
+			}
 		}
 	}
 


### PR DESCRIPTION
### Description of your changes

When no routing rules are defined for a website configuration, we must
avoid sending an empty XML attribute as AWS refuses this as part of the
schema validation:

    <WebsiteConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ErrorDocument><Key>techdocs-docs/index.html</Key></ErrorDocument><IndexDocument><Suffix>index.html</Suffix></IndexDocument><RoutingRules></RoutingRules></WebsiteConfiguration>

    cannot create or update: api error MalformedXML: The XML you provided was not well-formed or did not validate against our published schema

for the input:

    websiteConfiguration:
      errorDocument:
        key: 'techdocs-docs/index.html'
      indexDocument:
        suffix: 'index.html'

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes bug reported on slack. https://github.com/crossplane/provider-aws/issues/1155

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Created bucket, verified in the console that the config was created as requested.

```yaml
apiVersion: s3.aws.crossplane.io/v1beta1
kind: Bucket
metadata:
  name: test-bucket
  annotations:
    # This will be the actual bucket name. It must be globally unique, so you
    # probably want to change it before trying to apply this example.
    crossplane.io/external-name: crossplane-example-bucket123
spec:
  forProvider:
    acl: private
    locationConstraint: us-east-1
    publicAccessBlockConfiguration:
      blockPublicPolicy: true
    websiteConfiguration:
      errorDocument: 
        key: 'techdocs-docs/index.html'
      indexDocument: 
        suffix: 'index.html'
```

[contribution process]: https://git.io/fj2m9
