### PR TITLE
feat(ec2): add kmsKeyID Ref & Selector in ec2-instance ebs dbm

### DIFF
--- a/apis/ec2/manualv1alpha1/common.go
+++ b/apis/ec2/manualv1alpha1/common.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	awsclients "github.com/crossplane/provider-aws/pkg/clients"
@@ -178,7 +179,18 @@ type EBSBlockDevice struct {
 	// RunInstances (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html),
 	// RequestSpotFleet (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotFleet.html),
 	// and RequestSpotInstances (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotInstances.html).
+	// +crossplane:generate:reference:type=github.com/crossplane/provider-aws/apis/kms/v1alpha1.Key
+	// +crossplane:generate:reference:refFieldName=KMSKeyIDRef
+	// +crossplane:generate:reference:selectorFieldName=KMSKeyIDSelector
 	KmsKeyID *string `json:"kmsKeyId,omitempty"`
+
+	// KMSKeyIDRef is a reference to a KMS Key used to set KMSKeyID.
+	// +optional
+	KMSKeyIDRef *xpv1.Reference `json:"kmsKeyIdRef,omitempty"`
+
+	// KMSKeyIDSelector selects a reference to a KMS Key used to set KMSKeyID.
+	// +optional
+	KMSKeyIDSelector *xpv1.Selector `json:"kmsKeyIdSelector,omitempty"`
 
 	// The ID of the snapshot.
 	SnapshotID *string `json:"snapshotId,omitempty"`

--- a/apis/ec2/manualv1alpha1/zz_generated.deepcopy.go
+++ b/apis/ec2/manualv1alpha1/zz_generated.deepcopy.go
@@ -189,6 +189,16 @@ func (in *EBSBlockDevice) DeepCopyInto(out *EBSBlockDevice) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.KMSKeyIDRef != nil {
+		in, out := &in.KMSKeyIDRef, &out.KMSKeyIDRef
+		*out = new(v1.Reference)
+		**out = **in
+	}
+	if in.KMSKeyIDSelector != nil {
+		in, out := &in.KMSKeyIDSelector, &out.KMSKeyIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.SnapshotID != nil {
 		in, out := &in.SnapshotID, &out.SnapshotID
 		*out = new(string)

--- a/package/crds/ec2.aws.crossplane.io_instances.yaml
+++ b/package/crds/ec2.aws.crossplane.io_instances.yaml
@@ -155,6 +155,32 @@ spec:
                                 RequestSpotFleet (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotFleet.html),
                                 and RequestSpotInstances (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotInstances.html)."
                               type: string
+                            kmsKeyIdRef:
+                              description: KMSKeyIDRef is a reference to a KMS Key
+                                used to set KMSKeyID.
+                              properties:
+                                name:
+                                  description: Name of the referenced object.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            kmsKeyIdSelector:
+                              description: KMSKeyIDSelector selects a reference to
+                                a KMS Key used to set KMSKeyID.
+                              properties:
+                                matchControllerRef:
+                                  description: MatchControllerRef ensures an object
+                                    with the same controller reference as the selecting
+                                    object is selected.
+                                  type: boolean
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: MatchLabels ensures an object with
+                                    matching labels is selected.
+                                  type: object
+                              type: object
                             snapshotId:
                               description: The ID of the snapshot.
                               type: string


### PR DESCRIPTION
feat(ec2): add kmsKeyID Ref & Selector in ec2-instance ebs dbm
Signed-off-by: haarchri <chhaar30@googlemail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
added kmsKeyID Ref & Selector for kmsKeyID

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
created ec2 instance with blockDeviceMappings-ebs

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
