### PR TITLE
Update CI to work with Crossplane v1.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ manifests:
 e2e.run: test-integration
 
 # Run integration tests.
-test-integration: $(KIND) $(KUBECTL) $(HELM3)
+test-integration: $(KIND) $(KUBECTL) $(UP) $(HELM3)
 	@$(INFO) running integration tests using kind $(KIND_VERSION)
 	@KIND_NODE_IMAGE_TAG=${KIND_NODE_IMAGE_TAG} $(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
 	@$(OK) integration tests passed

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -91,11 +91,6 @@ echo "${KIND_CONFIG}" | "${KIND}" create cluster --name="${K8S_CLUSTER}" --wait=
 docker tag "${CONTROLLER_IMAGE}" "${PACKAGE_CONTROLLER_IMAGE}"
 "${KIND}" load docker-image "${PACKAGE_CONTROLLER_IMAGE}" --name="${K8S_CLUSTER}"
 
-# files are not synced properly from host to kind node container on Jenkins, so
-# we must manually copy image from host to node
-echo_step "pre-cache package by copying to kind node"
-docker cp "${CACHE_PATH}/${PACKAGE_NAME}.gz" "${K8S_CLUSTER}-control-plane":"/cache/${PACKAGE_NAME}.gz"
-
 echo_step "create crossplane-system namespace"
 "${KUBECTL}" create ns crossplane-system
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates CI to extract package contents into a gzipped file compatible with Crossplane's package cache format.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make build` and `make e2e` and verified success

```
>>>>>>> --- INTEGRATION TESTS ---

>>>>>>> installing provider-aws into "crossplane-system" namespace
provider.pkg.crossplane.io/provider-aws created

>>>>>>> check kind node cache dir contents
total 408
drwxrwxr-x 2 1000 1000   4096 Mar 30 02:48 .
drwxr-xr-x 1 root root   4096 Mar 30 02:48 ..
-rw-r--r-- 1 1000 1000 406797 Mar 30 02:47 provider-aws.gz

>>>>>>> waiting for provider to be installed
provider.pkg.crossplane.io/provider-aws condition met

>>>>>>> uninstalling provider-aws
provider.pkg.crossplane.io "provider-aws" deleted
waiting for provider to be deleted for another 3 seconds
waiting for provider to be deleted for another 3 seconds

Integration tests succeeded!

>>>>>>> Cleaning up...
Deleting cluster "build-b3b12a66-inttests" ...
22:49:13 [ OK ] integration tests passed
```

[contribution process]: https://git.io/fj2m9
