### PR TITLE
fix(cognitoidentityprovider): Remove nil pointer exceptions in isUpTo…

### DIFF
--- a/pkg/controller/cognitoidentityprovider/userpool/setup.go
+++ b/pkg/controller/cognitoidentityprovider/userpool/setup.go
@@ -155,10 +155,20 @@ func areAdminCreateUserConfigEqual(spec *svcapitypes.AdminCreateUserConfigType, 
 	if spec != nil && current != nil {
 		switch {
 		case awsclients.BoolValue(spec.AllowAdminCreateUserOnly) != awsclients.BoolValue(current.AllowAdminCreateUserOnly),
-			awsclients.StringValue(spec.InviteMessageTemplate.EmailMessage) != awsclients.StringValue(current.InviteMessageTemplate.EmailMessage),
-			awsclients.StringValue(spec.InviteMessageTemplate.EmailSubject) != awsclients.StringValue(current.InviteMessageTemplate.EmailSubject),
-			awsclients.StringValue(spec.InviteMessageTemplate.SMSMessage) != awsclients.StringValue(current.InviteMessageTemplate.SMSMessage),
+			!areInviteMessageTemplateEqual(spec.InviteMessageTemplate, current.InviteMessageTemplate),
 			awsclients.Int64Value(spec.UnusedAccountValidityDays) != awsclients.Int64Value(current.UnusedAccountValidityDays):
+			return false
+		}
+	}
+	return true
+}
+
+func areInviteMessageTemplateEqual(spec *svcapitypes.MessageTemplateType, current *svcsdk.MessageTemplateType) bool {
+	if spec != nil && current != nil {
+		switch {
+		case awsclients.StringValue(spec.EmailMessage) != awsclients.StringValue(current.EmailMessage),
+			awsclients.StringValue(spec.EmailSubject) != awsclients.StringValue(current.EmailSubject),
+			awsclients.StringValue(spec.SMSMessage) != awsclients.StringValue(current.SMSMessage):
 			return false
 		}
 	}
@@ -194,11 +204,9 @@ func areLambdaConfigEqual(spec *svcapitypes.LambdaConfigType, current *svcsdk.La
 	if spec != nil && current != nil {
 		switch {
 		case awsclients.StringValue(spec.CreateAuthChallenge) != awsclients.StringValue(current.CreateAuthChallenge),
-			awsclients.StringValue(spec.CustomEmailSender.LambdaARN) != awsclients.StringValue(current.CustomEmailSender.LambdaArn),
-			awsclients.StringValue(spec.CustomEmailSender.LambdaVersion) != awsclients.StringValue(current.CustomEmailSender.LambdaVersion),
+			!areCustomEmailSenderEqual(spec.CustomEmailSender, current.CustomEmailSender),
 			awsclients.StringValue(spec.CustomMessage) != awsclients.StringValue(current.CustomMessage),
-			awsclients.StringValue(spec.CustomSMSSender.LambdaARN) != awsclients.StringValue(current.CustomSMSSender.LambdaArn),
-			awsclients.StringValue(spec.CustomSMSSender.LambdaVersion) != awsclients.StringValue(current.CustomSMSSender.LambdaVersion),
+			!areCustomSMSSenderEqual(spec.CustomSMSSender, current.CustomSMSSender),
 			awsclients.StringValue(spec.DefineAuthChallenge) != awsclients.StringValue(current.DefineAuthChallenge),
 			awsclients.StringValue(spec.KMSKeyID) != awsclients.StringValue(current.KMSKeyID),
 			awsclients.StringValue(spec.PostAuthentication) != awsclients.StringValue(current.PostAuthentication),
@@ -214,8 +222,30 @@ func areLambdaConfigEqual(spec *svcapitypes.LambdaConfigType, current *svcsdk.La
 	return true
 }
 
-func arePoliciesEqual(spec *svcapitypes.UserPoolPolicyType, current *svcsdk.UserPoolPolicyType) bool {
+func areCustomEmailSenderEqual(spec *svcapitypes.CustomEmailLambdaVersionConfigType, current *svcsdk.CustomEmailLambdaVersionConfigType) bool {
 	if spec != nil && current != nil {
+		switch {
+		case awsclients.StringValue(spec.LambdaARN) != awsclients.StringValue(current.LambdaArn),
+			awsclients.StringValue(spec.LambdaVersion) != awsclients.StringValue(current.LambdaVersion):
+			return false
+		}
+	}
+	return true
+}
+
+func areCustomSMSSenderEqual(spec *svcapitypes.CustomSMSLambdaVersionConfigType, current *svcsdk.CustomSMSLambdaVersionConfigType) bool {
+	if spec != nil && current != nil {
+		switch {
+		case awsclients.StringValue(spec.LambdaARN) != awsclients.StringValue(current.LambdaArn),
+			awsclients.StringValue(spec.LambdaVersion) != awsclients.StringValue(current.LambdaVersion):
+			return false
+		}
+	}
+	return true
+}
+
+func arePoliciesEqual(spec *svcapitypes.UserPoolPolicyType, current *svcsdk.UserPoolPolicyType) bool {
+	if spec != nil && current != nil && spec.PasswordPolicy != nil && current.PasswordPolicy != nil {
 		switch {
 		case awsclients.Int64Value(spec.PasswordPolicy.MinimumLength) != awsclients.Int64Value(current.PasswordPolicy.MinimumLength),
 			awsclients.BoolValue(spec.PasswordPolicy.RequireLowercase) != awsclients.BoolValue(current.PasswordPolicy.RequireLowercase),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

The `UserPool` resource in `cognitoidentityprovider` tries to resolve some nil pointers during the `isUpToDate`  check. This PR checks if the pointers are nil.



<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

manual tests
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
