### PR TITLE
Handle NoSuchHostedZone errors on ResourceRecordSet delete

### DIFF
--- a/pkg/clients/resourcerecordset/resourcerecordset.go
+++ b/pkg/clients/resourcerecordset/resourcerecordset.go
@@ -29,6 +29,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
+	"github.com/crossplane/provider-aws/pkg/clients/hostedzone"
+
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 
 	"github.com/crossplane/provider-aws/apis/route53/v1alpha1"
@@ -58,7 +60,7 @@ func (r *NotFoundError) Error() string {
 // IsNotFound returns true if the error code indicates that the requested Resource Record was not found
 func IsNotFound(err error) bool {
 	var notFoundError *NotFoundError
-	return errors.As(err, &notFoundError)
+	return errors.As(err, &notFoundError) || hostedzone.IsNotFound(err)
 }
 
 // NewClient creates new AWS client with provided AWS Configuration/Credentials

--- a/pkg/controller/route53/resourcerecordset/controller.go
+++ b/pkg/controller/route53/resourcerecordset/controller.go
@@ -164,5 +164,5 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) error {
 
 	// There is no way to confirm 404 (from response) when deleting a recordset
 	// which isn't present using ChangeResourceRecordSetRequest.
-	return awsclient.Wrap(err, errDelete)
+	return awsclient.Wrap(resource.Ignore(resourcerecordset.IsNotFound, err), errDelete)
 }


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes

Updated the ResourceRecordSet controller to handle the case where the HostedZone has been deleted before the ResourceRecordSet, to prevent the ResourceRecordSet from being permanently stuck.

If the HostedZone does not exist then the ResourceRecordSet cannot exist and so this case can be handled as equivalent to a "NotFound".

Fixes #1251 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested in a local Kind environment.  Reproduced the problem locally, then applied the changes and verified that the ResourceRecordSet gets deleted when the HostedZone has already been deleted.

[contribution process]: https://git.io/fj2m9
