### PR TITLE
fix(routetable): fix panic on sorting both v4 and v6 routes

### DIFF
--- a/pkg/clients/ec2/routetable.go
+++ b/pkg/clients/ec2/routetable.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -214,12 +216,56 @@ func IsRtUpToDate(p v1beta1.RouteTableParameters, rt ec2types.RouteTable) (bool,
 // SortRoutes sorts array of Routes on DestinationCIDR
 func SortRoutes(route []v1beta1.RouteBeta, ec2Route []ec2types.Route) {
 	sort.Slice(route, func(i, j int) bool {
-		return (route[i].DestinationCIDRBlock != nil && *route[i].DestinationCIDRBlock < *route[j].DestinationCIDRBlock) ||
-			(route[i].DestinationIPV6CIDRBlock != nil && *route[i].DestinationIPV6CIDRBlock < *route[j].DestinationIPV6CIDRBlock)
+		return compareRoutes(i, j, route)
 	})
 
 	sort.Slice(ec2Route, func(i, j int) bool {
-		return (ec2Route[i].DestinationCidrBlock != nil && *ec2Route[i].DestinationCidrBlock < *ec2Route[j].DestinationCidrBlock) ||
-			(ec2Route[i].DestinationIpv6CidrBlock != nil && *ec2Route[i].DestinationIpv6CidrBlock < *ec2Route[j].DestinationIpv6CidrBlock)
+		return compareEC2Routes(i, j, ec2Route)
 	})
+}
+
+func compareRoutes(i, j int, route []v1beta1.RouteBeta) bool {
+	if route[i].DestinationCIDRBlock != nil && route[j].DestinationCIDRBlock != nil {
+		return *route[i].DestinationCIDRBlock < *route[j].DestinationCIDRBlock
+	}
+	if route[i].DestinationIPV6CIDRBlock != nil && route[j].DestinationIPV6CIDRBlock != nil {
+		return *route[i].DestinationIPV6CIDRBlock < *route[j].DestinationIPV6CIDRBlock
+	}
+	if route[i].DestinationCIDRBlock != nil && route[j].DestinationIPV6CIDRBlock != nil {
+		return true
+	}
+	if route[i].DestinationIPV6CIDRBlock != nil && route[j].DestinationCIDRBlock != nil {
+		return false
+	}
+	return false
+}
+
+func compareEC2Routes(i, j int, ec2Route []ec2types.Route) bool {
+	if ec2Route[i].DestinationCidrBlock != nil && ec2Route[j].DestinationCidrBlock != nil {
+		return *ec2Route[i].DestinationCidrBlock < *ec2Route[j].DestinationCidrBlock
+	}
+	if ec2Route[i].DestinationIpv6CidrBlock != nil && ec2Route[j].DestinationIpv6CidrBlock != nil {
+		return *ec2Route[i].DestinationIpv6CidrBlock < *ec2Route[j].DestinationIpv6CidrBlock
+	}
+	if ec2Route[i].DestinationCidrBlock != nil && ec2Route[j].DestinationIpv6CidrBlock != nil {
+		return true
+	}
+	if ec2Route[i].DestinationIpv6CidrBlock != nil && ec2Route[j].DestinationCidrBlock != nil {
+		return false
+	}
+	return false
+}
+
+// ValidateRoutes on empty cidrs
+func ValidateRoutes(route []v1beta1.RouteBeta) error {
+	errs := make([]string, 0, len(route))
+	for i, r := range route {
+		if r.DestinationCIDRBlock == nil && r.DestinationIPV6CIDRBlock == nil {
+			errs = append(errs, fmt.Sprintf("route[%d]: both v4 and v6 cidrs are empty", i))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("invalid routes: %s", strings.Join(errs, ";"))
+	}
+	return nil
 }

--- a/pkg/clients/ec2/routetable_test.go
+++ b/pkg/clients/ec2/routetable_test.go
@@ -1,6 +1,7 @@
 package ec2
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -166,6 +167,214 @@ func TestCreateRTPatch(t *testing.T) {
 			result, _ := CreateRTPatch(tc.args.rt, *tc.args.p)
 			if diff := cmp.Diff(tc.want.patch, result); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSortRoutes(t *testing.T) {
+	type args struct {
+		route    []v1beta1.RouteBeta
+		ec2Route []ec2types.Route
+	}
+
+	type want struct {
+		route    []v1beta1.RouteBeta
+		ec2Route []ec2types.Route
+	}
+
+	var (
+		v4RouteMin = aws.String("v4_0")
+		v4RouteMax = aws.String("v4_1")
+		v6RouteMin = aws.String("v6_0")
+		v6RouteMax = aws.String("v6_1")
+	)
+
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"v4": {
+			args: args{
+				route: []v1beta1.RouteBeta{
+					{
+						DestinationCIDRBlock: v4RouteMax,
+					},
+					{
+						DestinationCIDRBlock: v4RouteMin,
+					},
+				},
+				ec2Route: []ec2types.Route{
+					{
+						DestinationCidrBlock: v4RouteMax,
+					},
+					{
+						DestinationCidrBlock: v4RouteMin,
+					},
+				},
+			},
+			want: want{
+				route: []v1beta1.RouteBeta{
+					{
+						DestinationCIDRBlock: v4RouteMin,
+					},
+					{
+						DestinationCIDRBlock: v4RouteMax,
+					},
+				},
+				ec2Route: []ec2types.Route{
+					{
+						DestinationCidrBlock: v4RouteMin,
+					},
+					{
+						DestinationCidrBlock: v4RouteMax,
+					},
+				},
+			},
+		},
+		"v6": {
+			args: args{
+				route: []v1beta1.RouteBeta{
+					{
+						DestinationIPV6CIDRBlock: v6RouteMax,
+					},
+					{
+						DestinationIPV6CIDRBlock: v6RouteMin,
+					},
+				},
+				ec2Route: []ec2types.Route{
+					{
+						DestinationCidrBlock: v6RouteMax,
+					},
+					{
+						DestinationCidrBlock: v6RouteMin,
+					},
+				},
+			},
+			want: want{
+				route: []v1beta1.RouteBeta{
+					{
+						DestinationIPV6CIDRBlock: v6RouteMin,
+					},
+					{
+						DestinationIPV6CIDRBlock: v6RouteMax,
+					},
+				},
+				ec2Route: []ec2types.Route{
+					{
+						DestinationCidrBlock: v6RouteMin,
+					},
+					{
+						DestinationCidrBlock: v6RouteMax,
+					},
+				},
+			},
+		},
+		"both": {
+			args: args{
+				route: []v1beta1.RouteBeta{
+					{
+						DestinationCIDRBlock: v4RouteMax,
+					},
+					{
+						DestinationIPV6CIDRBlock: v6RouteMax,
+					},
+					{
+						DestinationCIDRBlock: v4RouteMin,
+					},
+					{
+						DestinationIPV6CIDRBlock: v6RouteMin,
+					},
+				},
+				ec2Route: []ec2types.Route{
+					{
+						DestinationCidrBlock: v4RouteMax,
+					},
+					{
+						DestinationIpv6CidrBlock: v6RouteMax,
+					},
+					{
+						DestinationCidrBlock: v4RouteMin,
+					},
+					{
+						DestinationIpv6CidrBlock: v6RouteMin,
+					},
+				},
+			},
+			want: want{
+				route: []v1beta1.RouteBeta{
+					{
+						DestinationCIDRBlock: v4RouteMin,
+					},
+					{
+						DestinationCIDRBlock: v4RouteMax,
+					},
+					{
+						DestinationIPV6CIDRBlock: v6RouteMin,
+					},
+					{
+						DestinationIPV6CIDRBlock: v6RouteMax,
+					},
+				},
+				ec2Route: []ec2types.Route{
+					{
+						DestinationCidrBlock: v4RouteMin,
+					},
+					{
+						DestinationCidrBlock: v4RouteMax,
+					},
+					{
+						DestinationIpv6CidrBlock: v6RouteMin,
+					},
+					{
+						DestinationIpv6CidrBlock: v6RouteMax,
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			SortRoutes(tc.args.route, tc.args.ec2Route)
+			if !reflect.DeepEqual(tc.args.route, tc.want.route) {
+				t.Errorf("SortRoutes() route got = %v, want %v", tc.args.route, tc.want.route)
+			}
+			if !reflect.DeepEqual(tc.args.ec2Route, tc.want.ec2Route) {
+				t.Errorf("SortRoutes() ec2 route got = %v, want %v", tc.args.ec2Route, tc.want.ec2Route)
+			}
+		})
+	}
+}
+
+func TestValidateRoutes(t *testing.T) {
+	type args struct {
+		route []v1beta1.RouteBeta
+	}
+	tests := map[string]struct {
+		args args
+		err  string
+	}{
+		"valid": {
+			args: args{
+				route: []v1beta1.RouteBeta{{DestinationCIDRBlock: aws.String("0.0.0.0/0")}},
+			},
+		},
+		"empty cidrs": {
+			args: args{
+				route: []v1beta1.RouteBeta{{}},
+			},
+			err: "invalid routes: route[0]: both v4 and v6 cidrs are empty",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateRoutes(tt.args.route)
+			if err != nil && err.Error() != tt.err {
+				t.Errorf("ValidateRoutes() error = %s, wantErr %s", err, err)
+			}
+			if err == nil && tt.err != "" {
+				t.Errorf("ValidateRoutes() error = %s, wantErr %s", err, err)
 			}
 		})
 	}

--- a/pkg/controller/ec2/routetable/controller.go
+++ b/pkg/controller/ec2/routetable/controller.go
@@ -45,6 +45,7 @@ import (
 
 const (
 	errUnexpectedObject = "The managed resource is not an RouteTable resource"
+	errInvalidRoutes    = "RouteTable routes are invalid"
 
 	errDescribe           = "failed to describe RouteTable"
 	errMultipleItems      = "retrieved multiple RouteTables for the given routeTableId"
@@ -112,7 +113,9 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 	if !ok {
 		return managed.ExternalObservation{}, errors.New(errUnexpectedObject)
 	}
-
+	if err := ec2.ValidateRoutes(cr.Spec.ForProvider.Routes); err != nil {
+		return managed.ExternalObservation{}, errors.Wrap(err, errInvalidRoutes)
+	}
 	// To find out whether a RouteTable exist:
 	// - the object's ExternalName should have routeTableId populated
 	// - a RouteTable with the given routeTableId should exist
@@ -169,6 +172,9 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 	if !ok {
 		return managed.ExternalCreation{}, errors.New(errUnexpectedObject)
 	}
+	if err := ec2.ValidateRoutes(cr.Spec.ForProvider.Routes); err != nil {
+		return managed.ExternalCreation{}, errors.Wrap(err, errInvalidRoutes)
+	}
 	result, err := e.client.CreateRouteTable(ctx, &awsec2.CreateRouteTableInput{
 		VpcId: cr.Spec.ForProvider.VPCID,
 	})
@@ -184,7 +190,9 @@ func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.Ex
 	if !ok {
 		return managed.ExternalUpdate{}, errors.New(errUnexpectedObject)
 	}
-
+	if err := ec2.ValidateRoutes(cr.Spec.ForProvider.Routes); err != nil {
+		return managed.ExternalUpdate{}, errors.Wrap(err, errInvalidRoutes)
+	}
 	response, err := e.client.DescribeRouteTables(ctx, &awsec2.DescribeRouteTablesInput{
 		RouteTableIds: []string{meta.GetExternalName(cr)},
 	})
@@ -246,6 +254,10 @@ func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
 	cr, ok := mgd.(*v1beta1.RouteTable)
 	if !ok {
 		return errors.New(errUnexpectedObject)
+	}
+
+	if err := ec2.ValidateRoutes(cr.Spec.ForProvider.Routes); err != nil {
+		return errors.Wrap(err, errInvalidRoutes)
 	}
 
 	cr.Status.SetConditions(xpv1.Deleting())

--- a/pkg/controller/ec2/routetable/controller_test.go
+++ b/pkg/controller/ec2/routetable/controller_test.go
@@ -39,18 +39,19 @@ import (
 )
 
 var (
-	rtID           = "some rt"
-	vpcID          = "some vpc"
-	igID           = "some ig"
-	instanceID     = "natID"
-	associationID  = "someAssociation"
-	subnetID       = "some subnet"
-	removeSubnetID = "removeMe"
-	testKey        = "testKey"
-	testValue      = "testValue"
-	CIDR           = "10.0.0.0/8"
-	instanceCIDR   = "10.1.1.1/32"
-	errBoom        = errors.New("boom")
+	rtID            = "some rt"
+	vpcID           = "some vpc"
+	igID            = "some ig"
+	destinationCIDR = "0.0.0.0/0"
+	instanceID      = "natID"
+	associationID   = "someAssociation"
+	subnetID        = "some subnet"
+	removeSubnetID  = "removeMe"
+	testKey         = "testKey"
+	testValue       = "testValue"
+	CIDR            = "10.0.0.0/8"
+	instanceCIDR    = "10.1.1.1/32"
+	errBoom         = errors.New("boom")
 )
 
 type args struct {
@@ -282,7 +283,8 @@ func TestUpdate(t *testing.T) {
 				},
 				cr: rt(withSpec(v1beta1.RouteTableParameters{
 					Routes: []v1beta1.RouteBeta{{
-						GatewayID: aws.String(igID),
+						GatewayID:            aws.String(igID),
+						DestinationCIDRBlock: aws.String(destinationCIDR),
 					}},
 					Associations: []v1beta1.Association{{
 						SubnetID: aws.String(subnetID),
@@ -295,7 +297,8 @@ func TestUpdate(t *testing.T) {
 			want: want{
 				cr: rt(withSpec(v1beta1.RouteTableParameters{
 					Routes: []v1beta1.RouteBeta{{
-						GatewayID: aws.String(igID),
+						GatewayID:            aws.String(igID),
+						DestinationCIDRBlock: aws.String(destinationCIDR),
 					}},
 					Associations: []v1beta1.Association{{
 						SubnetID: aws.String(subnetID),
@@ -685,7 +688,8 @@ func TestUpdate(t *testing.T) {
 				},
 				cr: rt(withSpec(v1beta1.RouteTableParameters{
 					Routes: []v1beta1.RouteBeta{{
-						GatewayID: aws.String(igID),
+						GatewayID:            aws.String(igID),
+						DestinationCIDRBlock: aws.String(destinationCIDR),
 					}},
 				}),
 					withStatus(v1beta1.RouteTableObservation{
@@ -695,7 +699,8 @@ func TestUpdate(t *testing.T) {
 			want: want{
 				cr: rt(withSpec(v1beta1.RouteTableParameters{
 					Routes: []v1beta1.RouteBeta{{
-						GatewayID: aws.String(igID),
+						GatewayID:            aws.String(igID),
+						DestinationCIDRBlock: aws.String(destinationCIDR),
 					}},
 				}),
 					withStatus(v1beta1.RouteTableObservation{


### PR DESCRIPTION
This is just a rebase + conflict resolution of PR https://github.com/crossplane/provider-aws/pull/893 which appears to be abandoned. Credit for this fix should go to @vaspahomov.

Signed-off-by: vaspahomov <vas2142553@gmail.com>
Signed-off-by: Jesse Suen <jessesuen@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane/provider-aws/issues/795

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I was encountering the panic in https://github.com/crossplane/provider-aws/issues/795 when creating route tables in a VPC with ipv6 enabled. The panic causes the provider-aws controller to crashloop and will not recover. With this fix, the panic no longer happens.
