### PR TITLE
feat (CloudFront): Add support to update Elasticache ReplicationGroup number of cache clusters

### DIFF
--- a/pkg/clients/elasticache/fake/fake.go
+++ b/pkg/clients/elasticache/fake/fake.go
@@ -40,6 +40,8 @@ type MockClient struct {
 	MockCreateCacheCluster    func(context.Context, *elasticache.CreateCacheClusterInput, []func(*elasticache.Options)) (*elasticache.CreateCacheClusterOutput, error)
 	MockDeleteCacheCluster    func(context.Context, *elasticache.DeleteCacheClusterInput, []func(*elasticache.Options)) (*elasticache.DeleteCacheClusterOutput, error)
 	MockModifyCacheCluster    func(context.Context, *elasticache.ModifyCacheClusterInput, []func(*elasticache.Options)) (*elasticache.ModifyCacheClusterOutput, error)
+	MockIncreaseReplicaCount  func(context.Context, *elasticache.IncreaseReplicaCountInput, []func(*elasticache.Options)) (*elasticache.IncreaseReplicaCountOutput, error)
+	MockDecreaseReplicaCount  func(context.Context, *elasticache.DecreaseReplicaCountInput, []func(*elasticache.Options)) (*elasticache.DecreaseReplicaCountOutput, error)
 
 	MockModifyReplicationGroupShardConfiguration func(context.Context, *elasticache.ModifyReplicationGroupShardConfigurationInput, []func(*elasticache.Options)) (*elasticache.ModifyReplicationGroupShardConfigurationOutput, error)
 
@@ -142,4 +144,16 @@ func (c *MockClient) AddTagsToResource(ctx context.Context, i *elasticache.AddTa
 // MockRemoveTagsFromResource method
 func (c *MockClient) RemoveTagsFromResource(ctx context.Context, i *elasticache.RemoveTagsFromResourceInput, opts ...func(*elasticache.Options)) (*elasticache.RemoveTagsFromResourceOutput, error) {
 	return c.MockRemoveTagsFromResource(ctx, i, opts)
+}
+
+// DecreaseReplicaCount calls the underlying
+// MockDecreaseReplicaCount method
+func (c *MockClient) DecreaseReplicaCount(ctx context.Context, i *elasticache.DecreaseReplicaCountInput, opts ...func(*elasticache.Options)) (*elasticache.DecreaseReplicaCountOutput, error) {
+	return c.MockDecreaseReplicaCount(ctx, i, opts)
+}
+
+// IncreaseReplicaCount calls the underlying
+// MockIncreaseReplicaCount method
+func (c *MockClient) IncreaseReplicaCount(ctx context.Context, i *elasticache.IncreaseReplicaCountInput, opts ...func(*elasticache.Options)) (*elasticache.IncreaseReplicaCountOutput, error) {
+	return c.MockIncreaseReplicaCount(ctx, i, opts)
 }

--- a/pkg/controller/cache/managed_test.go
+++ b/pkg/controller/cache/managed_test.go
@@ -57,6 +57,7 @@ var (
 	transitEncryptionEnabled = true
 
 	cacheClusterID = name + "-0001"
+	cacheClusters  = []string{name + "-0001", name + "-0002", name + "-0003"}
 
 	ctx       = context.Background()
 	errorBoom = errors.New("boom")
@@ -119,6 +120,10 @@ func withTags(tagMaps ...map[string]string) replicationGroupModifier {
 
 func withNumNodeGroups(n int) replicationGroupModifier {
 	return func(r *v1beta1.ReplicationGroup) { r.Spec.ForProvider.NumNodeGroups = &n }
+}
+
+func withNumCacheClusters(n int) replicationGroupModifier {
+	return func(r *v1beta1.ReplicationGroup) { r.Spec.ForProvider.NumCacheClusters = &n }
 }
 
 func replicationGroup(rm ...replicationGroupModifier) *v1beta1.ReplicationGroup {
@@ -455,12 +460,14 @@ func TestUpdate(t *testing.T) {
 				withProviderStatus(v1beta1.StatusAvailable),
 				withConditions(xpv1.Available()),
 				withMemberClusters([]string{cacheClusterID}),
+				withNumCacheClusters(1),
 			),
 			want: replicationGroup(
 				withReplicationGroupID(name),
 				withProviderStatus(v1beta1.StatusAvailable),
 				withConditions(xpv1.Available()),
 				withMemberClusters([]string{cacheClusterID}),
+				withNumCacheClusters(1),
 			),
 			returnsErr: true,
 		},
@@ -510,6 +517,144 @@ func TestUpdate(t *testing.T) {
 				withNumNodeGroups(3),
 			),
 			returnsErr: true,
+		},
+		{
+			name: "FailedDecreaseReplicationGroupNumCacheClusters",
+			e: &external{client: &fake.MockClient{
+				MockDescribeReplicationGroups: func(ctx context.Context, _ *elasticache.DescribeReplicationGroupsInput, opts []func(*elasticache.Options)) (*elasticache.DescribeReplicationGroupsOutput, error) {
+					return &elasticache.DescribeReplicationGroupsOutput{
+						ReplicationGroups: []types.ReplicationGroup{{
+							Status:                 aws.String(v1beta1.StatusAvailable),
+							MemberClusters:         cacheClusters,
+							AutomaticFailover:      types.AutomaticFailoverStatusEnabled,
+							CacheNodeType:          aws.String(cacheNodeType),
+							SnapshotRetentionLimit: aws.Int32(int32(snapshotRetentionLimit)),
+							SnapshotWindow:         aws.String(snapshotWindow),
+							ClusterEnabled:         aws.Bool(true),
+							ConfigurationEndpoint:  &types.Endpoint{Address: aws.String(host), Port: int32(port)},
+						}},
+					}, nil
+				},
+				MockDescribeCacheClusters: func(ctx context.Context, _ *elasticache.DescribeCacheClustersInput, opts []func(*elasticache.Options)) (*elasticache.DescribeCacheClustersOutput, error) {
+					return &elasticache.DescribeCacheClustersOutput{
+						CacheClusters: []types.CacheCluster{
+							{EngineVersion: aws.String(engineVersion)},
+							{EngineVersion: aws.String(engineVersion)},
+							{EngineVersion: aws.String(engineVersion)},
+						},
+					}, nil
+				},
+				MockDecreaseReplicaCount: func(ctx context.Context, _ *elasticache.DecreaseReplicaCountInput, opts []func(*elasticache.Options)) (*elasticache.DecreaseReplicaCountOutput, error) {
+					return &elasticache.DecreaseReplicaCountOutput{}, errors.New("error decreasing number of cache clusters")
+				},
+			}},
+			r: replicationGroup(
+				withReplicationGroupID(name),
+				withProviderStatus(v1beta1.StatusAvailable),
+				withConditions(xpv1.Available()),
+				withMemberClusters(cacheClusters),
+				withNumCacheClusters(1),
+			),
+			want: replicationGroup(
+				withReplicationGroupID(name),
+				withProviderStatus(v1beta1.StatusAvailable),
+				withConditions(xpv1.Available()),
+				withMemberClusters(cacheClusters),
+				withNumCacheClusters(1),
+			),
+			returnsErr: true,
+		},
+		{
+			name: "DecreaseReplicationGroupNumCacheClusters",
+			e: &external{client: &fake.MockClient{
+				MockDescribeReplicationGroups: func(ctx context.Context, _ *elasticache.DescribeReplicationGroupsInput, opts []func(*elasticache.Options)) (*elasticache.DescribeReplicationGroupsOutput, error) {
+					return &elasticache.DescribeReplicationGroupsOutput{
+						ReplicationGroups: []types.ReplicationGroup{{
+							Status:                 aws.String(v1beta1.StatusAvailable),
+							MemberClusters:         cacheClusters,
+							AutomaticFailover:      types.AutomaticFailoverStatusEnabled,
+							CacheNodeType:          aws.String(cacheNodeType),
+							SnapshotRetentionLimit: aws.Int32(int32(snapshotRetentionLimit)),
+							SnapshotWindow:         aws.String(snapshotWindow),
+							ClusterEnabled:         aws.Bool(true),
+							ConfigurationEndpoint:  &types.Endpoint{Address: aws.String(host), Port: int32(port)},
+						}},
+					}, nil
+				},
+				MockDescribeCacheClusters: func(ctx context.Context, _ *elasticache.DescribeCacheClustersInput, opts []func(*elasticache.Options)) (*elasticache.DescribeCacheClustersOutput, error) {
+					return &elasticache.DescribeCacheClustersOutput{
+						CacheClusters: []types.CacheCluster{
+							{EngineVersion: aws.String(engineVersion)},
+							{EngineVersion: aws.String(engineVersion)},
+							{EngineVersion: aws.String(engineVersion)},
+						},
+					}, nil
+				},
+				MockDecreaseReplicaCount: func(ctx context.Context, _ *elasticache.DecreaseReplicaCountInput, opts []func(*elasticache.Options)) (*elasticache.DecreaseReplicaCountOutput, error) {
+					return &elasticache.DecreaseReplicaCountOutput{}, nil
+				},
+			}},
+			r: replicationGroup(
+				withReplicationGroupID(name),
+				withProviderStatus(v1beta1.StatusAvailable),
+				withConditions(xpv1.Available()),
+				withMemberClusters(cacheClusters),
+				withNumCacheClusters(2),
+			),
+			want: replicationGroup(
+				withReplicationGroupID(name),
+				withProviderStatus(v1beta1.StatusAvailable),
+				withConditions(xpv1.Available()),
+				withMemberClusters(cacheClusters),
+				withNumCacheClusters(2),
+			),
+			returnsErr: false,
+		},
+		{
+			name: "IncreaseReplicationGroupNumCacheClusters",
+			e: &external{client: &fake.MockClient{
+				MockDescribeReplicationGroups: func(ctx context.Context, _ *elasticache.DescribeReplicationGroupsInput, opts []func(*elasticache.Options)) (*elasticache.DescribeReplicationGroupsOutput, error) {
+					return &elasticache.DescribeReplicationGroupsOutput{
+						ReplicationGroups: []types.ReplicationGroup{{
+							Status:                 aws.String(v1beta1.StatusAvailable),
+							MemberClusters:         cacheClusters,
+							AutomaticFailover:      types.AutomaticFailoverStatusEnabled,
+							CacheNodeType:          aws.String(cacheNodeType),
+							SnapshotRetentionLimit: aws.Int32(int32(snapshotRetentionLimit)),
+							SnapshotWindow:         aws.String(snapshotWindow),
+							ClusterEnabled:         aws.Bool(true),
+							ConfigurationEndpoint:  &types.Endpoint{Address: aws.String(host), Port: int32(port)},
+						}},
+					}, nil
+				},
+				MockDescribeCacheClusters: func(ctx context.Context, _ *elasticache.DescribeCacheClustersInput, opts []func(*elasticache.Options)) (*elasticache.DescribeCacheClustersOutput, error) {
+					return &elasticache.DescribeCacheClustersOutput{
+						CacheClusters: []types.CacheCluster{
+							{EngineVersion: aws.String(engineVersion)},
+							{EngineVersion: aws.String(engineVersion)},
+							{EngineVersion: aws.String(engineVersion)},
+						},
+					}, nil
+				},
+				MockIncreaseReplicaCount: func(ctx context.Context, _ *elasticache.IncreaseReplicaCountInput, opts []func(*elasticache.Options)) (*elasticache.IncreaseReplicaCountOutput, error) {
+					return &elasticache.IncreaseReplicaCountOutput{}, nil
+				},
+			}},
+			r: replicationGroup(
+				withReplicationGroupID(name),
+				withProviderStatus(v1beta1.StatusAvailable),
+				withConditions(xpv1.Available()),
+				withMemberClusters(cacheClusters),
+				withNumCacheClusters(4),
+			),
+			want: replicationGroup(
+				withReplicationGroupID(name),
+				withProviderStatus(v1beta1.StatusAvailable),
+				withConditions(xpv1.Available()),
+				withMemberClusters(cacheClusters),
+				withNumCacheClusters(4),
+			),
+			returnsErr: false,
 		},
 	}
 
@@ -644,4 +789,85 @@ func TestInitialize(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpdateReplicationGroupNumCacheClusters(t *testing.T) {
+
+	cases := []struct {
+		name                string
+		e                   *external
+		rg                  string
+		existingClusterSize int
+		desiredclusterSize  int
+		want                error
+	}{
+		{
+			name:                "ErrDesiredTooSmall",
+			e:                   &external{client: &fake.MockClient{}},
+			desiredclusterSize:  0,
+			existingClusterSize: 1,
+			want:                errors.New("at least 1 replica is required"),
+		},
+		{
+			name:                "ErrDesiredTooLarge",
+			e:                   &external{client: &fake.MockClient{}},
+			desiredclusterSize:  7,
+			existingClusterSize: 1,
+			want:                errors.New("maximum of 5 replicas are allowed"),
+		},
+		{
+			name: "ErrIncreaseReplicaCount",
+			e: &external{client: &fake.MockClient{
+				MockIncreaseReplicaCount: func(ctx context.Context, _ *elasticache.IncreaseReplicaCountInput, opts []func(*elasticache.Options)) (*elasticache.IncreaseReplicaCountOutput, error) {
+					return &elasticache.IncreaseReplicaCountOutput{}, errors.New("error increasing number of cache clusters")
+				},
+			}},
+			desiredclusterSize:  4,
+			existingClusterSize: 1,
+			want:                errors.New("error increasing number of cache clusters"),
+		},
+		{
+			name: "IncreaseReplicaCount",
+			e: &external{client: &fake.MockClient{
+				MockIncreaseReplicaCount: func(ctx context.Context, _ *elasticache.IncreaseReplicaCountInput, opts []func(*elasticache.Options)) (*elasticache.IncreaseReplicaCountOutput, error) {
+					return &elasticache.IncreaseReplicaCountOutput{}, nil
+				},
+			}},
+			desiredclusterSize:  4,
+			existingClusterSize: 1,
+			want:                nil,
+		},
+		{
+			name: "ErrDecreaseReplicaCount",
+			e: &external{client: &fake.MockClient{
+				MockDecreaseReplicaCount: func(ctx context.Context, _ *elasticache.DecreaseReplicaCountInput, opts []func(*elasticache.Options)) (*elasticache.DecreaseReplicaCountOutput, error) {
+					return &elasticache.DecreaseReplicaCountOutput{}, errors.New("error decreasing number of cache clusters")
+				},
+			}},
+			desiredclusterSize:  3,
+			existingClusterSize: 5,
+			want:                errors.New("error decreasing number of cache clusters"),
+		},
+		{
+			name: "DecreaseReplicaCount",
+			e: &external{client: &fake.MockClient{
+				MockDecreaseReplicaCount: func(ctx context.Context, _ *elasticache.DecreaseReplicaCountInput, opts []func(*elasticache.Options)) (*elasticache.DecreaseReplicaCountOutput, error) {
+					return &elasticache.DecreaseReplicaCountOutput{}, nil
+				},
+			}},
+			desiredclusterSize:  3,
+			existingClusterSize: 5,
+			want:                nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.e.updateReplicationGroupNumCacheClusters(ctx, tc.rg, tc.existingClusterSize, tc.desiredclusterSize)
+			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
+				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
### Description of your changes

This PR is a follow up of https://github.com/crossplane/provider-aws/pull/1277 and adds the ability to update the number of cache clusters in an Elasticache Replication group. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Modified the `numCacheClusters` field of the following Managed resource and observed changes in the AWS UI:

```yaml
apiVersion: cache.aws.crossplane.io/v1beta1
kind: ReplicationGroup
metadata:
  name: redis-replication-group
spec:
  forProvider:
    region: us-east-1
    replicationGroupDescription: "A redis replication group"
    applyModificationsImmediately: true
    engine: "redis"
    engineVersion: "5.0.6"
    port: 6379
    cacheSubnetGroupName: borrelli-cache-test
    numCacheClusters: 2
    cacheParameterGroupName: default.redis5.0
    cacheNodeType: cache.t3.medium
    securityGroupIds:
      - sg-123456
    automaticFailoverEnabled: true
    #multiAZEnabled: false
    tags:
      - key: Name
        value: redis-replication-group
      - key: Environment
        value: dev
  providerConfigRef:
    name: default
```