### PR TITLE
fix(rds): include the port number in the connection details

### DIFF
--- a/pkg/controller/rds/dbcluster/setup.go
+++ b/pkg/controller/rds/dbcluster/setup.go
@@ -2,6 +2,7 @@ package dbcluster
 
 import (
 	"context"
+	"strconv"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/rds"
 	svcsdkapi "github.com/aws/aws-sdk-go/service/rds/rdsiface"
@@ -83,6 +84,7 @@ func (e *custom) postObserve(ctx context.Context, cr *svcapitypes.DBCluster, res
 	obs.ConnectionDetails = managed.ConnectionDetails{
 		xpv1.ResourceCredentialsSecretEndpointKey: []byte(aws.StringValue(cr.Status.AtProvider.Endpoint)),
 		xpv1.ResourceCredentialsSecretUserKey:     []byte(aws.StringValue(cr.Spec.ForProvider.MasterUsername)),
+		xpv1.ResourceCredentialsSecretPortKey:     []byte(strconv.FormatInt(aws.Int64Value(cr.Spec.ForProvider.Port), 10)),
 	}
 	pw, _, _ := rds.GetPassword(ctx, e.kube, &cr.Spec.ForProvider.MasterUserPasswordSecretRef, cr.Spec.WriteConnectionSecretToReference)
 	if pw != "" {


### PR DESCRIPTION
### Description of your changes

The connection details secret is missing the port.
Some other Crossplane providers expect the port to be in the secret, like, for example, the Provider SQL.
This relates to: https://github.com/crossplane-contrib/provider-sql/issues/76

Fixes #1296

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

I had some issues running the `make` command:
- initially, the `make` commands were mangling my working copy and I had to `export ROOT_DIR=$(pwd)` to get it to work properly.
- running `make reviewable` resulted in an error:
   ```
   Error: open /Users/luisdavim/.cache/ack-generate/src/aws-sdk-go/models/apis/servicecatalog/2015-12-10/api-2.json: too many open files
   ```
   I tried running `make -j1 reviewable` and it still failed.
- Running `make test` worked.
- When the `make` execution stopped with the error mentioned above, `goimports` had updated the imports of all the generated files, removing redundant imports and adding a space between the `stdlib` imports and the rest of the imports; I ran `go generate ./...` to revert those changes

### How has this code been tested

Ran `make run` whilst connected to a real EKS cluster
