### PR TITLE
bugfix(panic): fix panic route resource in CIDRBlocksEqual

### DIFF
--- a/pkg/controller/ec2/route/setup.go
+++ b/pkg/controller/ec2/route/setup.go
@@ -116,7 +116,7 @@ func (e *external) findRouteByDestination(ctx context.Context, cr *svcapitypes.R
 
 	for _, route := range response.RouteTables[0].Routes {
 		if awsclients.StringValue(route.Origin) == svcsdk.RouteOriginCreateRoute {
-			if awsclients.CIDRBlocksEqual(awsclients.StringValue(route.DestinationCidrBlock), *cr.Spec.ForProvider.DestinationCIDRBlock) {
+			if awsclients.CIDRBlocksEqual(awsclients.StringValue(route.DestinationCidrBlock), awsclients.StringValue(cr.Spec.ForProvider.DestinationCIDRBlock)) {
 				return route, nil
 			}
 		}


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1272

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
```
kubectl get managed
Warning: Please use v1beta1 version of SNS group.
NAME                                                           READY   SYNCED   ID                      VPC                     AGE
internetgateway.ec2.aws.crossplane.io/sample-internetgateway   True    True     igw-0b2e5ca49cf012bae   vpc-0af0af423f4605041   21m

NAME                                          READY   SYNCED   ID                         VPC                     CIDR          AGE
subnet.ec2.aws.crossplane.io/sample-subnet1   True    True     subnet-04a6eac5948aba708   vpc-0af0af423f4605041   10.0.1.0/24   28m
subnet.ec2.aws.crossplane.io/sample-subnet2   True    True     subnet-06180c0fdbc20dcc4   vpc-0af0af423f4605041   10.0.2.0/24   28m

NAME                                       READY   SYNCED   ID                           IP              AGE
address.ec2.aws.crossplane.io/sample-eip   True    True     eipalloc-0a0ce97e6cb8dc7f1   52.20.177.205   28m

NAME                                                               READY   SYNCED   ID                      VPC                     AGE
routetable.ec2.aws.crossplane.io/sample-routetable-ignore-routes   True    True     rtb-0f396b2a19bd22823   vpc-0af0af423f4605041   27m

NAME                                                 READY   SYNCED   ID                      VPC                     SUBNET                     ALLOCATION ID                AGE
natgateway.ec2.aws.crossplane.io/sample-natgateway   True    True     nat-0e736ac0bafab199b   vpc-0af0af423f4605041   subnet-04a6eac5948aba708   eipalloc-0a0ce97e6cb8dc7f1   16m

NAME                                    READY   SYNCED   ID                      CIDR          IPV6CIDR   AGE
vpc.ec2.aws.crossplane.io/sample-vpc    True    True     vpc-0af0af423f4605041   10.0.0.0/16              31m
vpc.ec2.aws.crossplane.io/sample-vpc2   True    True     vpc-02258c06ec4b2bc1b   10.1.0.0/16              31m

NAME                                  READY   SYNCED   EXTERNAL-NAME
route.ec2.aws.crossplane.io/example   True    True     example

NAME                                                       READY   SYNCED   EXTERNAL-NAME
vpcendpoint.ec2.aws.crossplane.io/sample-vpcendpoint-rtb   True    True     vpce-0d2c5980d45ce8af7

```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
