### PR TITLE
Set Crossplane user agent on AWS clients

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,5 @@
+// Package version contains the version of provider-aws repo
+package version
+
+// Version will be overridden with the current version at build time using the -X linker flag
+var Version = "0.0.0"


### PR DESCRIPTION
Signed-off-by: Clare Liguori <liguori@amazon.com>

### Description of your changes

Sets the user agent to crossplane-provider-aws with the provider version number

Fixes #1241

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I ran the provider locally in KinD and created an ECR repo through it using `examples/ecr/repository`.

In CloudTrail, I can now see the CreateRepository call with:
```
"userAgent": "aws-sdk-go-v2/1.11.2 os/linux lang/go/1.17 md/GOOS/linux md/GOARCH/amd64 api/ecr/1.9.0 crossplane-provider-aws/v0.26.0-rc.0.18.ge6ac32da.dirty",
```

[contribution process]: https://git.io/fj2m9
