### PR TITLE
add default Crossplane tags to iam.Policy

### DIFF
--- a/pkg/clients/iam/fake/policy.go
+++ b/pkg/clients/iam/fake/policy.go
@@ -29,8 +29,16 @@ import (
 var _ clientset.PolicyClient = (*MockPolicyClient)(nil)
 var _ clientset.STSClient = (*MockSTSClient)(nil)
 
+// MockPolicyInput holds the input structures for future inspections
+type MockPolicyInput struct {
+	CreatePolicyInput *iam.CreatePolicyInput
+	TagPolicyInput    *iam.TagPolicyInput
+	UntagPolicyInput  *iam.UntagPolicyInput
+}
+
 // MockPolicyClient is a type that implements all the methods for PolicyClient interface
 type MockPolicyClient struct {
+	MockPolicyInput         MockPolicyInput
 	MockGetPolicy           func(ctx context.Context, input *iam.GetPolicyInput, opts []func(*iam.Options)) (*iam.GetPolicyOutput, error)
 	MockCreatePolicy        func(ctx context.Context, input *iam.CreatePolicyInput, opts []func(*iam.Options)) (*iam.CreatePolicyOutput, error)
 	MockDeletePolicy        func(ctx context.Context, input *iam.DeletePolicyInput, opts []func(*iam.Options)) (*iam.DeletePolicyOutput, error)
@@ -59,6 +67,7 @@ func (m *MockPolicyClient) GetPolicy(ctx context.Context, input *iam.GetPolicyIn
 
 // CreatePolicy mocks CreatePolicy method
 func (m *MockPolicyClient) CreatePolicy(ctx context.Context, input *iam.CreatePolicyInput, opts ...func(*iam.Options)) (*iam.CreatePolicyOutput, error) {
+	m.MockPolicyInput.CreatePolicyInput = input
 	return m.MockCreatePolicy(ctx, input, opts)
 }
 
@@ -89,10 +98,12 @@ func (m *MockPolicyClient) DeletePolicyVersion(ctx context.Context, input *iam.D
 
 // TagPolicy mocks TagPolicy method
 func (m *MockPolicyClient) TagPolicy(ctx context.Context, input *iam.TagPolicyInput, opts ...func(*iam.Options)) (*iam.TagPolicyOutput, error) {
+	m.MockPolicyInput.TagPolicyInput = input
 	return m.MockTagPolicy(ctx, input, opts)
 }
 
 // UntagPolicy mocks UnTagPolicy method
 func (m *MockPolicyClient) UntagPolicy(ctx context.Context, input *iam.UntagPolicyInput, opts ...func(*iam.Options)) (*iam.UntagPolicyOutput, error) {
+	m.MockPolicyInput.UntagPolicyInput = input
 	return m.MockUntagPolicy(ctx, input, opts)
 }

--- a/pkg/controller/iam/policy/controller.go
+++ b/pkg/controller/iam/policy/controller.go
@@ -43,14 +43,17 @@ import (
 const (
 	errUnexpectedObject = "The managed resource is not a Policy resource"
 
-	errGet           = "failed to get IAM Policy"
-	errCreate        = "failed to create the IAM Policy"
-	errDelete        = "failed to delete the IAM Policy"
-	errUpdate        = "failed to update the IAM Policy"
-	errExternalName  = "failed to update the IAM Policy external-name"
-	errEmptyPolicy   = "empty IAM Policy received from IAM API"
-	errPolicyVersion = "No version for policy received from IAM API"
-	errUpToDate      = "cannot check if policy is up to date"
+	errGet              = "failed to get IAM Policy"
+	errCreate           = "failed to create the IAM Policy"
+	errDelete           = "failed to delete the IAM Policy"
+	errUpdate           = "failed to update the IAM Policy"
+	errExternalName     = "failed to update the IAM Policy external-name"
+	errEmptyPolicy      = "empty IAM Policy received from IAM API"
+	errPolicyVersion    = "No version for policy received from IAM API"
+	errUpToDate         = "cannot check if policy is up to date"
+	errKubeUpdateFailed = "cannot late initialize IAM Policy"
+	errTag              = "cannot tag policy"
+	errUntag            = "cannot untag policy"
 )
 
 // SetupPolicy adds a controller that reconciles IAM Policy.
@@ -64,7 +67,7 @@ func SetupPolicy(mgr ctrl.Manager, o controller.Options) error {
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.PolicyGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: iam.NewPolicyClient, newSTSClientFn: iam.NewSTSClient}),
-			managed.WithInitializers(),
+			managed.WithInitializers(&tagger{kube: mgr.GetClient()}),
 			managed.WithConnectionPublishers(),
 			managed.WithPollInterval(o.PollInterval),
 			managed.WithLogger(o.Logger.WithValues("controller", name)),
@@ -224,18 +227,13 @@ func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.Ex
 		return managed.ExternalUpdate{}, awsclient.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errGet)
 	}
 
-	crTagMap := make(map[string]string, len(cr.Spec.ForProvider.Tags))
-	for _, v := range cr.Spec.ForProvider.Tags {
-		crTagMap[v.Key] = v.Value
-	}
-
-	add, remove, _ := iam.DiffIAMTags(crTagMap, observed.Policy.Tags)
+	add, remove, _ := iam.DiffIAMTagsWithUpdates(cr.Spec.ForProvider.Tags, observed.Policy.Tags)
 	if len(add) != 0 {
 		if _, err := e.client.TagPolicy(ctx, &awsiam.TagPolicyInput{
 			PolicyArn: aws.String(meta.GetExternalName(cr)),
 			Tags:      add,
 		}); err != nil {
-			return managed.ExternalUpdate{}, awsclient.Wrap(err, "cannot tag policy")
+			return managed.ExternalUpdate{}, awsclient.Wrap(err, errTag)
 		}
 	}
 
@@ -244,7 +242,7 @@ func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.Ex
 			PolicyArn: aws.String(meta.GetExternalName(cr)),
 			TagKeys:   remove,
 		}); err != nil {
-			return managed.ExternalUpdate{}, awsclient.Wrap(err, "cannot untag policy")
+			return managed.ExternalUpdate{}, awsclient.Wrap(err, errUntag)
 		}
 	}
 
