### PR TITLE
Replication group fixes: multiAz and Tag update support

### DIFF
--- a/apis/cache/v1beta1/replication_group_types.go
+++ b/apis/cache/v1beta1/replication_group_types.go
@@ -282,8 +282,8 @@ type ReplicationGroupParameters struct {
 
 	// AutomaticFailoverEnabled specifies whether a read-only replica is
 	// automatically promoted to read/write primary if the existing primary
-	// fails. If true, Multi-AZ is enabled for this replication group. If false,
-	// Multi-AZ is disabled for this replication group.
+	// fails. Must be set to true if Multi-AZ is enabled for this replication group.
+	// If false, Multi-AZ cannot be enabled for this replication group.
 	//
 	// AutomaticFailoverEnabled must be enabled for Redis (cluster mode enabled)
 	// replication groups.
@@ -386,12 +386,10 @@ type ReplicationGroupParameters struct {
 	// +optional
 	EngineVersion *string `json:"engineVersion,omitempty"`
 
-	// MultiAZ
-	// +optional
-
 	// MultiAZEnabled specifies if Multi-AZ is enabled to enhance fault tolerance
 	// You must have nodes across two or more Availability Zones in order to enable
 	// this feature.
+	// If this feature is set, automaticFailoverEnabled must be set to true.
 	// +optional
 	MultiAZEnabled *bool `json:"multiAZEnabled,omitempty"`
 
@@ -559,7 +557,6 @@ type ReplicationGroupParameters struct {
 
 	// A list of cost allocation tags to be added to this resource. A tag is a key-value
 	// pair.
-	// +immutable
 	// +optional
 	Tags []Tag `json:"tags,omitempty"`
 

--- a/apis/cache/v1beta1/replication_group_types.go
+++ b/apis/cache/v1beta1/replication_group_types.go
@@ -386,6 +386,12 @@ type ReplicationGroupParameters struct {
 	// +optional
 	EngineVersion *string `json:"engineVersion,omitempty"`
 
+	// MultiAZ specifies if Multi-AZ is enabled to enhance fault tolerance.
+	// +optional
+
+	// MultiAZEnabled is a flag to indicate if Multt-AZ is enabled.
+	MultiAZEnabled *bool `json:"multiAZEnabled,omitempty"`
+
 	// NodeGroupConfigurationSpec specifies a list of node group (shard)
 	// configuration options.
 	//
@@ -423,7 +429,7 @@ type ReplicationGroupParameters struct {
 	// between 2 and 6.
 	//
 	// The maximum permitted value for NumCacheClusters is 6 (1 primary plus 5 replicas).
-	// +immutable
+	// +kubebuilder:validation:Maximum=6
 	// +optional
 	NumCacheClusters *int `json:"numCacheClusters,omitempty"`
 

--- a/apis/cache/v1beta1/replication_group_types.go
+++ b/apis/cache/v1beta1/replication_group_types.go
@@ -386,10 +386,13 @@ type ReplicationGroupParameters struct {
 	// +optional
 	EngineVersion *string `json:"engineVersion,omitempty"`
 
-	// MultiAZ specifies if Multi-AZ is enabled to enhance fault tolerance.
+	// MultiAZ
 	// +optional
 
-	// MultiAZEnabled is a flag to indicate if Multt-AZ is enabled.
+	// MultiAZEnabled specifies if Multi-AZ is enabled to enhance fault tolerance
+	// You must have nodes across two or more Availability Zones in order to enable
+	// this feature.
+	// +optional
 	MultiAZEnabled *bool `json:"multiAZEnabled,omitempty"`
 
 	// NodeGroupConfigurationSpec specifies a list of node group (shard)

--- a/apis/cache/v1beta1/zz_generated.deepcopy.go
+++ b/apis/cache/v1beta1/zz_generated.deepcopy.go
@@ -269,6 +269,11 @@ func (in *ReplicationGroupParameters) DeepCopyInto(out *ReplicationGroupParamete
 		*out = new(string)
 		**out = **in
 	}
+	if in.MultiAZEnabled != nil {
+		in, out := &in.MultiAZEnabled, &out.MultiAZEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	if in.NodeGroupConfiguration != nil {
 		in, out := &in.NodeGroupConfiguration, &out.NodeGroupConfiguration
 		*out = make([]NodeGroupConfigurationSpec, len(*in))

--- a/package/crds/cache.aws.crossplane.io_replicationgroups.yaml
+++ b/package/crds/cache.aws.crossplane.io_replicationgroups.yaml
@@ -100,14 +100,14 @@ spec:
                   automaticFailoverEnabled:
                     description: "AutomaticFailoverEnabled specifies whether a read-only
                       replica is automatically promoted to read/write primary if the
-                      existing primary fails. If true, Multi-AZ is enabled for this
-                      replication group. If false, Multi-AZ is disabled for this replication
-                      group. \n AutomaticFailoverEnabled must be enabled for Redis
-                      (cluster mode enabled) replication groups. \n Amazon ElastiCache
-                      for Redis does not support Multi-AZ with automatic failover
-                      on: * Redis versions earlier than 2.8.6. * Redis (cluster mode
-                      disabled): T1 and T2 cache node types. * Redis (cluster mode
-                      enabled): T1 node types."
+                      existing primary fails. Must be set to true if Multi-AZ is enabled
+                      for this replication group. If false, Multi-AZ cannot be enabled
+                      for this replication group. \n AutomaticFailoverEnabled must
+                      be enabled for Redis (cluster mode enabled) replication groups.
+                      \n Amazon ElastiCache for Redis does not support Multi-AZ with
+                      automatic failover on: * Redis versions earlier than 2.8.6.
+                      * Redis (cluster mode disabled): T1 and T2 cache node types.
+                      * Redis (cluster mode enabled): T1 node types."
                     type: boolean
                   cacheNodeType:
                     description: 'CacheNodeType specifies the compute and memory capacity
@@ -228,8 +228,10 @@ spec:
                       group and create it anew with the earlier engine version."
                     type: string
                   multiAZEnabled:
-                    description: MultiAZEnabled is a flag to indicate if Multt-AZ
-                      is enabled.
+                    description: MultiAZEnabled specifies if Multi-AZ is enabled to
+                      enhance fault tolerance You must have nodes across two or more
+                      Availability Zones in order to enable this feature. If this
+                      feature is set, automaticFailoverEnabled must be set to true.
                     type: boolean
                   nodeGroupConfiguration:
                     description: "NodeGroupConfigurationSpec specifies a list of node

--- a/package/crds/cache.aws.crossplane.io_replicationgroups.yaml
+++ b/package/crds/cache.aws.crossplane.io_replicationgroups.yaml
@@ -227,6 +227,10 @@ spec:
                       version, you must delete the existing cluster or replication
                       group and create it anew with the earlier engine version."
                     type: string
+                  multiAZEnabled:
+                    description: MultiAZEnabled is a flag to indicate if Multt-AZ
+                      is enabled.
+                    type: boolean
                   nodeGroupConfiguration:
                     description: "NodeGroupConfigurationSpec specifies a list of node
                       group (shard) configuration options. \n If you're creating a
@@ -287,6 +291,7 @@ spec:
                       (it will default to 1), or you can explicitly set it to a value
                       between 2 and 6. \n The maximum permitted value for NumCacheClusters
                       is 6 (1 primary plus 5 replicas)."
+                    maximum: 6
                     type: integer
                   numNodeGroups:
                     description: "NumNodeGroups specifies the number of node groups

--- a/pkg/clients/elasticache/elasticache_test.go
+++ b/pkg/clients/elasticache/elasticache_test.go
@@ -748,13 +748,36 @@ func TestReplicationGroupNeedsUpdate(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "NeedsNewMultiAZ",
+			name: "NeedsMultiAZUpdate",
 			kube: replicationGroup.Spec.ForProvider,
 			rg: elasticachetypes.ReplicationGroup{
-				//AutomaticFailover:      elasticachetypes.AutomaticFailoverStatusEnabling,
-				//CacheNodeType:          aws.String(cacheNodeType),
-				MultiAZ: elasticachetypes.MultiAZStatusDisabled,
-				//SnapshotRetentionLimit: aws.Int32Address(&snapshotRetentionLimit),
+				AutomaticFailover:      elasticachetypes.AutomaticFailoverStatusEnabling,
+				CacheNodeType:          aws.String(cacheNodeType),
+				MultiAZ:                elasticachetypes.MultiAZStatusDisabled, // trigger Update
+				SnapshotRetentionLimit: aws.Int32Address(&snapshotRetentionLimit),
+				SnapshotWindow:         aws.String(snapshotWindow),
+			},
+			ccList: []elasticachetypes.CacheCluster{
+				{
+					EngineVersion:              aws.String(engineVersion),
+					CacheParameterGroup:        &elasticachetypes.CacheParameterGroupStatus{CacheParameterGroupName: aws.String(cacheParameterGroupName)},
+					NotificationConfiguration:  &elasticachetypes.NotificationConfiguration{TopicArn: aws.String(notificationTopicARN), TopicStatus: aws.String(notificationTopicStatus)},
+					PreferredMaintenanceWindow: aws.String(maintenanceWindow),
+					SecurityGroups: func() []elasticachetypes.SecurityGroupMembership {
+						ids := make([]elasticachetypes.SecurityGroupMembership, len(securityGroupIDs))
+						for i, id := range securityGroupIDs {
+							ids[i] = elasticachetypes.SecurityGroupMembership{SecurityGroupId: aws.String(id)}
+						}
+						return ids
+					}(),
+					CacheSecurityGroups: func() []elasticachetypes.CacheSecurityGroupMembership {
+						names := make([]elasticachetypes.CacheSecurityGroupMembership, len(cacheSecurityGroupNames))
+						for i, n := range cacheSecurityGroupNames {
+							names[i] = elasticachetypes.CacheSecurityGroupMembership{CacheSecurityGroupName: aws.String(n)}
+						}
+						return names
+					}(),
+				},
 			},
 			want: true,
 		},

--- a/pkg/clients/elasticache/elasticache_test.go
+++ b/pkg/clients/elasticache/elasticache_test.go
@@ -1292,7 +1292,7 @@ func TestDiffTags(t *testing.T) {
 	}
 }
 
-func TestReplicationGroupTagsNeedUpdate(t *testing.T) {
+func TestReplicationGroupTagsNeedsUpdate(t *testing.T) {
 	type args struct {
 		local  []v1beta1.Tag
 		remote []elasticachetypes.Tag
@@ -1397,7 +1397,7 @@ func TestReplicationGroupTagsNeedUpdate(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			res := ReplicationGroupTagsNeedUpdate(tc.args.local, tc.args.remote)
+			res := ReplicationGroupTagsNeedsUpdate(tc.args.local, tc.args.remote)
 			if diff := cmp.Diff(tc.want.res, res); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
 			}

--- a/pkg/clients/elasticache/fake/fake.go
+++ b/pkg/clients/elasticache/fake/fake.go
@@ -42,6 +42,10 @@ type MockClient struct {
 	MockModifyCacheCluster    func(context.Context, *elasticache.ModifyCacheClusterInput, []func(*elasticache.Options)) (*elasticache.ModifyCacheClusterOutput, error)
 
 	MockModifyReplicationGroupShardConfiguration func(context.Context, *elasticache.ModifyReplicationGroupShardConfigurationInput, []func(*elasticache.Options)) (*elasticache.ModifyReplicationGroupShardConfigurationOutput, error)
+
+	MockListTagsForResource    func(context.Context, *elasticache.ListTagsForResourceInput, []func(*elasticache.Options)) (*elasticache.ListTagsForResourceOutput, error)
+	MockAddTagsToResource      func(context.Context, *elasticache.AddTagsToResourceInput, []func(*elasticache.Options)) (*elasticache.AddTagsToResourceOutput, error)
+	MockRemoveTagsFromResource func(context.Context, *elasticache.RemoveTagsFromResourceInput, []func(*elasticache.Options)) (*elasticache.RemoveTagsFromResourceOutput, error)
 }
 
 // DescribeReplicationGroups calls the underlying
@@ -120,4 +124,22 @@ func (c *MockClient) DeleteCacheCluster(ctx context.Context, i *elasticache.Dele
 // MockModifyCacheCluster method.
 func (c *MockClient) ModifyCacheCluster(ctx context.Context, i *elasticache.ModifyCacheClusterInput, opts ...func(*elasticache.Options)) (*elasticache.ModifyCacheClusterOutput, error) {
 	return c.MockModifyCacheCluster(ctx, i, opts)
+}
+
+// ListTagsForResource calls the underlying
+// MockListTagsForResource method
+func (c *MockClient) ListTagsForResource(ctx context.Context, i *elasticache.ListTagsForResourceInput, opts ...func(*elasticache.Options)) (*elasticache.ListTagsForResourceOutput, error) {
+	return c.MockListTagsForResource(ctx, i, opts)
+}
+
+// AddTagsToResource calls the underlying
+// MockAddTagsToResource method
+func (c *MockClient) AddTagsToResource(ctx context.Context, i *elasticache.AddTagsToResourceInput, opts ...func(*elasticache.Options)) (*elasticache.AddTagsToResourceOutput, error) {
+	return c.MockAddTagsToResource(ctx, i, opts)
+}
+
+// RemoveTagsFromResource calls the underlying
+// MockRemoveTagsFromResource method
+func (c *MockClient) RemoveTagsFromResource(ctx context.Context, i *elasticache.RemoveTagsFromResourceInput, opts ...func(*elasticache.Options)) (*elasticache.RemoveTagsFromResourceOutput, error) {
+	return c.MockRemoveTagsFromResource(ctx, i, opts)
 }

--- a/pkg/controller/cache/managed.go
+++ b/pkg/controller/cache/managed.go
@@ -18,14 +18,12 @@ package cache
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"sort"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
 	awselasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,15 +46,17 @@ import (
 
 // Error strings.
 const (
-	errUpdateReplicationGroupCR = "cannot update ReplicationGroup Custom Resource"
-	errGetCacheClusterList      = "cannot get cache cluster list"
-	errNotReplicationGroup      = "managed resource is not an ElastiCache replication group"
-	errDescribeReplicationGroup = "cannot describe ElastiCache replication group"
-	errGenerateAuthToken        = "cannot generate ElastiCache auth token"
-	errCreateReplicationGroup   = "cannot create ElastiCache replication group"
-	errModifyReplicationGroup   = "cannot modify ElastiCache replication group"
-	errDeleteReplicationGroup   = "cannot delete ElastiCache replication group"
-	errModifyReplicationGroupSC = "cannot modify ElastiCache replication group shard configuration"
+	errUpdateReplicationGroupCR   = "cannot update ReplicationGroup Custom Resource"
+	errGetCacheClusterList        = "cannot get cache cluster list"
+	errNotReplicationGroup        = "managed resource is not an ElastiCache replication group"
+	errDescribeReplicationGroup   = "cannot describe ElastiCache replication group"
+	errGenerateAuthToken          = "cannot generate ElastiCache auth token"
+	errCreateReplicationGroup     = "cannot create ElastiCache replication group"
+	errModifyReplicationGroup     = "cannot modify ElastiCache replication group"
+	errDeleteReplicationGroup     = "cannot delete ElastiCache replication group"
+	errModifyReplicationGroupSC   = "cannot modify ElastiCache replication group shard configuration"
+	errListReplicationGroupTags   = "cannot list ElastiCache replication group tags"
+	errUpdateReplicationGroupTags = "cannot update ElastiCache replication group tags"
 )
 
 // SetupReplicationGroup adds a controller that reconciles ReplicationGroups.
@@ -119,8 +119,6 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	// ask for one group by name, so we should get either a single element list
 	// or an error.
 	rg := rsp.ReplicationGroups[0]
-	fmt.Println("OBSERVE RG")
-	spew.Dump(rg)
 	ccList, err := getCacheClusterList(ctx, e.client, rg.MemberClusters)
 	if err != nil {
 		return managed.ExternalObservation{}, awsclient.Wrap(err, errGetCacheClusterList)
@@ -150,9 +148,20 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		cr.Status.SetConditions(xpv1.Unavailable())
 	}
 
+	var tagsNeedUpdate bool
+	if cr.Status.AtProvider.Status == v1beta1.StatusAvailable {
+		tags, err := e.client.ListTagsForResource(ctx, elasticache.NewListTagsForResourceInput(rg.ARN))
+		if err != nil {
+			return managed.ExternalObservation{}, awsclient.Wrap(resource.Ignore(elasticache.IsNotFound, err), errListReplicationGroupTags)
+		}
+		tagsNeedUpdate = elasticache.ReplicationGroupTagsNeedsUpdate(cr.Spec.ForProvider.Tags, tags.TagList)
+	}
+
 	return managed.ExternalObservation{
-		ResourceExists:    true,
-		ResourceUpToDate:  !elasticache.ReplicationGroupNeedsUpdate(cr.Spec.ForProvider, rg, ccList) && !elasticache.ReplicationGroupShardConfigurationNeedsUpdate(cr.Spec.ForProvider, rg),
+		ResourceExists: true,
+		ResourceUpToDate: !elasticache.ReplicationGroupNeedsUpdate(cr.Spec.ForProvider, rg, ccList) &&
+			!elasticache.ReplicationGroupShardConfigurationNeedsUpdate(cr.Spec.ForProvider, rg) &&
+			!tagsNeedUpdate,
 		ConnectionDetails: elasticache.ConnectionEndpoint(rg),
 	}, nil
 }
@@ -217,8 +226,23 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, nil
 	}
 
-	_, err = e.client.ModifyReplicationGroup(ctx, elasticache.NewModifyReplicationGroupInput(cr.Spec.ForProvider, meta.GetExternalName(cr)))
-	return managed.ExternalUpdate{}, awsclient.Wrap(err, errModifyReplicationGroup)
+	ccList, err := getCacheClusterList(ctx, e.client, rg.MemberClusters)
+	if err != nil {
+		return managed.ExternalUpdate{}, awsclient.Wrap(err, errGetCacheClusterList)
+	}
+
+	if elasticache.ReplicationGroupNeedsUpdate(cr.Spec.ForProvider, rg, ccList) {
+		_, err = e.client.ModifyReplicationGroup(ctx, elasticache.NewModifyReplicationGroupInput(cr.Spec.ForProvider, meta.GetExternalName(cr)))
+		if err != nil {
+			return managed.ExternalUpdate{}, awsclient.Wrap(err, errModifyReplicationGroup)
+		}
+		// perform one update at a time
+		return managed.ExternalUpdate{}, nil
+
+	}
+
+	err = e.updateTags(ctx, cr.Spec.ForProvider.Tags, rg.ARN)
+	return managed.ExternalUpdate{}, awsclient.Wrap(err, errUpdateReplicationGroupTags)
 }
 
 func (e *external) Delete(ctx context.Context, mg resource.Managed) error {
@@ -232,6 +256,29 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) error {
 	}
 	_, err := e.client.DeleteReplicationGroup(ctx, elasticache.NewDeleteReplicationGroupInput(meta.GetExternalName(cr)))
 	return awsclient.Wrap(resource.Ignore(elasticache.IsNotFound, err), errDeleteReplicationGroup)
+}
+
+func (e *external) updateTags(ctx context.Context, tags []v1beta1.Tag, arn *string) error {
+	resp, err := e.client.ListTagsForResource(ctx, elasticache.NewListTagsForResourceInput(arn))
+	if err != nil {
+		return awsclient.Wrap(err, errListReplicationGroupTags)
+	}
+	add, remove := elasticache.DiffTags(tags, resp.TagList)
+	if len(remove) != 0 {
+		if _, err := e.client.RemoveTagsFromResource(ctx, &awselasticache.RemoveTagsFromResourceInput{ResourceName: arn, TagKeys: remove}); err != nil {
+			return awsclient.Wrap(err, errUpdateReplicationGroupTags)
+		}
+	}
+	if len(add) != 0 {
+		addTags := []awselasticachetypes.Tag{}
+		for k, v := range add {
+			addTags = append(addTags, awselasticachetypes.Tag{Key: aws.String(k), Value: aws.String(v)})
+		}
+		if _, err := e.client.AddTagsToResource(ctx, &awselasticache.AddTagsToResourceInput{ResourceName: arn, Tags: addTags}); err != nil {
+			return awsclient.Wrap(err, errUpdateReplicationGroupTags)
+		}
+	}
+	return nil
 }
 
 type tagger struct {

--- a/pkg/controller/cache/managed.go
+++ b/pkg/controller/cache/managed.go
@@ -18,12 +18,14 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"sort"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
 	awselasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -117,7 +119,8 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	// ask for one group by name, so we should get either a single element list
 	// or an error.
 	rg := rsp.ReplicationGroups[0]
-
+	fmt.Println("OBSERVE RG")
+	spew.Dump(rg)
 	ccList, err := getCacheClusterList(ctx, e.client, rg.MemberClusters)
 	if err != nil {
 		return managed.ExternalObservation{}, awsclient.Wrap(err, errGetCacheClusterList)

--- a/pkg/controller/cache/managed_test.go
+++ b/pkg/controller/cache/managed_test.go
@@ -265,6 +265,14 @@ func TestObserve(t *testing.T) {
 						}},
 					}, nil
 				},
+				MockListTagsForResource: func(ctx context.Context, _ *elasticache.ListTagsForResourceInput, opts []func(*elasticache.Options)) (*elasticache.ListTagsForResourceOutput, error) {
+					return &elasticache.ListTagsForResourceOutput{
+						TagList: []types.Tag{
+							{Key: aws.String("key1"), Value: aws.String("val1")},
+							{Key: aws.String("key2"), Value: aws.String("val2")},
+						},
+					}, nil
+				},
 			}},
 			r: replicationGroup(
 				withReplicationGroupID(name),


### PR DESCRIPTION
### Description of your changes

This PR adds functionality to update multiAZ and tags for ElastiCache Replication groups. 

Fixes #914

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Created a replication group and changed Tags and MultiAZenabled.

```yaml
apiVersion: cache.aws.crossplane.io/v1beta1
kind: ReplicationGroup
metadata:
  name: redis-replication-group
spec:
  forProvider:
    region: us-east-1
    replicationGroupDescription: "A redis replication group"
    applyModificationsImmediately: true
    engine: "redis"
    engineVersion: "5.0.6"
    port: 6379
    cacheSubnetGroupName: borrelli-cache-test
    #cacheSubnetGroupName: default
    numCacheClusters: 2
    cacheParameterGroupName: default.redis5.0
    cacheNodeType: cache.t3.medium
    securityGroupIds:
      - sg-xxxxxyyyyy 
    automaticFailoverEnabled: true
    multiAZEnabled: false
    tags:
      - key: Name
        value: redis-replication-group
      #- key: VS
      #  value: sandbox
      - key: Environment
        value: dev
      - key: Squad
        value: my-team
      - key: Tier
        value: sandbox
```

[contribution process]: https://git.io/fj2m9
