### PR TITLE
fix(permission): Fix dealing with Pricipal being just a string

### DIFF
--- a/pkg/controller/lambda/permission/policy.go
+++ b/pkg/controller/lambda/permission/policy.go
@@ -20,17 +20,23 @@ import (
 	"encoding/json"
 )
 
-// type statementAction []string
+func (p *policyPrincipal) UnmarshalJSON(data []byte) error {
+	// Check if its a single action
+	var str string
 
-// func (s *statementAction) UnmarshalJSON(data []byte) (err error) {
-// 	// Check if its a single action
-// 	var str string
-// 	if err := json.Unmarshal(data, &str); err == nil {
-// 		_ = append(*s, str)
-// 		return nil
-// 	}
-// 	return json.Unmarshal(data, s)
-// }
+	if err := json.Unmarshal(data, &str); err == nil {
+		p.Service = &str
+		return nil
+	}
+
+	pp := _policyPrincipal{}
+	if err := json.Unmarshal(data, &pp); err != nil {
+		return err
+	}
+
+	p.Service = pp.Service
+	return nil
+}
 
 type policyCondition struct {
 	ArnLike      map[string]string `json:"ArnLike,omitempty"`
@@ -40,6 +46,8 @@ type policyCondition struct {
 type policyPrincipal struct {
 	Service *string `json:"Service,omitempty"`
 }
+
+type _policyPrincipal policyPrincipal
 
 type policyStatement struct {
 	Sid       string          `json:"Sid"`

--- a/pkg/controller/lambda/permission/policy_test.go
+++ b/pkg/controller/lambda/permission/policy_test.go
@@ -1,0 +1,245 @@
+package permission
+
+import (
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/google/go-cmp/cmp"
+)
+
+type args struct {
+	rawPolicy string
+}
+
+func stringPtr(v string) *string {
+	return &v
+}
+
+func TestUnmarshalPolicyPrincipal(t *testing.T) {
+	type want struct {
+		result policyPrincipal
+		err    error
+	}
+
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"PrincipalJustWildcardString": {
+			args: args{
+				rawPolicy: `"foo"`,
+			},
+			want: want{
+				result: policyPrincipal{
+					Service: stringPtr("foo"),
+				},
+				err: nil,
+			},
+		},
+		"PrincipalJustServiceString": {
+			args: args{
+				rawPolicy: `"s3.amazonaws.com"`,
+			},
+			want: want{
+				result: policyPrincipal{
+					Service: stringPtr("s3.amazonaws.com"),
+				},
+				err: nil,
+			},
+		},
+		"PrincipalObjectService": {
+			args: args{
+				rawPolicy: `{"Service":"lambda.amazonaws.com"}`,
+			},
+			want: want{
+				result: policyPrincipal{
+					Service: stringPtr("lambda.amazonaws.com"),
+				},
+				err: nil,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Act
+			result := policyPrincipal{}
+			err := result.UnmarshalJSON([]byte(tc.args.rawPolicy))
+
+			// Assert
+			if diff := cmp.Diff(tc.want.result, result, test.EquateConditions()); diff != "" {
+				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestUnmarshalPolicy(t *testing.T) {
+	type want struct {
+		result *policyDocument
+		err    error
+	}
+
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"UnmarshalPolicyWithStringAsPrincipal": {
+			args: args{
+				rawPolicy: `{
+					"Version":"version",
+					"Id":"default",
+					"Statement":[
+						{
+							"Sid": "sid",
+							"Effect": "effect",
+							"Principal": "service",
+							"Action": "action",
+							"Resource": "resource",
+							"Condition": {
+								"StringEquals": {
+									"equals1": "foo",
+									"equals2": "bar"
+								},
+								"ArnLike": {
+									"like1": "foo",
+									"like2": "bar"
+								}
+							}
+						},
+						{
+							"Sid": "sid2",
+							"Effect": "effect2",
+							"Principal": "service2",
+							"Action": "action2",
+							"Resource": "resource2",
+							"Condition": {
+								"StringEquals": {
+									"equals1": "foo"
+								},
+								"ArnLike": {
+									"like2": "bar"
+								}
+							}
+						}
+					]
+				}`,
+			},
+			want: want{
+				result: &policyDocument{
+					Version: "version",
+					Statement: []policyStatement{
+						{
+							Sid:      "sid",
+							Effect:   "effect",
+							Action:   "action",
+							Resource: "resource",
+							Principal: policyPrincipal{
+								Service: stringPtr("service"),
+							},
+							Condition: policyCondition{
+								ArnLike: map[string]string{
+									"like1": "foo",
+									"like2": "bar",
+								},
+								StringEquals: map[string]string{
+									"equals1": "foo",
+									"equals2": "bar",
+								},
+							},
+						},
+						{
+							Sid:      "sid2",
+							Effect:   "effect2",
+							Action:   "action2",
+							Resource: "resource2",
+							Principal: policyPrincipal{
+								Service: stringPtr("service2"),
+							},
+							Condition: policyCondition{
+								ArnLike: map[string]string{
+									"like2": "bar",
+								},
+								StringEquals: map[string]string{
+									"equals1": "foo",
+								},
+							},
+						},
+					},
+				},
+				err: nil,
+			},
+		},
+		"UnmarshalPolicyWithObjectAsPrincipal": {
+			args: args{
+				rawPolicy: `{
+					"Version":"version",
+					"Id":"default",
+					"Statement":[
+						{
+							"Sid": "sid",
+							"Effect": "effect",
+							"Principal": {
+								"Service": "service"
+							},
+							"Action": "action",
+							"Resource": "resource",
+							"Condition": {
+								"StringEquals": {
+									"equals1": "foo"
+								},
+								"ArnLike": {
+									"like2": "bar"
+								}
+							}
+						}
+					]
+				}`,
+			},
+			want: want{
+				result: &policyDocument{
+					Version: "version",
+					Statement: []policyStatement{
+						{
+							Sid:      "sid",
+							Effect:   "effect",
+							Action:   "action",
+							Resource: "resource",
+							Principal: policyPrincipal{
+								Service: stringPtr("service"),
+							},
+							Condition: policyCondition{
+								ArnLike: map[string]string{
+									"like2": "bar",
+								},
+								StringEquals: map[string]string{
+									"equals1": "foo",
+								},
+							},
+						},
+					},
+				},
+				err: nil,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Act
+			result, err := parsePolicy(tc.args.rawPolicy)
+
+			// Assert
+			if diff := cmp.Diff(tc.want.result, result, test.EquateConditions()); diff != "" {
+				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

On reconciliation the AWS API returns the resulting policy document for the lambda. This includes the Principal and it can be in two forms: A plain string or an object with a `Service` key. I.e.:

```json
"Principal": "foo"
```
vs.
```json
"Prinicpal": {
  "Service": "foo"
}
```

The current code breaks on the first one. This PR fixes that.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Unit tests are included, code changes are very local.

[contribution process]: https://git.io/fj2m9