@@ -370,4 +368,37 @@ func (e *external) getPolicyArnByNameAndPath(ctx context.Context, policyName str
 		Resource:  "policy" + awsclient.StringValue(policyPath) + policyName}
 
 	return aws.String(policyArn.String()), nil
+}
+
+type tagger struct {
+	kube client.Client
+}
+
+func (t *tagger) Initialize(ctx context.Context, mgd resource.Managed) error {
+	cr, ok := mgd.(*v1beta1.Policy)
+	if !ok {
+		return errors.New(errUnexpectedObject)
+	}
+	added := false
+	defaultTags := resource.GetExternalTags(mgd)
+
+	for i, t := range cr.Spec.ForProvider.Tags {
+		v, ok := defaultTags[t.Key]
+		if ok {
+			if v != t.Value {
+				cr.Spec.ForProvider.Tags[i].Value = v
+				added = true
+			}
+			delete(defaultTags, t.Key)
+		}
+	}
+
+	for k, v := range defaultTags {
+		cr.Spec.ForProvider.Tags = append(cr.Spec.ForProvider.Tags, v1beta1.Tag{Key: k, Value: v})
+		added = true
+	}
+	if !added {
+		return nil
+	}
+	return errors.Wrap(t.kube.Update(ctx, cr), errKubeUpdateFailed)
 }


### PR DESCRIPTION
Signed-off-by: Cecilia Bernardi <cbernardi@expediagroup.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1206

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- Unit Tests
- Manual tests on a kind cluster configured with an AWS account:
    - Create resource scenario: a new iam.policy crossplane resource was created and the default tags were added in the kubernetes cluster; the policy was successfully created in the configured AWS account with the default tags
    - Add custom tags scenario: custom tags were added to the crossplane resources, and the AWS policy was successfully tagged with the new tags
    - Modify custom tags scenario: custom tags were modified on the kubernetes resource, and the modification was successfully reconciled with the AWS resource (could observe tags values being modified)
    - Remove custom tags scenario: custom tags were removed from the kubernetes resource, and after the reconciliation, the tags were removed also from the AWS resource
    - Modify / Remove default tags: default tags were removed and changed, and they were immediately restored. No modification was observed on the AWS resource

[contribution process]: https://git.io/fj2m9
