### PR TITLE
ec2.securitygroup: Fix missing resolvers by using code gen

### DIFF
--- a/apis/ec2/v1beta1/securitygroup_types.go
+++ b/apis/ec2/v1beta1/securitygroup_types.go
@@ -125,6 +125,7 @@ type UserIDGroupPair struct {
 
 	// The ID of the security group.
 	// +optional
+	// +crossplane:generate:reference:type=SecurityGroup
 	GroupID *string `json:"groupId,omitempty"`
 
 	// GroupIDRef reference a security group to retrieve its GroupID

--- a/apis/ec2/v1beta1/zz_generated.resolvers.go
+++ b/apis/ec2/v1beta1/zz_generated.resolvers.go
@@ -183,6 +183,26 @@ func (mg *SecurityGroup) ResolveReferences(ctx context.Context, c client.Reader)
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.Ingress); i3++ {
 		for i4 := 0; i4 < len(mg.Spec.ForProvider.Ingress[i3].UserIDGroupPairs); i4++ {
 			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+				CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Ingress[i3].UserIDGroupPairs[i4].GroupID),
+				Extract:      reference.ExternalName(),
+				Reference:    mg.Spec.ForProvider.Ingress[i3].UserIDGroupPairs[i4].GroupIDRef,
+				Selector:     mg.Spec.ForProvider.Ingress[i3].UserIDGroupPairs[i4].GroupIDSelector,
+				To: reference.To{
+					List:    &SecurityGroupList{},
+					Managed: &SecurityGroup{},
+				},
+			})
+			if err != nil {
+				return errors.Wrap(err, "mg.Spec.ForProvider.Ingress[i3].UserIDGroupPairs[i4].GroupID")
+			}
+			mg.Spec.ForProvider.Ingress[i3].UserIDGroupPairs[i4].GroupID = reference.ToPtrValue(rsp.ResolvedValue)
+			mg.Spec.ForProvider.Ingress[i3].UserIDGroupPairs[i4].GroupIDRef = rsp.ResolvedReference
+
+		}
+	}
+	for i3 := 0; i3 < len(mg.Spec.ForProvider.Ingress); i3++ {
+		for i4 := 0; i4 < len(mg.Spec.ForProvider.Ingress[i3].UserIDGroupPairs); i4++ {
+			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 				CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Ingress[i3].UserIDGroupPairs[i4].VPCID),
 				Extract:      reference.ExternalName(),
 				Reference:    mg.Spec.ForProvider.Ingress[i3].UserIDGroupPairs[i4].VPCIDRef,
@@ -197,6 +217,26 @@ func (mg *SecurityGroup) ResolveReferences(ctx context.Context, c client.Reader)
 			}
 			mg.Spec.ForProvider.Ingress[i3].UserIDGroupPairs[i4].VPCID = reference.ToPtrValue(rsp.ResolvedValue)
 			mg.Spec.ForProvider.Ingress[i3].UserIDGroupPairs[i4].VPCIDRef = rsp.ResolvedReference
+
+		}
+	}
+	for i3 := 0; i3 < len(mg.Spec.ForProvider.Egress); i3++ {
+		for i4 := 0; i4 < len(mg.Spec.ForProvider.Egress[i3].UserIDGroupPairs); i4++ {
+			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+				CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Egress[i3].UserIDGroupPairs[i4].GroupID),
+				Extract:      reference.ExternalName(),
+				Reference:    mg.Spec.ForProvider.Egress[i3].UserIDGroupPairs[i4].GroupIDRef,
+				Selector:     mg.Spec.ForProvider.Egress[i3].UserIDGroupPairs[i4].GroupIDSelector,
+				To: reference.To{
+					List:    &SecurityGroupList{},
+					Managed: &SecurityGroup{},
+				},
+			})
+			if err != nil {
+				return errors.Wrap(err, "mg.Spec.ForProvider.Egress[i3].UserIDGroupPairs[i4].GroupID")
+			}
+			mg.Spec.ForProvider.Egress[i3].UserIDGroupPairs[i4].GroupID = reference.ToPtrValue(rsp.ResolvedValue)
+			mg.Spec.ForProvider.Egress[i3].UserIDGroupPairs[i4].GroupIDRef = rsp.ResolvedReference
 
 		}
 	}


### PR DESCRIPTION

### Description of your changes

Security group resolvers was missing during a refactor when changing other parts of the ec2 package. I think we should consider backporting this change.

Fixes #1312

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested with ingress rule by @petteja 

[contribution process]: https://git.io/fj2m9
