### PR TITLE
fix(elasticache) normalize preferred maintenance window

### DIFF
--- a/pkg/clients/elasticache/elasticache.go
+++ b/pkg/clients/elasticache/elasticache.go
@@ -348,7 +348,9 @@ func cacheClusterNeedsUpdate(kube v1beta1.ReplicationGroupParameters, cc elastic
 	} else if clients.StringValue(kube.NotificationTopicARN) != "" {
 		return true
 	}
-	if !reflect.DeepEqual(kube.PreferredMaintenanceWindow, cc.PreferredMaintenanceWindow) {
+	// AWS will normalize preferred maintenance windows to lowercase
+	if !strings.EqualFold(clients.StringValue(kube.PreferredMaintenanceWindow),
+		clients.StringValue(cc.PreferredMaintenanceWindow)) {
 		return true
 	}
 	return sgIDsNeedUpdate(kube.SecurityGroupIDs, cc.SecurityGroups) || sgNamesNeedUpdate(kube.CacheSecurityGroupNames, cc.CacheSecurityGroups)


### PR DESCRIPTION
### Description of your changes

Relates to https://github.com/crossplane/provider-aws/issues/1023

We discovered a state where `provider-aws` was repeatedly modifying the elasticache cluster without it becoming available, as described in #1023. Tracked the issue down to the use of a PreferredMaintenanceWindow argument that included capitalized day names: `Fri:04:20-Fri:16:20`. 

This is invalid according to [aws docs](https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateReplicationGroup.html), as day names are supposed to be lowercased, however the AWS API accepts uppercased day names, and normalizes them behind the scenes to lowercased. This ends up breaking the `cacheClusterNeedsUpdate` check, which tests for exact equality between the declared maintenance window in the resource spec (which will still be uppercased), and the maintenance window returned from the AWS API, which will be lowercased.

This PR offers a potential fix, by normalizing the casing of the maintenance window when performing this check. However, it suffers from the following issues:

* we don't know the actual normalization strategy used by AWS here, so this is just a best guess.
* there are likely other cases impacted by this.

Overall it might be better to try to validate this string at resource-create time, but that would likely require a webhook, etc.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

adds a unit test, also tested against the AWS API with ReplicationGroup resource w/ capitalized day names.

[contribution process]: https://git.io/fj2m9
